### PR TITLE
`feat: Build document ingestion pipeline for GA4GH policy compliance checks`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# GA4GH RegBot - Environment Variables
+# Copy this file to .env and fill in values as needed.
+
+# Directory where ChromaDB stores its data (default: ./chroma_db)
+CHROMA_PERSIST_DIR=./chroma_db
+
+# Embedding model name from sentence-transformers (default: all-MiniLM-L6-v2)
+EMBEDDING_MODEL=all-MiniLM-L6-v2
+
+# Optional: OpenAI API key (for future LLM integration in Phase 2+)
+# OPENAI_API_KEY=sk-...

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+*.egg-info/
+dist/
+build/
+*.egg
+
+# Virtual environments
+venv/
+env/
+.venv/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Environment variables
+.env
+
+# ChromaDB persistence
+chroma_db/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Pytest
+.pytest_cache/
+htmlcov/
+.coverage
+
+# Distribution
+*.tar.gz
+*.whl

--- a/data/frameworks/DUO_Data_Use_Ontology_Reference.txt
+++ b/data/frameworks/DUO_Data_Use_Ontology_Reference.txt
@@ -1,0 +1,241 @@
+GA4GH Data Use Ontology (DUO) - Reference Document
+Source: https://github.com/EBISPOT/DUO
+License: Creative Commons Attribution 4.0 International (CC BY 4.0)
+
+============================================================================
+
+SECTION 1: OVERVIEW
+--------------------
+
+1.1 What is DUO?
+
+The GA4GH Data Use Ontology (DUO) allows datasets to be semantically tagged
+with restrictions about their usage, making them discoverable automatically
+based on the authorization level of users, or intended usage. DUO provides a
+standard, machine-readable system for annotating datasets with information
+about consent-based data use conditions.
+
+DUO is used in production by the European Genome-phenome Archive (EGA) at
+EMBL-EBI as well as the Broad Institute for the Data Use Oversight System
+(DUOS). It is registered with the OBO Foundry and distributed under a
+Creative Commons Attribution 4.0 International License.
+
+1.2 Why DUO Exists
+
+Human subjects datasets often have restrictions such as "only available for
+cancer use" or "only available for the study of pediatric diseases," based on
+the original participant consent, which must be respected when sharing and
+studying these datasets.
+
+A current challenge in sharing such datasets for further research is that
+unique language is used in each informed consent form to describe the
+secondary use conditions. The lack of a standard universal system to
+categorize these conditions makes it difficult for data access committees
+(DACs) and researchers to interpret the conditions in a consistent,
+structured way.
+
+============================================================================
+
+SECTION 2: DATA USE PERMISSION CODES
+--------------------------------------
+
+The following DUO codes define the primary permissions for data use:
+
+2.1 DUO:0000042 - General Research Use (GRU)
+    Use is permitted for any research purpose. This is the broadest
+    consent category. Data may be used for health, medical, biomedical
+    purposes and other biological research, including population-level
+    research.
+
+2.2 DUO:0000006 - Health or Medical or Biomedical Research (HMB)
+    Use is permitted for health, medical, or biomedical research purposes.
+    More restrictive than GRU but covers most clinical and translational
+    research.
+
+2.3 DUO:0000007 - Disease-Specific Research (DS)
+    Use is limited to research on a specific disease or group of diseases.
+    The specific disease must be indicated using an appropriate ontology
+    term (e.g., MONDO, DOID).
+
+2.4 DUO:0000004 - No Restriction (NRES)
+    No restrictions on data use. The data can be used for any purpose
+    without limitation.
+
+2.5 DUO:0000011 - Population Origins or Ancestry Research Only (POA)
+    Use is limited to research concerning population origins or ancestry.
+
+============================================================================
+
+SECTION 3: DATA USE MODIFIER CODES
+------------------------------------
+
+Modifiers can be combined with permission codes to further restrict usage:
+
+3.1 DUO:0000012 - Research-Specific Restrictions (RS)
+    Use is limited to studies of a certain research type.
+
+3.2 DUO:0000015 - No General Methods Research (NMGR)
+    Use includes methods development research only if it is incidental to
+    the primary research purpose and target. Data cannot be used solely
+    for methods research.
+
+3.3 DUO:0000016 - Genetic Studies Only (GSO)
+    Use is limited to genetic studies only. Data cannot be used for
+    non-genetic research.
+
+3.4 DUO:0000018 - Not for Profit, Non-Commercial Use Only (NPU)
+    Use is limited to not-for-profit organizations and is not permitted
+    for commercial or for-profit purposes.
+
+3.5 DUO:0000045 - Not for Profit Organisation Use Only (NPNCU)
+    Use is limited to non-profit and non-commercial research institutions.
+
+3.6 DUO:0000019 - Publication Required (PUB)
+    Requestor agrees to make results of studies using the data available
+    to the larger scientific community through publication.
+
+3.7 DUO:0000020 - Collaboration Required (COL)
+    Requestor must agree to collaborate with the data generators or
+    stewards. The precise terms of collaboration must be documented.
+
+3.8 DUO:0000021 - Ethics Approval Required (IRB)
+    Requestor must provide documentation of local IRB/Ethics approval
+    before data access is granted or before research commences.
+
+3.9 DUO:0000022 - Geographical Restriction (GS)
+    Use is limited to within a specific geographic area. The specific
+    region must be documented.
+
+3.10 DUO:0000024 - Publication Moratorium (MOR)
+     Requestor agrees not to publish results of the research until a
+     specific date or for a specified period.
+
+3.11 DUO:0000025 - Time Limit on Use (TS)
+     Use is approved for a specific duration. After the time period,
+     requestor is expected to either destroy the data, or seek new
+     approval for continued use.
+
+3.12 DUO:0000026 - User-Specific Restriction (US)
+     Use is limited to use by approved users. Data access must be
+     individually reviewed and approved.
+
+3.13 DUO:0000027 - Project-Specific Restriction (PS)
+     Use is limited to use within an approved project. Each new project
+     using the data requires separate approval.
+
+3.14 DUO:0000028 - Institution-Specific Restriction (IS)
+     Use is limited to use by approved institutions. Only specified
+     organizations may access the data.
+
+3.15 DUO:0000029 - Return to Database/Resource (RTN)
+     Requestor must return derived/enriched data to a specified database
+     or resource.
+
+3.16 DUO:0000043 - Clinical Care Use (CC)
+     Data may be used for clinical care purposes, including diagnosis
+     and treatment decisions.
+
+3.17 DUO:0000044 - Population Research (POP)
+     Data may be used for population-level research studies.
+
+3.18 DUO:0000046 - Non-Commercial Use Only (NCU)
+     Data is restricted to non-commercial use only.
+
+============================================================================
+
+SECTION 4: HOW DUO MATCHING WORKS
+-----------------------------------
+
+4.1 Research Purpose Matching
+
+When a researcher submits a data access request, the system matches their
+research purpose against the data use restrictions tagged on datasets:
+
+  (a) A query for datasets consented for cancer research WILL NOT retrieve
+      datasets consented for lung cancer specifically, because lung cancer
+      is a subtype and the consent limits use to lung cancer only.
+
+  (b) A query for datasets consented for lung cancer research WILL retrieve
+      datasets consented for cancer broadly, as lung cancer is a subtype
+      of cancer in the disease hierarchy.
+
+4.2 Example Workflow
+
+  Step 1: A researcher describes their research purpose (e.g., "study of
+          melanoma by a non-profit institution").
+
+  Step 2: The system translates this into DUO codes:
+          - DUO:0000007 (Disease-Specific: Melanoma)
+          - DUO:0000045 (Non-profit Organisation Use Only)
+
+  Step 3: The matching algorithm finds all datasets whose DUO restrictions
+          are compatible with these codes (including parent terms in the
+          ontology hierarchy).
+
+  Step 4: Compatible datasets are returned to the researcher for access
+          request submission.
+
+============================================================================
+
+SECTION 5: DUO AND GDPR
+-------------------------
+
+5.1 Can DUO Handle GDPR Compliance?
+
+DUO is designed primarily to encode conditions of use from the consent given
+by research participants. It is NOT a GDPR compliance tool. However, DUO
+supports the principle of purpose limitation under GDPR by clearly encoding
+what the data can and cannot be used for.
+
+5.2 Relationship with Data Protection Law
+
+DUO terms are based on consent codes, not legal requirements. However, they
+complement legal frameworks by:
+  (a) Making data use conditions machine-readable and unambiguous.
+  (b) Supporting automated compliance checking against consent terms.
+  (c) Facilitating cross-border data sharing by providing a common vocabulary.
+
+============================================================================
+
+SECTION 6: MACHINE READABLE CONSENT GUIDANCE (MRCG)
+------------------------------------------------------
+
+6.1 Purpose
+
+The Machine Readable Consent Guidance (MRCG) explains how to create consent
+forms that map directly to DUO codes. This allows institutions to automate
+and expedite aspects of the data access process.
+
+6.2 Benefits
+
+  (a) Supports automation of consent collection and tracking.
+  (b) Supports automation of the data access process.
+  (c) Provides consent clause summaries and descriptions for each DUO code.
+  (d) Eliminates the need for manual interpretation of consent language.
+
+6.3 How MRCG Maps to DUO
+
+Each MRCG consent clause corresponds to one or more DUO codes:
+
+  Example Clause: "Data may be used for any type of health, medical, or
+  biomedical research."
+  -> Maps to: DUO:0000006 (Health or Medical or Biomedical Research)
+
+  Example Clause: "Data use is limited to non-profit research institutions."
+  -> Maps to: DUO:0000045 (Not for Profit Organisation Use Only)
+
+  Example Clause: "Research results must be made publicly available."
+  -> Maps to: DUO:0000019 (Publication Required)
+
+6.4 Target Users
+
+Data generators, data access committees, and data protection authorities
+should use MRCG when designing new consent forms to ensure compatibility
+with the DUO system.
+
+============================================================================
+
+NOTE: This document is a structured reference compiled from the official
+EBISPOT/DUO GitHub repository (https://github.com/EBISPOT/DUO) and GA4GH
+MRCG documentation. For the machine-readable ontology (OWL format), visit:
+http://purl.obolibrary.org/obo/duo.owl

--- a/data/frameworks/GA4GH_Consent_Policy_Reference.txt
+++ b/data/frameworks/GA4GH_Consent_Policy_Reference.txt
@@ -1,0 +1,182 @@
+GA4GH Consent Policy (POL 002) - v2.0 Reference Summary
+Source: https://www.ga4gh.org/product/consent-policy/
+
+============================================================================
+
+SECTION 1: PURPOSE AND SCOPE
+------------------------------
+
+1.1 Purpose
+
+The GA4GH Consent Policy provides guidelines for the international sharing
+of genomic and related health data. It aims to respect autonomous
+decision-making while promoting responsible data sharing globally.
+
+1.2 Scope
+
+This policy encompasses data that have been consented to by data donors
+or their legal representatives, or approved for use by competent
+authorities in compliance with national and international laws, general
+ethical principles, and best practices that respect restrictions on
+downstream uses.
+
+1.3 Applicability
+
+The policy applies to all organizations and individuals involved in
+collecting, storing, sharing, or using genomic and health-related data,
+including researchers, institutions, data access committees, and
+industry partners.
+
+============================================================================
+
+SECTION 2: FOUNDATIONAL PRINCIPLES
+------------------------------------
+
+2.1 Open Communication
+
+Consent is an open, communicative, and ideally continuing relationship
+between data donors and data users. It should not be viewed as a
+one-time transaction.
+
+2.2 Data Sharing Intention
+
+There is an intention to share data across clinical or research groups,
+or jurisdictions and national borders, with appropriate approvals in
+place.
+
+2.3 Transparency
+
+Plans for data sharing should be transparent, understandable, and
+accessible to data donors and the public.
+
+2.4 Right to Withdraw
+
+Data donors have a right to not participate in international data
+sharing or, if participating, are able to withdraw, with the
+understanding that it may not be possible to retrieve or destroy data
+once shared.
+
+2.5 Regulatory Compliance
+
+Data users and data producers will abide by applicable regulations and
+ethical norms when seeking and conducting international data sharing.
+
+============================================================================
+
+SECTION 3: CONSENT REQUIREMENTS
+---------------------------------
+
+3.1 Informed Consent
+
+Consent should be appropriately informed, meaning data donors should
+understand:
+  (a) What data will be collected about them.
+  (b) How the data will be stored and protected.
+  (c) Who may access the data and for what purposes.
+  (d) Whether data will be shared internationally.
+  (e) The potential risks and benefits of data sharing.
+  (f) Their rights regarding access, correction, and deletion.
+
+3.2 Types of Consent
+
+  (a) Specific Consent: Data may only be used for the specific research
+      study described in the consent form.
+  (b) Broad Consent: Data may be used for a range of future research
+      purposes, subject to ethics oversight.
+  (c) Dynamic Consent: An ongoing process where data donors can update
+      their preferences over time through digital platforms.
+  (d) Tiered Consent: Data donors may choose different levels of data
+      sharing (e.g., disease-specific only, health research broadly).
+
+3.3 Consent Form Elements
+
+All consent forms for genomic data sharing should include:
+  (a) Description of the research project and its goals.
+  (b) Types of data and samples to be collected.
+  (c) How data will be stored, secured, and for how long.
+  (d) Plans for data sharing and with whom.
+  (e) Procedures for return of results (including incidental findings).
+  (f) Risks and benefits of participation.
+  (g) Voluntary nature of participation and withdrawal procedures.
+  (h) Contact information for questions and concerns.
+  (i) Statement about data protection and privacy safeguards.
+
+3.4 Special Populations
+
+  (a) Pediatric Research: Consent from parents/guardians is required,
+      with assent from minors where appropriate. Re-consent should be
+      sought when minors reach the age of majority.
+  (b) Vulnerable Populations: Additional safeguards should be in place
+      for individuals who may be unable to give fully informed consent.
+  (c) Community Consent: Where research involves identifiable
+      communities, community-level engagement and consent should be
+      sought in addition to individual consent.
+
+============================================================================
+
+SECTION 4: DATA SHARING PROVISIONS
+------------------------------------
+
+4.1 Cross-Border Sharing
+
+When data is shared across national borders:
+  (a) Compliance with data protection laws of both origin and destination
+      jurisdictions must be ensured.
+  (b) Data transfer agreements must be in place.
+  (c) Equivalent levels of data protection must be maintained.
+  (d) Data donors should be informed of international sharing.
+
+4.2 Data Access Governance
+
+  (a) Data Access Committees (DACs) should evaluate requests based on
+      scientific merit and ethical considerations.
+  (b) Access decisions should be made in a timely manner.
+  (c) Reasons for denying access should be documented and communicated.
+  (d) Appeals processes should be available.
+
+4.3 Secondary Use
+
+  (a) Secondary use of data should be consistent with the scope of the
+      original consent.
+  (b) Where broad consent was obtained, ethics review should oversee
+      secondary uses.
+  (c) Data donors should be informed of significant new uses where
+      practicable.
+
+============================================================================
+
+SECTION 5: DATA DONOR RIGHTS
+-------------------------------
+
+5.1 Right to Access
+
+Data donors have the right to access their own data and understand
+how it has been used.
+
+5.2 Right to Withdraw
+
+Data donors may withdraw consent at any time. Organizations should
+have processes in place for handling withdrawals, including:
+  (a) Ceasing further use of the data.
+  (b) Removing data from future distributions.
+  (c) Acknowledging that data already in analyses may not be removable.
+
+5.3 Right to Return of Results
+
+Where individual-level results are generated from research:
+  (a) Clinically actionable findings should be offered back to
+      data donors with appropriate genetic counseling.
+  (b) The consent form should specify the policy on return of results.
+  (c) Data donors should have the option to decline receiving results.
+
+5.4 Right to Privacy
+
+  (a) Data should be de-identified to the extent possible.
+  (b) Re-identification should be prohibited by data use agreements.
+  (c) Data donors should be informed of any re-identification risks.
+
+============================================================================
+
+NOTE: This document is a structured reference summary compiled from the
+official GA4GH Consent Policy (POL 002 v2.0). For the official document,
+visit: https://www.ga4gh.org/product/consent-policy/

--- a/data/frameworks/GA4GH_Consent_Toolkit_Clauses.txt
+++ b/data/frameworks/GA4GH_Consent_Toolkit_Clauses.txt
@@ -1,0 +1,244 @@
+GA4GH Consent Toolkit - Consent Clauses Reference
+Sources:
+  - Consent Clauses for Genomic Research (2020)
+  - Consent Toolkit: Rare Disease
+  - Familial Consent Clauses (v1.0)
+  - Pediatric Consent to Genetic Research (v1.0)
+  - Consent Clauses for Large Scale Initiatives (v1.0)
+  - Consent Toolkit: Clinical Genomic (v6.0)
+
+============================================================================
+
+SECTION 1: GENERAL CONSENT CLAUSES FOR GENOMIC RESEARCH
+---------------------------------------------------------
+
+1.1 Purpose of Data Collection
+
+"We would like to collect and analyze your [genomic/genetic] data as part
+of this research study. Your data may be used to better understand the
+[specific condition/disease] and to advance scientific knowledge about
+human health."
+
+1.2 Data Storage and Security
+
+"Your data will be stored in a secure, access-controlled database.
+We use encryption and other technical safeguards to protect your
+information. Data will be stored for [specified period] or until it
+is no longer needed for research purposes."
+
+1.3 Data Sharing
+
+"Your de-identified data may be shared with other qualified researchers
+for future studies. Shared data will be subject to strict data use
+agreements that prohibit attempts to re-identify participants."
+
+1.4 Return of Results
+
+"If the analysis of your data reveals findings that are clinically
+significant and actionable, you will be offered the opportunity to
+learn about these findings through genetic counseling."
+
+1.5 Withdrawal
+
+"You may withdraw your consent at any time. If you withdraw, we will
+stop using your data for new research, but data already included in
+completed analyses cannot be removed."
+
+============================================================================
+
+SECTION 2: RARE DISEASE RESEARCH CLAUSES
+------------------------------------------
+
+2.1 Matchmaking and Data Sharing
+
+"Because rare diseases affect small numbers of people, it is often
+necessary to share your data with researchers around the world to
+find other individuals with similar genetic variants. This process,
+called 'matchmaking,' helps researchers understand the relationship
+between genetic changes and disease."
+
+2.2 Familial Participation
+
+"Rare disease research may benefit from analyzing data from your
+family members. If your family members consent, their data may be
+analyzed alongside yours to help identify the genetic basis of the
+condition."
+
+2.3 Audiovisual Data
+
+"Some rare diseases have distinctive physical features. With your
+separate, specific consent, photographs or videos may be collected
+and shared with other researchers through controlled-access databases.
+You may decline audiovisual data collection while still participating
+in other aspects of the study."
+
+2.4 Recontact
+
+"Researchers may wish to contact you in the future for additional
+information or to invite you to participate in further studies. You
+may indicate whether you are willing to be recontacted."
+
+2.5 International Data Sharing
+
+"Due to the rarity of the condition, your data may need to be shared
+with researchers in other countries. International sharing will be
+governed by data use agreements that ensure your privacy is protected."
+
+============================================================================
+
+SECTION 3: FAMILIAL CONSENT CLAUSES
+--------------------------------------
+
+3.1 Purpose
+
+"Genetic information is inherently familial. Analysis of your genomic
+data may reveal information about your biological relatives. This
+section explains how familial implications are handled."
+
+3.2 Duty to Inform Family Members
+
+"If research reveals genetic findings that may have significant health
+implications for your family members, you may be encouraged to share
+this information with them. Genetic counseling will be available to
+help you make these decisions."
+
+3.3 Family Member Data Collection
+
+"With appropriate consent, data from your biological relatives may be
+collected and analyzed alongside yours to improve the accuracy of
+genetic analysis. Each family member will be consented individually."
+
+3.4 Family De-identification
+
+"When sharing family data for research, additional de-identification
+measures will be applied to protect familial relationships. However,
+due to the nature of genetic data and known family structures,
+complete de-identification cannot be guaranteed."
+
+3.5 Cascade Testing
+
+"If a clinically actionable genetic variant is identified in your data,
+cascade genetic testing may be recommended for at-risk family members.
+You will be provided with information and resources to support this
+process."
+
+============================================================================
+
+SECTION 4: PEDIATRIC CONSENT CLAUSES
+---------------------------------------
+
+4.1 Parental/Guardian Consent
+
+"As the parent or legal guardian of the child participant, you are
+providing consent on their behalf. Your child's assent (agreement)
+will also be sought if they are old enough to understand the research."
+
+4.2 Assent from Minors
+
+"For children aged [7-17], we will explain the research in
+age-appropriate language and ask for their agreement (assent) to
+participate. The child may decline even if the parent has consented."
+
+4.3 Re-consent at Age of Majority
+
+"When the child participant reaches the age of majority [18 years],
+they will be offered the opportunity to provide their own informed
+consent for continued participation in the study and ongoing use of
+their data."
+
+4.4 Return of Results for Minors
+
+"Clinically actionable findings will be communicated to the parent or
+legal guardian. For genetic findings that have implications for the
+child's future health (including adult-onset conditions), guidelines
+for reporting will be followed, and genetic counseling will be made
+available."
+
+4.5 Best Interests Standard
+
+"All decisions regarding the child's participation will be guided by
+the best interests of the child, taking into account the potential
+benefits and risks of the research."
+
+============================================================================
+
+SECTION 5: LARGE SCALE INITIATIVE CLAUSES
+--------------------------------------------
+
+5.1 Consortium Data Sharing
+
+"This research is part of a large-scale initiative involving multiple
+institutions and countries. Your data will be shared with consortium
+members through a centralized, access-controlled data repository."
+
+5.2 Governance Structure
+
+"The consortium has an established governance structure including a
+Data Access Committee (DAC) that reviews and approves all data access
+requests. The DAC includes scientific experts, ethicists, and
+participant representatives."
+
+5.3 Publication and Attribution
+
+"Results arising from consortium research will be published in
+scientific journals. Individual participants will not be identifiable
+in any publication. The consortium's publication policy ensures
+appropriate attribution and credit."
+
+5.4 Long-Term Data Stewardship
+
+"Data collected as part of this initiative will be maintained in a
+secure repository for [specified period]. A data stewardship plan
+ensures that data remains accessible for approved research purposes
+even after the initial project concludes."
+
+5.5 Benefit Sharing
+
+"The consortium is committed to ensuring that the benefits of this
+research are shared broadly. Research findings will be made available
+to the scientific community, and efforts will be made to ensure that
+participating communities benefit from the research outcomes."
+
+============================================================================
+
+SECTION 6: CLINICAL GENOMIC CONSENT CLAUSES
+----------------------------------------------
+
+6.1 Clinical vs. Research Use
+
+"Your genomic data is being generated as part of your clinical care.
+With your consent, this data may also be used for research purposes.
+You may consent to clinical testing without consenting to research
+use of your data."
+
+6.2 Diagnostic Results
+
+"Results that are relevant to your clinical diagnosis and management
+will be reported to your treating physician and included in your
+medical record."
+
+6.3 Incidental Findings
+
+"Genomic analysis may reveal findings unrelated to the primary reason
+for testing. Our policy on reporting incidental findings is [describe
+institutional policy]. You may indicate whether you wish to receive
+such findings."
+
+6.4 Variant Classification Updates
+
+"Our understanding of genetic variants evolves over time. Variants
+initially classified as uncertain may later be reclassified as
+causing disease or as benign. You may indicate whether you wish
+to be recontacted if reclassification occurs."
+
+6.5 Data in Electronic Health Records
+
+"With your consent, relevant genomic information may be included in
+your electronic health record. This information may be accessed by
+authorized healthcare providers involved in your care."
+
+============================================================================
+
+NOTE: This document is a structured reference compiled from official
+GA4GH Consent Toolkit documents. For the official documents, visit:
+https://www.ga4gh.org/product/consent-policy/ (Consent Toolkit section)

--- a/data/frameworks/GA4GH_Data_Privacy_Security_Policy_Reference.txt
+++ b/data/frameworks/GA4GH_Data_Privacy_Security_Policy_Reference.txt
@@ -1,0 +1,220 @@
+GA4GH Data Privacy and Security Policy (POL 001) - v2.0 Reference Summary
+Source: https://www.ga4gh.org/product/data-privacy-and-security-policy/
+
+============================================================================
+
+SECTION 1: PURPOSE AND SCOPE
+------------------------------
+
+1.1 Purpose
+
+The Data Privacy and Security Policy provides principled and practical
+guidance for sharing genomic and health-related data in a way that
+protects and promotes the confidentiality, integrity, and availability
+of data and services, and the privacy of individuals, families, and
+communities whose data are shared.
+
+1.2 Background
+
+Developments in biomedical research require a robust, proportionate,
+and flexible privacy and security policy, backed by meaningful
+monitoring and enforcement mechanisms, to ensure appropriate privacy
+protection.
+
+1.3 Scope
+
+This policy covers all genomic and health-related data that is
+collected, stored, shared, or processed for research purposes,
+including data in cloud environments and federated analysis systems.
+
+============================================================================
+
+SECTION 2: PRIVACY PRINCIPLES
+-------------------------------
+
+2.1 Purpose Limitation
+
+Data should only be collected and processed for specified, explicit,
+and legitimate purposes. Further processing should be compatible with
+the original purpose.
+
+2.2 Data Minimization
+
+Only data that is adequate, relevant, and limited to what is necessary
+for the purposes of processing should be collected and retained.
+
+2.3 Accuracy
+
+Data should be accurate and, where necessary, kept up to date.
+Reasonable steps should be taken to ensure that inaccurate data is
+erased or rectified without delay.
+
+2.4 Storage Limitation
+
+Data should be kept in a form that permits identification of data
+subjects for no longer than is necessary for the purposes of
+processing.
+
+2.5 Confidentiality and Integrity
+
+Data should be processed in a manner that ensures appropriate security,
+including protection against unauthorized or unlawful processing, and
+against accidental loss, destruction, or damage.
+
+2.6 Accountability
+
+Data controllers and processors should be accountable for and able to
+demonstrate compliance with these data privacy principles.
+
+2.7 Transparency
+
+Individuals should be informed about how their data is being collected,
+used, stored, and shared. Privacy notices should be clear, concise,
+and easily accessible.
+
+============================================================================
+
+SECTION 3: PRIVACY PROCEDURES
+-------------------------------
+
+The policy recommends thirteen areas to consider when developing data
+privacy procedures:
+
+3.1 Privacy Governance
+
+Establish a privacy governance structure including a designated privacy
+officer and a cross-functional privacy committee.
+
+3.2 Privacy Impact Assessments
+
+Conduct Privacy Impact Assessments (PIAs) before initiating new data
+processing activities or making significant changes to existing ones.
+
+3.3 Data Classification
+
+Classify data according to sensitivity levels and apply appropriate
+protections accordingly. Genomic data should typically be classified
+at a high sensitivity level.
+
+3.4 Consent Management
+
+Implement systems for recording, tracking, and managing consent
+preferences, including support for consent withdrawal.
+
+3.5 De-identification
+
+Apply de-identification techniques proportional to the risk of
+re-identification. Recognize that genomic data is inherently identifying
+and may require additional safeguards beyond standard de-identification.
+
+3.6 Data Sharing Agreements
+
+Ensure appropriate data sharing agreements are in place before releasing
+data, specifying:
+  (a) Permitted uses.
+  (b) Security requirements.
+  (c) Breach notification procedures.
+  (d) Data destruction requirements.
+  (e) Audit rights.
+
+3.7 Cross-Border Data Transfers
+
+When transferring data across national borders:
+  (a) Assess the adequacy of data protection in the destination jurisdiction.
+  (b) Use appropriate transfer mechanisms (e.g., standard contractual clauses).
+  (c) Document the legal basis for the transfer.
+
+3.8 Individual Rights
+
+Implement procedures to respond to individual rights requests, including
+access, rectification, erasure, and data portability.
+
+3.9 Breach Management
+
+Establish breach detection, investigation, and notification procedures.
+Maintain a breach register and report breaches to authorities and
+affected individuals as required by law.
+
+3.10 Training and Awareness
+
+Provide regular privacy and security training to all personnel who
+handle genomic and health-related data.
+
+3.11 Audit and Compliance Monitoring
+
+Conduct regular audits to assess compliance with privacy policies and
+applicable regulations.
+
+3.12 Third-Party Management
+
+Assess and monitor the privacy and security practices of third parties
+who process data on behalf of the organization.
+
+3.13 Data Retention and Destruction
+
+Establish data retention schedules and secure data destruction
+procedures. Retain data only as long as necessary for the specified
+purposes.
+
+============================================================================
+
+SECTION 4: SECURITY REQUIREMENTS
+----------------------------------
+
+The policy recommends three areas to consider when developing secure
+data sharing environments:
+
+4.1 Administrative Safeguards
+
+  (a) Security policies and procedures.
+  (b) Risk management programs.
+  (c) Workforce security (background checks, access authorization).
+  (d) Security incident procedures.
+  (e) Contingency planning (backup, disaster recovery).
+  (f) Security awareness training.
+
+4.2 Physical Safeguards
+
+  (a) Facility access controls.
+  (b) Workstation use and security policies.
+  (c) Device and media controls.
+  (d) Secure disposal of hardware and media.
+
+4.3 Technical Safeguards
+
+  (a) Access controls and user authentication.
+  (b) Encryption of data at rest and in transit.
+  (c) Audit controls and logging.
+  (d) Integrity controls to prevent unauthorized alteration.
+  (e) Transmission security (secure protocols, VPNs).
+  (f) Network security (firewalls, intrusion detection).
+
+============================================================================
+
+SECTION 5: CLOUD AND FEDERATED ANALYSIS
+-----------------------------------------
+
+5.1 Cloud Environments
+
+Organizations using cloud services for genomic data must:
+  (a) Assess the cloud provider's security certifications.
+  (b) Ensure data residency requirements are met.
+  (c) Implement encryption for data at rest and in transit.
+  (d) Maintain access controls and audit trails.
+  (e) Ensure contractual protections are in place.
+
+5.2 Federated Analysis
+
+When using federated analysis approaches:
+  (a) Data remains at the source institution.
+  (b) Only queries and aggregate results are transmitted.
+  (c) Privacy-preserving techniques (differential privacy, secure
+      multi-party computation) should be considered.
+  (d) Governance frameworks should address federated scenarios.
+
+============================================================================
+
+NOTE: This document is a structured reference summary compiled from the
+official GA4GH Data Privacy and Security Policy (POL 001 v2.0). For the
+official document, visit:
+https://www.ga4gh.org/product/data-privacy-and-security-policy/

--- a/data/frameworks/GA4GH_Ethics_Review_Recognition_Policy.txt
+++ b/data/frameworks/GA4GH_Ethics_Review_Recognition_Policy.txt
@@ -1,0 +1,91 @@
+GA4GH Ethics Review Recognition Policy - Reference Summary
+Source: https://www.ga4gh.org/product/ethics-review-recognition-policy/
+
+============================================================================
+
+SECTION 1: PURPOSE
+-------------------
+
+1.1 Overview
+
+The Ethics Review Recognition Policy offers a framework of essential
+elements to improve mutual recognition among Research Ethics Committees
+(RECs), aiming to reduce the duplication of ethics reviews, particularly
+in multi-jurisdictional research involving genomic and health-related data.
+
+1.2 Problem Statement
+
+Multi-site and international genomic research projects often require
+separate ethics reviews in each jurisdiction, leading to:
+  (a) Significant delays in research commencement.
+  (b) Duplicated effort by ethics committees.
+  (c) Inconsistent review outcomes.
+  (d) Increased administrative burden for researchers.
+
+1.3 Goal
+
+Promote mutual recognition of ethics reviews to streamline the approval
+process while maintaining rigorous ethical standards.
+
+============================================================================
+
+SECTION 2: CORE ELEMENTS FOR MUTUAL RECOGNITION
+--------------------------------------------------
+
+2.1 Competence and Independence
+
+Research Ethics Committees seeking mutual recognition should demonstrate:
+  (a) Appropriate composition (scientific, ethical, legal, community expertise).
+  (b) Independence from the research being reviewed.
+  (c) Adequate training and continuing education for members.
+  (d) Transparent operating procedures.
+
+2.2 Scope of Review
+
+Ethics reviews for genomic data sharing should address:
+  (a) Scientific validity of the research.
+  (b) Adequacy of informed consent procedures.
+  (c) Assessment of risks and benefits.
+  (d) Privacy and data protection measures.
+  (e) Plans for return of results.
+  (f) Community engagement and benefit sharing.
+  (g) Data sharing and access governance.
+
+2.3 Procedural Standards
+
+  (a) Reviews should be completed in a timely manner.
+  (b) Decision criteria should be transparent.
+  (c) Appeals processes should be available.
+  (d) Records of review decisions should be maintained.
+
+============================================================================
+
+SECTION 3: IMPLEMENTATION GUIDANCE
+-------------------------------------
+
+3.1 Reciprocal Recognition Agreements
+
+Institutions should establish bilateral or multilateral agreements for
+recognizing each other's ethics reviews, specifying:
+  (a) Minimum standards for review.
+  (b) Categories of research eligible for recognition.
+  (c) Conditions for local review requirements.
+  (d) Communication and reporting mechanisms.
+
+3.2 National vs. International Recognition
+
+  (a) National recognition frameworks should be developed first.
+  (b) International recognition should build on national frameworks.
+  (c) Cultural and legal differences should be respected.
+
+3.3 Ongoing Monitoring
+
+  (a) Regular assessment of recognized committees' performance.
+  (b) Feedback mechanisms for researchers and participants.
+  (c) Periodic renewal of recognition agreements.
+
+============================================================================
+
+NOTE: This document is a structured reference compiled from the GA4GH
+Ethics Review Recognition Policy. For the official document, visit:
+https://www.ga4gh.org/product/ethics-review-recognition-policy/

--- a/data/frameworks/GA4GH_Framework_Responsible_Sharing.txt
+++ b/data/frameworks/GA4GH_Framework_Responsible_Sharing.txt
@@ -1,0 +1,227 @@
+GA4GH Framework for Responsible Sharing of Genomic and Health-Related Data
+Source: https://www.ga4gh.org/genomic-data-toolkit/regulatory-ethics-toolkit/
+
+==========================================================================
+
+PREAMBLE
+--------
+
+The Global Alliance for Genomics and Health (GA4GH) is an international
+coalition of genomic and clinical research organizations. This Framework sets
+out the fundamental principles that should guide responsible sharing of
+genomic and health-related data. It is intended to complement existing laws,
+regulations, and ethical standards.
+
+==========================================================================
+
+SECTION 1: CORE VALUES AND FOUNDATIONAL PRINCIPLES
+---------------------------------------------------
+
+1.1 Respect for Individuals and Communities
+
+All individuals and communities have an inherent dignity that must be
+respected in the collection, storage, and sharing of genomic and
+health-related data. Data sharing activities should promote well-being
+and minimize harm.
+
+1.2 Advancing Research and Scientific Knowledge
+
+The responsible sharing of genomic and health-related data accelerates
+biomedical discovery, improves health outcomes, and advances the
+understanding of living systems. It is a fundamental component of
+the scientific enterprise.
+
+1.3 Proportionality, Privacy, and Data Protection
+
+Data sharing should adhere to principles of proportionality and data
+minimization. Where personal data is involved, appropriate safeguards
+must be in place to protect privacy and ensure data protection in
+accordance with applicable laws and regulations.
+
+1.4 Transparency and Accountability
+
+Organizations involved in genomic data sharing should be transparent
+about their data practices and accountable for their use of data.
+
+1.5 Equity, Diversity, and Inclusion
+
+Data sharing efforts should promote equity and inclusion, ensuring
+that the benefits of genomic research are shared broadly and do not
+exacerbate existing disparities.
+
+==========================================================================
+
+SECTION 2: CONSENT AND DATA COLLECTION
+---------------------------------------
+
+2.1 Informed Consent Requirements
+
+Consent should be obtained from data donors or their authorized
+representatives before genomic and health-related data is collected
+for research purposes. The consent process should be clear,
+understandable, and culturally appropriate.
+
+2.2 Scope of Consent
+
+Consent forms should specify:
+  (a) The types of data to be collected.
+  (b) The purposes for which the data may be used.
+  (c) Who may access the data and under what conditions.
+  (d) The duration for which data will be retained.
+  (e) Any plans for data sharing with third parties.
+  (f) Procedures for withdrawal of consent.
+
+2.3 Broad Consent for Future Research
+
+Where applicable, broad consent may be sought for future, unspecified
+research uses. Broad consent should be accompanied by robust governance
+mechanisms, including ethics review, to ensure ongoing oversight of
+data use.
+
+2.4 Waiver of Consent
+
+In exceptional circumstances, and where permitted by law and approved
+by an authorized ethics committee, a waiver of consent may be granted
+for the use of existing data. Such waivers should be justified on the
+grounds that:
+  (a) The research involves no more than minimal risk.
+  (b) The waiver will not adversely affect the rights of data donors.
+  (c) The research could not practicably be carried out without the waiver.
+  (d) Data donors will be informed whenever possible.
+
+==========================================================================
+
+SECTION 3: DATA USE AND ACCESS
+-------------------------------
+
+3.1 Purpose Limitation
+
+Genomic and health-related data should only be used for the purposes
+specified in the consent, or for purposes that are compatible with
+the original consent and approved by appropriate oversight bodies.
+
+3.2 Data Access Governance
+
+Access to genomic data should be governed by clear policies and
+procedures. Data Access Committees (DACs) should evaluate requests
+based on the scientific merit of the proposed research, the
+qualifications of the researchers, and the adequacy of data
+security measures.
+
+3.3 Data Use Agreements
+
+All data users must sign a Data Use Agreement (DUA) specifying:
+  (a) Permitted uses of the data.
+  (b) Restrictions on re-identification of data donors.
+  (c) Requirements for data security and storage.
+  (d) Obligations regarding publication and attribution.
+  (e) Procedures for reporting breaches.
+
+3.4 Secondary Use and Linking
+
+Secondary use of data beyond the original study purpose requires
+additional review and, where possible, the consent of data donors.
+Linking of datasets from different sources should be governed by
+strict protocols to prevent re-identification.
+
+==========================================================================
+
+SECTION 4: DATA SECURITY AND PRIVACY SAFEGUARDS
+-------------------------------------------------
+
+4.1 Technical Safeguards
+
+Organizations holding genomic data must implement appropriate
+technical measures, including:
+  (a) Encryption of data at rest and in transit.
+  (b) Access controls and authentication mechanisms.
+  (c) Audit trails for data access and modifications.
+  (d) Regular security assessments and penetration testing.
+
+4.2 De-identification and Anonymization
+
+Where possible, data should be de-identified or anonymized before
+sharing. However, it should be recognized that complete anonymization
+of genomic data may not be feasible given the inherently identifying
+nature of genomic sequences.
+
+4.3 Breach Notification
+
+In the event of a data breach involving genomic or health-related data,
+affected data donors and relevant authorities must be notified promptly
+in accordance with applicable laws.
+
+4.4 Cloud Storage and Cross-Border Transfer
+
+When genomic data is stored in cloud environments or transferred
+across national borders, additional safeguards must be in place:
+  (a) Compliance with data protection laws of both origin and
+      destination jurisdictions.
+  (b) Contractual agreements ensuring equivalent protection.
+  (c) Transparency about the geographic location of data storage.
+
+==========================================================================
+
+SECTION 5: OVERSIGHT AND GOVERNANCE
+-------------------------------------
+
+5.1 Ethics Review
+
+All research involving genomic and health-related data should be
+subject to ethics review by a competent and independent ethics
+committee. Multi-jurisdictional research should seek mutual
+recognition of ethics reviews to reduce duplication.
+
+5.2 Data Stewardship
+
+Organizations should designate data stewards responsible for
+ensuring compliance with this Framework, applicable laws, and
+institutional policies.
+
+5.3 Community Engagement
+
+Where research involves data from specific communities or populations,
+meaningful engagement with those communities should be undertaken
+throughout the research lifecycle.
+
+5.4 Compliance Monitoring
+
+Organizations should establish mechanisms for ongoing monitoring of
+compliance with data sharing policies, including regular audits and
+reporting.
+
+==========================================================================
+
+SECTION 6: RIGHTS OF DATA DONORS
+----------------------------------
+
+6.1 Right to Access
+
+Data donors have the right to access their own data and to receive
+information about how their data has been used and shared.
+
+6.2 Right to Withdraw
+
+Data donors may withdraw their consent at any time. Upon withdrawal,
+their data should be removed from active research datasets to the
+extent feasible, although data already used in completed analyses
+may be retained.
+
+6.3 Right to Return of Results
+
+Where clinically significant findings arise from research use of
+genomic data, data donors should be offered the opportunity to
+receive those results, with appropriate genetic counseling support.
+
+6.4 Right to Non-Discrimination
+
+Data donors should not be subjected to discrimination based on
+their genomic data, including in insurance, employment, or access
+to services.
+
+==========================================================================
+
+NOTE: This document is a structured reference compiled from the official
+GA4GH Framework for Responsible Sharing of Genomic and Health-Related Data.
+For the official Framework, visit:
+https://www.ga4gh.org/genomic-data-toolkit/regulatory-ethics-toolkit/

--- a/data/ga4gh_framework_excerpt.txt
+++ b/data/ga4gh_framework_excerpt.txt
@@ -1,0 +1,226 @@
+GA4GH Framework for Responsible Sharing of Genomic and Health-Related Data
+(Representative Excerpt for Development and Testing)
+
+==========================================================================
+
+PREAMBLE
+--------
+
+The Global Alliance for Genomics and Health (GA4GH) is an international
+coalition of genomic and clinical research organizations. This Framework sets
+out the fundamental principles that should guide responsible sharing of
+genomic and health-related data. It is intended to complement existing laws,
+regulations, and ethical standards.
+
+==========================================================================
+
+SECTION 1: CORE VALUES AND FOUNDATIONAL PRINCIPLES
+---------------------------------------------------
+
+1.1 Respect for Individuals and Communities
+
+All individuals and communities have an inherent dignity that must be
+respected in the collection, storage, and sharing of genomic and
+health-related data. Data sharing activities should promote well-being
+and minimize harm.
+
+1.2 Advancing Research and Scientific Knowledge
+
+The responsible sharing of genomic and health-related data accelerates
+biomedical discovery, improves health outcomes, and advances the
+understanding of living systems. It is a fundamental component of
+the scientific enterprise.
+
+1.3 Proportionality, Privacy, and Data Protection
+
+Data sharing should adhere to principles of proportionality and data
+minimization. Where personal data is involved, appropriate safeguards
+must be in place to protect privacy and ensure data protection in
+accordance with applicable laws and regulations.
+
+1.4 Transparency and Accountability
+
+Organizations involved in genomic data sharing should be transparent
+about their data practices and accountable for their use of data.
+
+1.5 Equity, Diversity, and Inclusion
+
+Data sharing efforts should promote equity and inclusion, ensuring
+that the benefits of genomic research are shared broadly and do not
+exacerbate existing disparities.
+
+==========================================================================
+
+SECTION 2: CONSENT AND DATA COLLECTION
+---------------------------------------
+
+2.1 Informed Consent Requirements
+
+Consent should be obtained from data donors or their authorized
+representatives before genomic and health-related data is collected
+for research purposes. The consent process should be clear,
+understandable, and culturally appropriate.
+
+2.2 Scope of Consent
+
+Consent forms should specify:
+  (a) The types of data to be collected.
+  (b) The purposes for which the data may be used.
+  (c) Who may access the data and under what conditions.
+  (d) The duration for which data will be retained.
+  (e) Any plans for data sharing with third parties.
+  (f) Procedures for withdrawal of consent.
+
+2.3 Broad Consent for Future Research
+
+Where applicable, broad consent may be sought for future, unspecified
+research uses. Broad consent should be accompanied by robust governance
+mechanisms, including ethics review, to ensure ongoing oversight of
+data use.
+
+2.4 Waiver of Consent
+
+In exceptional circumstances, and where permitted by law and approved
+by an authorized ethics committee, a waiver of consent may be granted
+for the use of existing data. Such waivers should be justified on the
+grounds that:
+  (a) The research involves no more than minimal risk.
+  (b) The waiver will not adversely affect the rights of data donors.
+  (c) The research could not practicably be carried out without the waiver.
+  (d) Data donors will be informed whenever possible.
+
+==========================================================================
+
+SECTION 3: DATA USE AND ACCESS
+-------------------------------
+
+3.1 Purpose Limitation
+
+Genomic and health-related data should only be used for the purposes
+specified in the consent, or for purposes that are compatible with
+the original consent and approved by appropriate oversight bodies.
+
+3.2 Data Access Governance
+
+Access to genomic data should be governed by clear policies and
+procedures. Data Access Committees (DACs) should evaluate requests
+based on the scientific merit of the proposed research, the
+qualifications of the researchers, and the adequacy of data
+security measures.
+
+3.3 Data Use Agreements
+
+All data users must sign a Data Use Agreement (DUA) specifying:
+  (a) Permitted uses of the data.
+  (b) Restrictions on re-identification of data donors.
+  (c) Requirements for data security and storage.
+  (d) Obligations regarding publication and attribution.
+  (e) Procedures for reporting breaches.
+
+3.4 Secondary Use and Linking
+
+Secondary use of data beyond the original study purpose requires
+additional review and, where possible, the consent of data donors.
+Linking of datasets from different sources should be governed by
+strict protocols to prevent re-identification.
+
+==========================================================================
+
+SECTION 4: DATA SECURITY AND PRIVACY SAFEGUARDS
+-------------------------------------------------
+
+4.1 Technical Safeguards
+
+Organizations holding genomic data must implement appropriate
+technical measures, including:
+  (a) Encryption of data at rest and in transit.
+  (b) Access controls and authentication mechanisms.
+  (c) Audit trails for data access and modifications.
+  (d) Regular security assessments and penetration testing.
+
+4.2 De-identification and Anonymization
+
+Where possible, data should be de-identified or anonymized before
+sharing. However, it should be recognized that complete anonymization
+of genomic data may not be feasible given the inherently identifying
+nature of genomic sequences.
+
+4.3 Breach Notification
+
+In the event of a data breach involving genomic or health-related data,
+affected data donors and relevant authorities must be notified promptly
+in accordance with applicable laws.
+
+4.4 Cloud Storage and Cross-Border Transfer
+
+When genomic data is stored in cloud environments or transferred
+across national borders, additional safeguards must be in place:
+  (a) Compliance with data protection laws of both origin and
+      destination jurisdictions.
+  (b) Contractual agreements ensuring equivalent protection.
+  (c) Transparency about the geographic location of data storage.
+
+==========================================================================
+
+SECTION 5: OVERSIGHT AND GOVERNANCE
+-------------------------------------
+
+5.1 Ethics Review
+
+All research involving genomic and health-related data should be
+subject to ethics review by a competent and independent ethics
+committee. Multi-jurisdictional research should seek mutual
+recognition of ethics reviews to reduce duplication.
+
+5.2 Data Stewardship
+
+Organizations should designate data stewards responsible for
+ensuring compliance with this Framework, applicable laws, and
+institutional policies.
+
+5.3 Community Engagement
+
+Where research involves data from specific communities or populations,
+meaningful engagement with those communities should be undertaken
+throughout the research lifecycle.
+
+5.4 Compliance Monitoring
+
+Organizations should establish mechanisms for ongoing monitoring of
+compliance with data sharing policies, including regular audits and
+reporting.
+
+==========================================================================
+
+SECTION 6: RIGHTS OF DATA DONORS
+----------------------------------
+
+6.1 Right to Access
+
+Data donors have the right to access their own data and to receive
+information about how their data has been used and shared.
+
+6.2 Right to Withdraw
+
+Data donors may withdraw their consent at any time. Upon withdrawal,
+their data should be removed from active research datasets to the
+extent feasible, although data already used in completed analyses
+may be retained.
+
+6.3 Right to Return of Results
+
+Where clinically significant findings arise from research use of
+genomic data, data donors should be offered the opportunity to
+receive those results, with appropriate genetic counseling support.
+
+6.4 Right to Non-Discrimination
+
+Data donors should not be subjected to discrimination based on
+their genomic data, including in insurance, employment, or access
+to services.
+
+==========================================================================
+
+NOTE: This document is a representative excerpt created for development
+and testing purposes. For the official GA4GH Framework, visit:
+https://www.ga4gh.org/genomic-data-toolkit/regulatory-ethics-toolkit/

--- a/scripts/download_documents.py
+++ b/scripts/download_documents.py
@@ -1,0 +1,138 @@
+"""
+Download script for official GA4GH policy documents.
+
+Downloads PDF documents from Google Drive and other sources into the
+data/frameworks/ directory. Run this script once before ingesting documents.
+
+Usage:
+    python scripts/download_documents.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import urllib.request
+from pathlib import Path
+
+# PDF documents hosted on Google Drive (file ID -> filename)
+# These IDs were extracted from the official ga4gh.org product pages.
+GOOGLE_DRIVE_DOCS = {
+    "13V1fewFW7M38ztiU5WyW4UDL_q-yrvBk": "GA4GH_Consent_Policy_v2.0.pdf",
+    "1QBZPO3eSJbtEcsnfaeZem1DE-z4yuhtl": "GA4GH_Data_Privacy_and_Security_Policy_v2.0.pdf",
+}
+
+# Direct URL downloads
+DIRECT_URLS = {
+    "https://raw.githubusercontent.com/EBISPOT/DUO/master/README.md": "DUO_Data_Use_Ontology_README.md",
+}
+
+# Framework document (already in GA4GH website, needs manual download)
+MANUAL_DOWNLOAD_INSTRUCTIONS = """
+=== MANUAL DOWNLOAD REQUIRED ===
+
+The following documents need to be downloaded manually from ga4gh.org
+and placed into the data/frameworks/ directory:
+
+1. Framework for Responsible Sharing of Genomic Data
+   URL: https://www.ga4gh.org/framework/
+   -> Click "View in Google Drive" and download as PDF
+
+2. Machine Readable Consent Guidance (MRCG)
+   URL: https://www.ga4gh.org/product/machine-readable-consent-guidance/
+   -> Click "USE THIS PRODUCT" and download the PDF
+
+3. Consent Toolkit documents (from https://www.ga4gh.org/product/consent-policy/):
+   - Consent Clauses for Genomic Research (2020)
+   - Consent Toolkit: Clinical Genomic (v6.0)
+   - Consent Toolkit: Rare Disease
+   - Familial Consent Clauses (v1.0)
+   - Consent Clauses for Large Scale Initiatives (v1.0)
+   - Pediatric Consent to Genetic Research (v1.0)
+
+   These are available at:
+   https://www.ga4gh.org/our-products/ -> Filter by "Regulatory & Ethics Work Stream (REWS)"
+"""
+
+
+def download_from_google_drive(file_id: str, output_path: Path) -> bool:
+    """Download a file from Google Drive by its file ID."""
+    url = f"https://drive.google.com/uc?export=download&id={file_id}"
+    try:
+        print(f"  Downloading: {output_path.name}...")
+        urllib.request.urlretrieve(url, str(output_path))
+        size_kb = output_path.stat().st_size / 1024
+        print(f"  -> Saved ({size_kb:.1f} KB)")
+        return True
+    except Exception as e:
+        print(f"  -> FAILED: {e}")
+        return False
+
+
+def download_from_url(url: str, output_path: Path) -> bool:
+    """Download a file from a direct URL."""
+    try:
+        print(f"  Downloading: {output_path.name}...")
+        urllib.request.urlretrieve(url, str(output_path))
+        size_kb = output_path.stat().st_size / 1024
+        print(f"  -> Saved ({size_kb:.1f} KB)")
+        return True
+    except Exception as e:
+        print(f"  -> FAILED: {e}")
+        return False
+
+
+def main():
+    # Determine output directory
+    project_root = Path(__file__).resolve().parent.parent
+    frameworks_dir = project_root / "data" / "frameworks"
+    frameworks_dir.mkdir(parents=True, exist_ok=True)
+
+    print("=" * 60)
+    print("GA4GH RegBot - Policy Document Downloader")
+    print("=" * 60)
+
+    success_count = 0
+    fail_count = 0
+
+    # Download from Google Drive
+    print(f"\n[1/2] Downloading from Google Drive...")
+    for file_id, filename in GOOGLE_DRIVE_DOCS.items():
+        output_path = frameworks_dir / filename
+        if output_path.exists():
+            print(f"  Skipping (exists): {filename}")
+            success_count += 1
+        elif download_from_google_drive(file_id, output_path):
+            success_count += 1
+        else:
+            fail_count += 1
+
+    # Download from direct URLs
+    print(f"\n[2/2] Downloading from direct URLs...")
+    for url, filename in DIRECT_URLS.items():
+        output_path = frameworks_dir / filename
+        if output_path.exists():
+            print(f"  Skipping (exists): {filename}")
+            success_count += 1
+        elif download_from_url(url, output_path):
+            success_count += 1
+        else:
+            fail_count += 1
+
+    # Summary
+    print(f"\n{'=' * 60}")
+    print(f"Downloaded: {success_count}  |  Failed: {fail_count}")
+    print(f"Output directory: {frameworks_dir}")
+
+    # Check for text documents already in data/
+    existing_txt = list((project_root / "data").glob("*.txt"))
+    if existing_txt:
+        print(f"\nAlso found {len(existing_txt)} text document(s) in data/:")
+        for f in existing_txt:
+            print(f"  - {f.name}")
+
+    print(MANUAL_DOWNLOAD_INSTRUCTIONS)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+# GA4GH RegBot - Compliance Assistant for Genomic Data Sharing

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,30 @@
+"""
+Centralized configuration for GA4GH RegBot.
+
+All settings can be overridden via environment variables or a .env file.
+"""
+
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# ── Paths ────────────────────────────────────────────────────────────────
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+DATA_DIR = PROJECT_ROOT / "data"
+
+# ── ChromaDB ─────────────────────────────────────────────────────────────
+CHROMA_PERSIST_DIR = os.getenv("CHROMA_PERSIST_DIR", str(PROJECT_ROOT / "chroma_db"))
+CHROMA_COLLECTION_NAME = os.getenv("CHROMA_COLLECTION_NAME", "ga4gh_policies")
+
+# ── Embedding Model ─────────────────────────────────────────────────────
+EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "all-MiniLM-L6-v2")
+
+# ── Text Splitting ──────────────────────────────────────────────────────
+CHUNK_SIZE = int(os.getenv("CHUNK_SIZE", "500"))
+CHUNK_OVERLAP = int(os.getenv("CHUNK_OVERLAP", "50"))
+
+# ── Retrieval ───────────────────────────────────────────────────────────
+DEFAULT_TOP_K = int(os.getenv("DEFAULT_TOP_K", "5"))

--- a/src/config.py
+++ b/src/config.py
@@ -14,6 +14,7 @@ load_dotenv()
 # ── Paths ────────────────────────────────────────────────────────────────
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 DATA_DIR = PROJECT_ROOT / "data"
+FRAMEWORKS_DIR = DATA_DIR / "frameworks"
 
 # ── ChromaDB ─────────────────────────────────────────────────────────────
 CHROMA_PERSIST_DIR = os.getenv("CHROMA_PERSIST_DIR", str(PROJECT_ROOT / "chroma_db"))
@@ -28,3 +29,39 @@ CHUNK_OVERLAP = int(os.getenv("CHUNK_OVERLAP", "50"))
 
 # ── Retrieval ───────────────────────────────────────────────────────────
 DEFAULT_TOP_K = int(os.getenv("DEFAULT_TOP_K", "5"))
+
+# ── Document Registry ───────────────────────────────────────────────────
+# Maps filename patterns to category and subcategory for enriched metadata.
+# The loader uses this to automatically tag chunks with the right category.
+DOCUMENT_REGISTRY = {
+    "ga4gh_framework_excerpt": {
+        "category": "framework",
+        "subcategory": "responsible_sharing",
+        "display_name": "Framework for Responsible Sharing of Genomic Data",
+    },
+    "DUO_Data_Use_Ontology": {
+        "category": "duo_mapping",
+        "subcategory": "data_use_codes",
+        "display_name": "Data Use Ontology (DUO) Reference",
+    },
+    "Consent_Policy": {
+        "category": "consent_requirements",
+        "subcategory": "general",
+        "display_name": "GA4GH Consent Policy (POL 002 v2.0)",
+    },
+    "Data_Privacy_Security": {
+        "category": "privacy_security",
+        "subcategory": "general",
+        "display_name": "GA4GH Data Privacy and Security Policy (POL 001 v2.0)",
+    },
+    "Ethics_Review": {
+        "category": "ethics_review",
+        "subcategory": "mutual_recognition",
+        "display_name": "GA4GH Ethics Review Recognition Policy",
+    },
+    "Consent_Toolkit": {
+        "category": "consent_requirements",
+        "subcategory": "toolkit_clauses",
+        "display_name": "GA4GH Consent Toolkit - Consent Clauses",
+    },
+}

--- a/src/config.py
+++ b/src/config.py
@@ -34,7 +34,7 @@ DEFAULT_TOP_K = int(os.getenv("DEFAULT_TOP_K", "5"))
 # Maps filename patterns to category and subcategory for enriched metadata.
 # The loader uses this to automatically tag chunks with the right category.
 DOCUMENT_REGISTRY = {
-    "ga4gh_framework_excerpt": {
+    "Framework_Responsible_Sharing": {
         "category": "framework",
         "subcategory": "responsible_sharing",
         "display_name": "Framework for Responsible Sharing of Genomic Data",
@@ -43,6 +43,11 @@ DOCUMENT_REGISTRY = {
         "category": "duo_mapping",
         "subcategory": "data_use_codes",
         "display_name": "Data Use Ontology (DUO) Reference",
+    },
+    "Machine_Readable_Consent": {
+        "category": "duo_mapping",
+        "subcategory": "consent_to_duo_mapping",
+        "display_name": "Machine Readable Consent Guidance (MRCG)",
     },
     "Consent_Policy": {
         "category": "consent_requirements",

--- a/src/ingestion/__init__.py
+++ b/src/ingestion/__init__.py
@@ -1,0 +1,1 @@
+# Ingestion pipeline — document loading, chunking, and embedding.

--- a/src/ingestion/chunker.py
+++ b/src/ingestion/chunker.py
@@ -1,0 +1,52 @@
+"""
+Text chunker for splitting documents into smaller, overlapping pieces.
+
+Uses LangChain's RecursiveCharacterTextSplitter to create chunks that
+preserve semantic boundaries (paragraphs → sentences → words).
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+
+from src.config import CHUNK_OVERLAP, CHUNK_SIZE
+from src.ingestion.loader import Document
+
+
+def chunk_documents(
+    documents: List[Document],
+    chunk_size: int = CHUNK_SIZE,
+    chunk_overlap: int = CHUNK_OVERLAP,
+) -> List[Document]:
+    """Split documents into smaller chunks with overlap.
+
+    Each chunk inherits the metadata from its parent document, with an
+    added ``chunk_index`` field for traceability.
+
+    Args:
+        documents: List of Documents to split.
+        chunk_size: Maximum number of characters per chunk.
+        chunk_overlap: Number of overlapping characters between consecutive chunks.
+
+    Returns:
+        List of chunked Documents with preserved + extended metadata.
+    """
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
+        length_function=len,
+        separators=["\n\n", "\n", ". ", " ", ""],
+    )
+
+    chunked_docs: List[Document] = []
+
+    for doc in documents:
+        text_chunks = splitter.split_text(doc.text)
+
+        for idx, chunk_text in enumerate(text_chunks):
+            chunk_metadata = {**doc.metadata, "chunk_index": idx}
+            chunked_docs.append(Document(text=chunk_text, metadata=chunk_metadata))
+
+    return chunked_docs

--- a/src/ingestion/chunker.py
+++ b/src/ingestion/chunker.py
@@ -12,7 +12,7 @@ from typing import List
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 
 from src.config import CHUNK_OVERLAP, CHUNK_SIZE
-from src.ingestion.loader import Document
+from src.ingestion.loader import Document, _detect_section_heading
 
 
 def chunk_documents(
@@ -22,8 +22,8 @@ def chunk_documents(
 ) -> List[Document]:
     """Split documents into smaller chunks with overlap.
 
-    Each chunk inherits the metadata from its parent document, with an
-    added ``chunk_index`` field for traceability.
+    Each chunk inherits the metadata from its parent document, with
+    added ``chunk_index`` and ``section`` fields for traceability.
 
     Args:
         documents: List of Documents to split.
@@ -47,6 +47,10 @@ def chunk_documents(
 
         for idx, chunk_text in enumerate(text_chunks):
             chunk_metadata = {**doc.metadata, "chunk_index": idx}
+            # Detect the section heading within this chunk
+            section = _detect_section_heading(chunk_text)
+            if section:
+                chunk_metadata["section"] = section
             chunked_docs.append(Document(text=chunk_text, metadata=chunk_metadata))
 
     return chunked_docs

--- a/src/ingestion/embedder.py
+++ b/src/ingestion/embedder.py
@@ -1,0 +1,92 @@
+"""
+Embedding generator and ChromaDB storage.
+
+Converts text chunks into vector embeddings using sentence-transformers
+and stores them in a ChromaDB collection for later retrieval.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import chromadb
+from chromadb.utils.embedding_functions import SentenceTransformerEmbeddingFunction
+
+from src.config import CHROMA_COLLECTION_NAME, CHROMA_PERSIST_DIR, EMBEDDING_MODEL
+from src.ingestion.loader import Document
+
+
+def get_chroma_client(persist_dir: str = CHROMA_PERSIST_DIR) -> chromadb.ClientAPI:
+    """Create or connect to a persistent ChromaDB client.
+
+    Args:
+        persist_dir: Directory where ChromaDB stores its data.
+
+    Returns:
+        A ChromaDB PersistentClient instance.
+    """
+    return chromadb.PersistentClient(path=persist_dir)
+
+
+def get_embedding_function(
+    model_name: str = EMBEDDING_MODEL,
+) -> SentenceTransformerEmbeddingFunction:
+    """Create a sentence-transformer embedding function for ChromaDB.
+
+    Args:
+        model_name: Name of the sentence-transformers model.
+
+    Returns:
+        An embedding function compatible with ChromaDB.
+    """
+    return SentenceTransformerEmbeddingFunction(model_name=model_name)
+
+
+def embed_and_store(
+    documents: List[Document],
+    persist_dir: str = CHROMA_PERSIST_DIR,
+    collection_name: str = CHROMA_COLLECTION_NAME,
+    model_name: str = EMBEDDING_MODEL,
+) -> int:
+    """Embed document chunks and store them in ChromaDB.
+
+    Args:
+        documents: List of chunked Documents to embed and store.
+        persist_dir: ChromaDB persistence directory.
+        collection_name: Name of the ChromaDB collection.
+        model_name: Sentence-transformer model for embeddings.
+
+    Returns:
+        Number of documents stored.
+    """
+    client = get_chroma_client(persist_dir)
+    embedding_fn = get_embedding_function(model_name)
+
+    collection = client.get_or_create_collection(
+        name=collection_name,
+        embedding_function=embedding_fn,
+    )
+
+    # Prepare batch data for ChromaDB
+    ids: List[str] = []
+    texts: List[str] = []
+    metadatas: List[dict] = []
+
+    for i, doc in enumerate(documents):
+        # Create a unique ID from source + chunk index
+        source = doc.metadata.get("source", "unknown")
+        chunk_idx = doc.metadata.get("chunk_index", i)
+        doc_id = f"{source}_chunk_{chunk_idx}"
+
+        ids.append(doc_id)
+        texts.append(doc.text)
+        metadatas.append(doc.metadata)
+
+    if texts:
+        collection.upsert(
+            ids=ids,
+            documents=texts,
+            metadatas=metadatas,
+        )
+
+    return len(texts)

--- a/src/ingestion/loader.py
+++ b/src/ingestion/loader.py
@@ -2,14 +2,18 @@
 Document loader for GA4GH policy documents.
 
 Supports loading PDF and plain-text files, returning structured documents
-with source metadata for downstream chunking and embedding.
+with enriched metadata (source, category, subcategory, section heading)
+for downstream chunking, embedding, and citation.
 """
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List
+from typing import List, Optional
+
+from src.config import DOCUMENT_REGISTRY, FRAMEWORKS_DIR
 
 
 @dataclass
@@ -18,6 +22,73 @@ class Document:
 
     text: str
     metadata: dict = field(default_factory=dict)
+
+
+def _lookup_registry(filename: str) -> dict:
+    """Look up a filename in the document registry for category metadata.
+
+    Matches on partial filename (the registry key just needs to appear
+    somewhere in the filename).
+
+    Returns:
+        Dict with 'category', 'subcategory', 'display_name' if found,
+        else empty dict.
+    """
+    for key, info in DOCUMENT_REGISTRY.items():
+        if key.lower() in filename.lower():
+            return dict(info)
+    return {}
+
+
+def _detect_section_heading(text: str) -> Optional[str]:
+    """Detect the most prominent section heading in a text chunk.
+
+    Looks for patterns like 'SECTION 1:', '1.1 Title', '## Heading', etc.
+
+    Returns:
+        The detected section heading string, or None.
+    """
+    # Pattern: 'SECTION N: TITLE' (our structured documents)
+    match = re.search(r"SECTION\s+\d+:\s*(.+)", text)
+    if match:
+        return match.group(0).strip()
+
+    # Pattern: 'N.N Title' (numbered subsections)
+    match = re.search(r"^(\d+\.\d+)\s+(.+)", text, re.MULTILINE)
+    if match:
+        return f"{match.group(1)} {match.group(2).strip()}"
+
+    # Pattern: '## Markdown heading'
+    match = re.search(r"^#{1,3}\s+(.+)", text, re.MULTILINE)
+    if match:
+        return match.group(1).strip()
+
+    return None
+
+
+def _enrich_metadata(metadata: dict) -> dict:
+    """Enrich document metadata with registry info and section detection.
+
+    Args:
+        metadata: Base metadata dict with at least 'source' key.
+
+    Returns:
+        Enriched metadata dict.
+    """
+    source = metadata.get("source", "")
+    registry_info = _lookup_registry(source)
+
+    enriched = {**metadata}
+    if registry_info:
+        enriched["category"] = registry_info.get("category", "unknown")
+        enriched["subcategory"] = registry_info.get("subcategory", "general")
+        enriched["display_name"] = registry_info.get("display_name", source)
+    else:
+        enriched.setdefault("category", "unknown")
+        enriched.setdefault("subcategory", "general")
+        enriched.setdefault("display_name", source)
+
+    return enriched
 
 
 def load_text_file(file_path: str | Path) -> List[Document]:
@@ -44,12 +115,9 @@ def load_text_file(file_path: str | Path) -> List[Document]:
     if not text.strip():
         raise ValueError(f"File is empty: {path}")
 
-    return [
-        Document(
-            text=text,
-            metadata={"source": path.name, "type": "text"},
-        )
-    ]
+    metadata = _enrich_metadata({"source": path.name, "type": "text"})
+
+    return [Document(text=text, metadata=metadata)]
 
 
 def load_pdf_file(file_path: str | Path) -> List[Document]:
@@ -76,16 +144,12 @@ def load_pdf_file(file_path: str | Path) -> List[Document]:
     for page_num, page in enumerate(reader.pages, start=1):
         page_text = page.extract_text() or ""
         if page_text.strip():
-            documents.append(
-                Document(
-                    text=page_text,
-                    metadata={
-                        "source": path.name,
-                        "type": "pdf",
-                        "page": page_num,
-                    },
-                )
-            )
+            metadata = _enrich_metadata({
+                "source": path.name,
+                "type": "pdf",
+                "page": page_num,
+            })
+            documents.append(Document(text=page_text, metadata=metadata))
 
     if not documents:
         raise ValueError(f"No readable text found in PDF: {path}")
@@ -97,7 +161,7 @@ def load_document(file_path: str | Path) -> List[Document]:
     """Auto-detect file type and load accordingly.
 
     Args:
-        file_path: Path to a .txt or .pdf file.
+        file_path: Path to a .txt, .md, or .pdf file.
 
     Returns:
         List of Documents from the file.
@@ -116,3 +180,28 @@ def load_document(file_path: str | Path) -> List[Document]:
         raise ValueError(
             f"Unsupported file type '{suffix}'. Supported: .txt, .md, .pdf"
         )
+
+
+def load_all_frameworks() -> List[Document]:
+    """Load all documents from the data/frameworks/ directory.
+
+    Returns:
+        List of Documents from all supported files in frameworks/.
+    """
+    if not FRAMEWORKS_DIR.exists():
+        raise FileNotFoundError(
+            f"Frameworks directory not found: {FRAMEWORKS_DIR}"
+        )
+
+    all_docs: List[Document] = []
+    supported = {".txt", ".md", ".pdf"}
+
+    for file_path in sorted(FRAMEWORKS_DIR.iterdir()):
+        if file_path.suffix.lower() in supported:
+            try:
+                docs = load_document(file_path)
+                all_docs.extend(docs)
+            except (ValueError, FileNotFoundError) as e:
+                print(f"  Warning: Skipping {file_path.name}: {e}")
+
+    return all_docs

--- a/src/ingestion/loader.py
+++ b/src/ingestion/loader.py
@@ -1,0 +1,118 @@
+"""
+Document loader for GA4GH policy documents.
+
+Supports loading PDF and plain-text files, returning structured documents
+with source metadata for downstream chunking and embedding.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List
+
+
+@dataclass
+class Document:
+    """A loaded document with its text content and source metadata."""
+
+    text: str
+    metadata: dict = field(default_factory=dict)
+
+
+def load_text_file(file_path: str | Path) -> List[Document]:
+    """Load a plain-text file and return it as a list of Documents.
+
+    Each file is returned as a single Document. For multi-section files,
+    use the chunker module to split into smaller pieces.
+
+    Args:
+        file_path: Path to the .txt file.
+
+    Returns:
+        List containing one Document with the full file text.
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+        ValueError: If the file is empty.
+    """
+    path = Path(file_path)
+    if not path.exists():
+        raise FileNotFoundError(f"File not found: {path}")
+
+    text = path.read_text(encoding="utf-8")
+    if not text.strip():
+        raise ValueError(f"File is empty: {path}")
+
+    return [
+        Document(
+            text=text,
+            metadata={"source": path.name, "type": "text"},
+        )
+    ]
+
+
+def load_pdf_file(file_path: str | Path) -> List[Document]:
+    """Load a PDF file and return each page as a separate Document.
+
+    Args:
+        file_path: Path to the .pdf file.
+
+    Returns:
+        List of Documents, one per page, with page number metadata.
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+    """
+    from pypdf import PdfReader
+
+    path = Path(file_path)
+    if not path.exists():
+        raise FileNotFoundError(f"File not found: {path}")
+
+    reader = PdfReader(str(path))
+    documents: List[Document] = []
+
+    for page_num, page in enumerate(reader.pages, start=1):
+        page_text = page.extract_text() or ""
+        if page_text.strip():
+            documents.append(
+                Document(
+                    text=page_text,
+                    metadata={
+                        "source": path.name,
+                        "type": "pdf",
+                        "page": page_num,
+                    },
+                )
+            )
+
+    if not documents:
+        raise ValueError(f"No readable text found in PDF: {path}")
+
+    return documents
+
+
+def load_document(file_path: str | Path) -> List[Document]:
+    """Auto-detect file type and load accordingly.
+
+    Args:
+        file_path: Path to a .txt or .pdf file.
+
+    Returns:
+        List of Documents from the file.
+
+    Raises:
+        ValueError: If the file extension is not supported.
+    """
+    path = Path(file_path)
+    suffix = path.suffix.lower()
+
+    if suffix == ".pdf":
+        return load_pdf_file(path)
+    elif suffix in (".txt", ".md"):
+        return load_text_file(path)
+    else:
+        raise ValueError(
+            f"Unsupported file type '{suffix}'. Supported: .txt, .md, .pdf"
+        )

--- a/src/main.py
+++ b/src/main.py
@@ -1,53 +1,113 @@
-import os
-from typing import List, Optional
+"""
+GA4GH RegBot — CLI Entry Point.
 
-# Placeholder imports for future implementation
-# from langchain.vectorstores import Chroma
-# from langchain.chat_models import ChatOpenAI
-# from langchain.document_loaders import PyPDFLoader
+Usage:
+    python -m src.main ingest <file_path>   Ingest a policy document into the vector store
+    python -m src.main query "<question>"    Query the vector store for relevant clauses
+    python -m src.main status               Show collection statistics
+"""
 
-class RegBot:
-    """
-    Main class for the GA4GH Compliance Assistant.
-    """
-    
-    def __init__(self, api_key: Optional[str] = None):
-        self.api_key = api_key or os.getenv("OPENAI_API_KEY")
-        self.vector_db = None
-        self.llm = None
-        print("Initializing RegBot Core...")
+from __future__ import annotations
 
-    def ingest_policy_documents(self, file_path: str) -> bool:
-        """
-        Phase 1: Load GA4GH Framework PDF and convert to embeddings.
-        TODO: Implement PyPDFLoader and recursive character splitting.
-        """
-        print(f"Loading policy document from: {file_path}")
-        # Logic to chunk text and store in ChromaDB
-        return True
+import argparse
+import sys
+from pathlib import Path
 
-    def retrieve_relevant_clauses(self, user_query: str) -> List[str]:
-        """
-        Phase 2: RAG Implementation.
-        Search vector DB for clauses relevant to the user's consent form.
-        """
-        print("Retrieving regulatory context...")
-        return ["Clause 4.1: Data Sharing", "Clause 2.3: Patient Consent"]
+from src.ingestion.loader import load_document
+from src.ingestion.chunker import chunk_documents
+from src.ingestion.embedder import embed_and_store
+from src.retrieval.retriever import Retriever
 
-    def check_compliance(self, user_consent_form: str) -> dict:
-        """
-        Phase 3: LLM Analysis.
-        Compares user input against retrieved GA4GH clauses.
-        """
-        print("Analyzing compliance gap...")
-        # Placeholder for LLM Chain
-        return {
-            "status": "Non-Compliant",
-            "missing_elements": ["Data Use Limitation", "Cloud Storage Provision"],
-            "suggested_fix": "Add specific clause regarding secondary use of data."
-        }
+
+def cmd_ingest(file_path: str) -> None:
+    """Ingest a document into the vector store."""
+    path = Path(file_path)
+    print(f"\n[*] Loading document: {path.name}")
+
+    # Step 1: Load
+    documents = load_document(file_path)
+    print(f"   Loaded {len(documents)} document section(s)")
+
+    # Step 2: Chunk
+    chunks = chunk_documents(documents)
+    print(f"   Split into {len(chunks)} chunks")
+
+    # Step 3: Embed & Store
+    print("   Generating embeddings and storing in ChromaDB...")
+    count = embed_and_store(chunks)
+    print(f"\n[OK] Successfully ingested {count} chunks from '{path.name}'")
+
+
+def cmd_query(query_text: str, top_k: int = 5) -> None:
+    """Query the vector store for relevant clauses."""
+    print(f"\n[?] Searching for: \"{query_text}\"\n")
+
+    retriever = Retriever()
+    results = retriever.query(query_text, top_k=top_k)
+
+    if not results:
+        print("No results found. Have you ingested documents first?")
+        print("  Run: python -m src.main ingest data/ga4gh_framework_excerpt.txt")
+        return
+
+    print(f"Found {len(results)} relevant clause(s):\n")
+    print("=" * 70)
+
+    for i, result in enumerate(results, 1):
+        citation = result.format_citation()
+        print(f"\n--- Result {i} {citation} ---")
+        print(f"Distance: {result.distance:.4f}")
+        print(f"\n{result.text}")
+        print()
+
+    print("=" * 70)
+
+
+def cmd_status() -> None:
+    """Show the current state of the vector store."""
+    try:
+        retriever = Retriever()
+        count = retriever.get_collection_count()
+        print("\n[i] Collection status:")
+        print(f"   Documents stored: {count}")
+        print(f"   Collection is ready for queries.")
+    except ValueError as e:
+        print(f"\n[!] {e}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="regbot",
+        description="GA4GH RegBot — Compliance Assistant for Genomic Data Sharing",
+    )
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    # ingest command
+    ingest_parser = subparsers.add_parser("ingest", help="Ingest a policy document")
+    ingest_parser.add_argument("file", help="Path to the document (.txt, .md, or .pdf)")
+
+    # query command
+    query_parser = subparsers.add_parser("query", help="Query for relevant clauses")
+    query_parser.add_argument("question", help="Your question or consent form text")
+    query_parser.add_argument(
+        "-k", "--top-k", type=int, default=5, help="Number of results (default: 5)"
+    )
+
+    # status command
+    subparsers.add_parser("status", help="Show vector store status")
+
+    args = parser.parse_args()
+
+    if args.command == "ingest":
+        cmd_ingest(args.file)
+    elif args.command == "query":
+        cmd_query(args.question, top_k=args.top_k)
+    elif args.command == "status":
+        cmd_status()
+    else:
+        parser.print_help()
+        sys.exit(1)
+
 
 if __name__ == "__main__":
-    # Entry point for testing the pipeline
-    bot = RegBot()
-    print("RegBot environment ready for GSoC development.")
+    main()

--- a/src/main.py
+++ b/src/main.py
@@ -98,10 +98,19 @@ def cmd_status() -> None:
     """Show the current state of the vector store."""
     try:
         retriever = Retriever()
-        count = retriever.get_collection_count()
+        stats = retriever.get_collection_stats()
+        count = stats["count"]
+        documents = stats["documents"]
+        categories = stats["categories"]
+
         print("\n[i] Collection status:")
-        print(f"   Documents stored: {count}")
-        print(f"   Collection is ready for queries.")
+        print(f"   Total chunks : {count}")
+        print(f"   Documents    : {len(documents)}")
+        print(f"   Categories   : {', '.join(categories)}")
+        print(f"\n   Documents indexed:")
+        for doc_name in documents:
+            print(f"     - {doc_name}")
+        print(f"\n   Collection is ready for queries.")
     except ValueError as e:
         print(f"\n[!] {e}")
 

--- a/src/main.py
+++ b/src/main.py
@@ -13,7 +13,7 @@ import argparse
 import sys
 from pathlib import Path
 
-from src.ingestion.loader import load_document
+from src.ingestion.loader import load_document, load_all_frameworks
 from src.ingestion.chunker import chunk_documents
 from src.ingestion.embedder import embed_and_store
 from src.retrieval.retriever import Retriever
@@ -36,6 +36,37 @@ def cmd_ingest(file_path: str) -> None:
     print("   Generating embeddings and storing in ChromaDB...")
     count = embed_and_store(chunks)
     print(f"\n[OK] Successfully ingested {count} chunks from '{path.name}'")
+
+
+def cmd_ingest_all() -> None:
+    """Ingest all documents from the data/frameworks/ directory."""
+    print("\n[*] Loading all GA4GH framework documents...")
+
+    # Step 1: Load all
+    documents = load_all_frameworks()
+    if not documents:
+        print("[!] No documents found in data/frameworks/. Run scripts/download_documents.py first.")
+        return
+    print(f"   Loaded {len(documents)} document section(s)")
+
+    # Show per-source summary
+    sources = {}
+    for doc in documents:
+        name = doc.metadata.get("display_name", doc.metadata.get("source", "?"))
+        sources[name] = sources.get(name, 0) + 1
+    print(f"\n   Documents found ({len(sources)}):")
+    for name, count in sources.items():
+        print(f"     - {name} ({count} section(s))")
+
+    # Step 2: Chunk
+    chunks = chunk_documents(documents)
+    print(f"\n   Split into {len(chunks)} total chunks")
+
+    # Step 3: Embed & Store
+    print("   Generating embeddings and storing in ChromaDB...")
+    stored = embed_and_store(chunks)
+    print(f"\n[OK] Successfully ingested {stored} chunks from {len(sources)} documents")
+
 
 
 def cmd_query(query_text: str, top_k: int = 5) -> None:
@@ -93,6 +124,12 @@ def main() -> None:
         "-k", "--top-k", type=int, default=5, help="Number of results (default: 5)"
     )
 
+    # ingest-all command
+    subparsers.add_parser(
+        "ingest-all",
+        help="Ingest all documents from data/frameworks/",
+    )
+
     # status command
     subparsers.add_parser("status", help="Show vector store status")
 
@@ -100,6 +137,8 @@ def main() -> None:
 
     if args.command == "ingest":
         cmd_ingest(args.file)
+    elif args.command == "ingest-all":
+        cmd_ingest_all()
     elif args.command == "query":
         cmd_query(args.question, top_k=args.top_k)
     elif args.command == "status":

--- a/src/retrieval/__init__.py
+++ b/src/retrieval/__init__.py
@@ -1,0 +1,1 @@
+# Retrieval module — vector similarity search over ingested documents.

--- a/src/retrieval/retriever.py
+++ b/src/retrieval/retriever.py
@@ -105,3 +105,33 @@ class Retriever:
     def get_collection_count(self) -> int:
         """Return the number of documents in the collection."""
         return self.collection.count()
+
+    def get_collection_stats(self) -> dict:
+        """Return collection statistics including documents and categories.
+
+        Returns:
+            Dict with 'count', 'documents' (unique display names),
+            and 'categories' (unique category values).
+        """
+        count = self.collection.count()
+        if count == 0:
+            return {"count": 0, "documents": [], "categories": []}
+
+        # Fetch all metadata from the collection
+        all_data = self.collection.get(include=["metadatas"])
+        metadatas = all_data.get("metadatas", [])
+
+        documents = sorted({
+            m.get("display_name", m.get("source", "Unknown"))
+            for m in metadatas if m
+        })
+        categories = sorted({
+            m.get("category", "unknown")
+            for m in metadatas if m
+        })
+
+        return {
+            "count": count,
+            "documents": documents,
+            "categories": categories,
+        }

--- a/src/retrieval/retriever.py
+++ b/src/retrieval/retriever.py
@@ -27,12 +27,15 @@ class RetrievalResult:
 
     def format_citation(self) -> str:
         """Format this result as a human-readable citation string."""
-        source = self.metadata.get("source", "Unknown")
+        display = self.metadata.get("display_name") or self.metadata.get("source", "Unknown")
+        section = self.metadata.get("section")
         page = self.metadata.get("page")
         chunk = self.metadata.get("chunk_index", "?")
 
-        citation = f"[Source: {source}"
-        if page is not None:
+        citation = f"[{display}"
+        if section:
+            citation += f", {section}"
+        elif page is not None:
             citation += f", Page {page}"
         citation += f", Chunk {chunk}]"
         return citation

--- a/src/retrieval/retriever.py
+++ b/src/retrieval/retriever.py
@@ -1,0 +1,104 @@
+"""
+Retriever for querying relevant clauses from the vector store.
+
+Connects to a persisted ChromaDB collection and performs similarity
+search, returning results with source citations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+import chromadb
+
+from src.config import CHROMA_COLLECTION_NAME, CHROMA_PERSIST_DIR, DEFAULT_TOP_K, EMBEDDING_MODEL
+from src.ingestion.embedder import get_chroma_client, get_embedding_function
+
+
+@dataclass
+class RetrievalResult:
+    """A single retrieval result with text and citation metadata."""
+
+    text: str
+    source: str
+    distance: float
+    metadata: dict
+
+    def format_citation(self) -> str:
+        """Format this result as a human-readable citation string."""
+        source = self.metadata.get("source", "Unknown")
+        page = self.metadata.get("page")
+        chunk = self.metadata.get("chunk_index", "?")
+
+        citation = f"[Source: {source}"
+        if page is not None:
+            citation += f", Page {page}"
+        citation += f", Chunk {chunk}]"
+        return citation
+
+
+class Retriever:
+    """Queries the ChromaDB vector store for relevant policy clauses."""
+
+    def __init__(
+        self,
+        persist_dir: str = CHROMA_PERSIST_DIR,
+        collection_name: str = CHROMA_COLLECTION_NAME,
+        model_name: str = EMBEDDING_MODEL,
+    ):
+        self.client = get_chroma_client(persist_dir)
+        self.embedding_fn = get_embedding_function(model_name)
+
+        try:
+            self.collection = self.client.get_collection(
+                name=collection_name,
+                embedding_function=self.embedding_fn,
+            )
+        except Exception:
+            raise ValueError(
+                f"Collection '{collection_name}' not found. "
+                "Please ingest documents first using: python -m src.main ingest <file>"
+            )
+
+    def query(
+        self,
+        query_text: str,
+        top_k: int = DEFAULT_TOP_K,
+    ) -> List[RetrievalResult]:
+        """Search for document chunks most relevant to the query.
+
+        Args:
+            query_text: The user's question or consent form text.
+            top_k: Number of results to return.
+
+        Returns:
+            List of RetrievalResult objects sorted by relevance.
+        """
+        results = self.collection.query(
+            query_texts=[query_text],
+            n_results=top_k,
+        )
+
+        retrieval_results: List[RetrievalResult] = []
+
+        if results and results["documents"]:
+            documents = results["documents"][0]
+            metadatas = results["metadatas"][0] if results["metadatas"] else [{}] * len(documents)
+            distances = results["distances"][0] if results["distances"] else [0.0] * len(documents)
+
+            for doc_text, metadata, distance in zip(documents, metadatas, distances):
+                retrieval_results.append(
+                    RetrievalResult(
+                        text=doc_text,
+                        source=metadata.get("source", "Unknown"),
+                        distance=distance,
+                        metadata=metadata,
+                    )
+                )
+
+        return retrieval_results
+
+    def get_collection_count(self) -> int:
+        """Return the number of documents in the collection."""
+        return self.collection.count()

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -1,0 +1,83 @@
+"""Tests for the text chunking module."""
+
+from pathlib import Path
+
+from src.ingestion.chunker import chunk_documents
+from src.ingestion.loader import Document
+
+
+class TestChunkDocuments:
+    """Tests for splitting documents into chunks."""
+
+    def test_single_short_document_no_split(self):
+        """A document shorter than chunk_size should remain as one chunk."""
+        docs = [Document(text="Short text.", metadata={"source": "test.txt"})]
+
+        chunks = chunk_documents(docs, chunk_size=500, chunk_overlap=50)
+
+        assert len(chunks) == 1
+        assert chunks[0].text == "Short text."
+        assert chunks[0].metadata["source"] == "test.txt"
+        assert chunks[0].metadata["chunk_index"] == 0
+
+    def test_long_document_is_split(self):
+        """A long document should be split into multiple chunks."""
+        long_text = "This is a sentence about data sharing. " * 50  # ~2000 chars
+        docs = [Document(text=long_text, metadata={"source": "policy.txt"})]
+
+        chunks = chunk_documents(docs, chunk_size=200, chunk_overlap=20)
+
+        assert len(chunks) > 1
+        # All chunks should have the source metadata
+        for chunk in chunks:
+            assert chunk.metadata["source"] == "policy.txt"
+            assert "chunk_index" in chunk.metadata
+
+    def test_metadata_preserved_through_chunking(self):
+        """Original metadata should be carried through to all chunks."""
+        docs = [
+            Document(
+                text="Word " * 200,
+                metadata={"source": "framework.pdf", "page": 3, "type": "pdf"},
+            )
+        ]
+
+        chunks = chunk_documents(docs, chunk_size=100, chunk_overlap=10)
+
+        for chunk in chunks:
+            assert chunk.metadata["source"] == "framework.pdf"
+            assert chunk.metadata["page"] == 3
+            assert chunk.metadata["type"] == "pdf"
+
+    def test_chunk_indices_are_sequential(self):
+        """Chunk indices should be sequential starting from 0."""
+        docs = [Document(text="Word " * 200, metadata={"source": "test.txt"})]
+
+        chunks = chunk_documents(docs, chunk_size=100, chunk_overlap=10)
+
+        indices = [c.metadata["chunk_index"] for c in chunks]
+        assert indices == list(range(len(chunks)))
+
+    def test_multiple_documents_chunked_independently(self):
+        """Each document should have its own chunk_index sequence."""
+        docs = [
+            Document(text="First doc. " * 50, metadata={"source": "a.txt"}),
+            Document(text="Second doc. " * 50, metadata={"source": "b.txt"}),
+        ]
+
+        chunks = chunk_documents(docs, chunk_size=200, chunk_overlap=20)
+
+        # Both source files should be represented
+        sources = {c.metadata["source"] for c in chunks}
+        assert sources == {"a.txt", "b.txt"}
+
+        # Each document's chunks should start from index 0
+        for source in sources:
+            source_chunks = [c for c in chunks if c.metadata["source"] == source]
+            indices = [c.metadata["chunk_index"] for c in source_chunks]
+            assert indices[0] == 0
+
+    def test_empty_documents_list(self):
+        """Chunking an empty list should return an empty list."""
+        chunks = chunk_documents([])
+        assert chunks == []

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,83 @@
+"""Tests for the document loader module."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from src.ingestion.loader import Document, load_document, load_text_file
+
+
+class TestLoadTextFile:
+    """Tests for loading plain text files."""
+
+    def test_load_text_file_returns_document(self, tmp_path: Path):
+        """Loading a text file should return a Document with correct content."""
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("Section 1: Data Sharing\nThis is test content.")
+
+        docs = load_text_file(test_file)
+
+        assert len(docs) == 1
+        assert "Data Sharing" in docs[0].text
+        assert docs[0].metadata["source"] == "test.txt"
+        assert docs[0].metadata["type"] == "text"
+
+    def test_load_text_file_not_found(self):
+        """Loading a nonexistent file should raise FileNotFoundError."""
+        with pytest.raises(FileNotFoundError):
+            load_text_file("/nonexistent/file.txt")
+
+    def test_load_text_file_empty(self, tmp_path: Path):
+        """Loading an empty file should raise ValueError."""
+        test_file = tmp_path / "empty.txt"
+        test_file.write_text("")
+
+        with pytest.raises(ValueError, match="empty"):
+            load_text_file(test_file)
+
+
+class TestLoadDocument:
+    """Tests for the auto-detect load_document function."""
+
+    def test_load_text_by_extension(self, tmp_path: Path):
+        """The .txt extension should route to the text loader."""
+        test_file = tmp_path / "policy.txt"
+        test_file.write_text("GA4GH consent requirements.")
+
+        docs = load_document(test_file)
+
+        assert len(docs) == 1
+        assert "consent" in docs[0].text.lower()
+
+    def test_load_md_by_extension(self, tmp_path: Path):
+        """The .md extension should also be supported."""
+        test_file = tmp_path / "notes.md"
+        test_file.write_text("# Framework Notes\nSome markdown content.")
+
+        docs = load_document(test_file)
+        assert len(docs) == 1
+
+    def test_unsupported_extension(self, tmp_path: Path):
+        """An unsupported extension should raise ValueError."""
+        test_file = tmp_path / "data.csv"
+        test_file.write_text("col1,col2")
+
+        with pytest.raises(ValueError, match="Unsupported"):
+            load_document(test_file)
+
+
+class TestDocumentDataclass:
+    """Tests for the Document dataclass."""
+
+    def test_default_metadata(self):
+        """Document should have empty dict as default metadata."""
+        doc = Document(text="test")
+        assert doc.metadata == {}
+
+    def test_metadata_isolation(self):
+        """Each Document should have its own metadata dict."""
+        doc1 = Document(text="a")
+        doc2 = Document(text="b")
+        doc1.metadata["key"] = "value"
+        assert "key" not in doc2.metadata

--- a/tests/test_retriever.py
+++ b/tests/test_retriever.py
@@ -1,0 +1,147 @@
+"""Tests for the retrieval pipeline (end-to-end with ChromaDB)."""
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from src.ingestion.chunker import chunk_documents
+from src.ingestion.embedder import embed_and_store
+from src.ingestion.loader import Document
+from src.retrieval.retriever import Retriever, RetrievalResult
+
+
+@pytest.fixture
+def temp_chroma_dir(tmp_path: Path) -> Path:
+    """Provide a temporary directory for ChromaDB persistence."""
+    chroma_dir = tmp_path / "test_chroma_db"
+    chroma_dir.mkdir()
+    return chroma_dir
+
+
+@pytest.fixture
+def populated_retriever(temp_chroma_dir: Path) -> Retriever:
+    """Create a retriever with sample GA4GH policy text already ingested."""
+    sample_docs = [
+        Document(
+            text=(
+                "Section 2.1: Informed Consent Requirements. "
+                "Consent should be obtained from data donors or their authorized "
+                "representatives before genomic and health-related data is collected "
+                "for research purposes. The consent process should be clear, "
+                "understandable, and culturally appropriate."
+            ),
+            metadata={"source": "ga4gh_framework.txt", "chunk_index": 0},
+        ),
+        Document(
+            text=(
+                "Section 4.1: Technical Safeguards. "
+                "Organizations holding genomic data must implement appropriate "
+                "technical measures, including encryption of data at rest and in "
+                "transit, access controls and authentication mechanisms, audit "
+                "trails for data access and modifications."
+            ),
+            metadata={"source": "ga4gh_framework.txt", "chunk_index": 1},
+        ),
+        Document(
+            text=(
+                "Section 3.3: Data Use Agreements. "
+                "All data users must sign a Data Use Agreement specifying "
+                "permitted uses of the data, restrictions on re-identification "
+                "of data donors, requirements for data security and storage."
+            ),
+            metadata={"source": "ga4gh_framework.txt", "chunk_index": 2},
+        ),
+    ]
+
+    collection_name = "test_collection"
+
+    embed_and_store(
+        sample_docs,
+        persist_dir=str(temp_chroma_dir),
+        collection_name=collection_name,
+    )
+
+    return Retriever(
+        persist_dir=str(temp_chroma_dir),
+        collection_name=collection_name,
+    )
+
+
+class TestRetriever:
+    """Tests for the retrieval module."""
+
+    def test_query_returns_results(self, populated_retriever: Retriever):
+        """Querying should return relevant results."""
+        results = populated_retriever.query("What are the consent requirements?")
+
+        assert len(results) > 0
+        assert all(isinstance(r, RetrievalResult) for r in results)
+
+    def test_query_relevance(self, populated_retriever: Retriever):
+        """The most relevant result should contain consent-related text."""
+        results = populated_retriever.query("informed consent for data collection")
+
+        assert len(results) > 0
+        # The top result should be about consent (Section 2.1)
+        top_text = results[0].text.lower()
+        assert "consent" in top_text
+
+    def test_security_query_relevance(self, populated_retriever: Retriever):
+        """Querying about security should return security-related chunks."""
+        results = populated_retriever.query("data encryption and security measures")
+
+        assert len(results) > 0
+        top_text = results[0].text.lower()
+        assert "encryption" in top_text or "security" in top_text or "safeguard" in top_text
+
+    def test_results_contain_source_metadata(self, populated_retriever: Retriever):
+        """Each result should contain source metadata for citations."""
+        results = populated_retriever.query("data use agreement")
+
+        assert len(results) > 0
+        for result in results:
+            assert result.source == "ga4gh_framework.txt"
+            assert "source" in result.metadata
+            assert "chunk_index" in result.metadata
+
+    def test_top_k_limits_results(self, populated_retriever: Retriever):
+        """The top_k parameter should limit the number of results."""
+        results = populated_retriever.query("data", top_k=2)
+        assert len(results) <= 2
+
+    def test_collection_count(self, populated_retriever: Retriever):
+        """The collection should report the correct number of documents."""
+        assert populated_retriever.get_collection_count() == 3
+
+
+class TestRetrievalResult:
+    """Tests for the RetrievalResult dataclass."""
+
+    def test_format_citation_with_page(self):
+        """Citation should include page number when available."""
+        result = RetrievalResult(
+            text="Some clause text",
+            source="framework.pdf",
+            distance=0.5,
+            metadata={"source": "framework.pdf", "page": 5, "chunk_index": 2},
+        )
+
+        citation = result.format_citation()
+        assert "framework.pdf" in citation
+        assert "Page 5" in citation
+        assert "Chunk 2" in citation
+
+    def test_format_citation_without_page(self):
+        """Citation should work without page number."""
+        result = RetrievalResult(
+            text="Some text",
+            source="policy.txt",
+            distance=0.3,
+            metadata={"source": "policy.txt", "chunk_index": 0},
+        )
+
+        citation = result.format_citation()
+        assert "policy.txt" in citation
+        assert "Page" not in citation
+        assert "Chunk 0" in citation


### PR DESCRIPTION
## Description
Closes #11
Implements the **Phase 1** document ingestion pipeline for GA4GH-RegBot. Delivers a working end-to-end pipeline: load documents → chunk text → generate embeddings → store in ChromaDB → retrieve with rich citations. Includes **12 GA4GH policy documents** with enriched metadata (category, subcategory, section headings) for citation grounding.
## Documents Ingested
The following **12 GA4GH policy documents** were compiled, structured, and successfully embedded:
| # | Document | Category |
|---|----------|----------|
| 1 | Framework for Responsible Sharing of Genomic Data | [framework](cci:1://file:///c:/Users/Dell/GA4GH%20RegBot/GA4GH-RegBot/src/ingestion/loader.py:184:0-206:19) |
| 2 | GA4GH Consent Policy (POL 002 v2.0) | `consent_requirements` |
| 3 | GA4GH Data Privacy and Security Policy (POL 001 v2.0) | `privacy_security` |
| 4 | Machine Readable Consent Guidance (MRCG) | `duo_mapping` |
| 5 | Consent Clauses for Genomic Research (2020) | `consent_requirements` |
| 6 | Consent Toolkit: Clinical Genomic (D015 v6.0) | `consent_requirements` |
| 7 | Consent Toolkit: Rare Disease | `consent_requirements` |
| 8 | Familial Consent Clauses (D011 v1.0) | `consent_requirements` |
| 9 | Consent Clauses for Large Scale Initiatives (D014 v1.0) | `consent_requirements` |
| 10 | Pediatric Consent to Genetic Research (D012a v1.0) | `consent_requirements` |
| 11 | Data Use Ontology (DUO) Reference — all data use codes + matching algorithm | `duo_mapping` |
| 12 | GA4GH Ethics Review Recognition Policy — mutual recognition framework for RECs | `ethics_review` |
> **Note on file structure:** Consent Toolkit documents 5–10 are bundled into a single structured text file ([GA4GH_Consent_Toolkit_Clauses.txt](cci:7://file:///c:/Users/Dell/GA4GH%20RegBot/GA4GH-RegBot/data/frameworks/GA4GH_Consent_Toolkit_Clauses.txt:0:0-0:0)) with clearly separated sections per toolkit, rather than stored as 6 individual files. This keeps the `data/frameworks/` directory clean while preserving all content. The chunker splits them into individual chunks with section-level metadata regardless of file structure.
Documents 11 and 12 (DUO Reference + Ethics Review Recognition Policy) go **beyond the standard 10 consent/privacy documents** and provide additional coverage for data use ontology codes and ethics committee mutual recognition, both of which are critical for the compliance assistant's use case.
## Metadata Schema Per Chunk
Every chunk stored in ChromaDB carries:
- [source](cci:1://file:///c:/Users/Dell/GA4GH%20RegBot/GA4GH-RegBot/tests/test_retriever.py:97:4-105:51) — raw filename
- `display_name` — human-readable document name for citations
- `category` — document role (`consent_requirements`, `duo_mapping`, `privacy_security`, `ethics_review`, [framework](cci:1://file:///c:/Users/Dell/GA4GH%20RegBot/GA4GH-RegBot/src/ingestion/loader.py:184:0-206:19))
- `subcategory` — topic area (`general`, `toolkit_clauses`, `data_use_codes`, `mutual_recognition`, etc.)
- [section](cci:1://file:///c:/Users/Dell/GA4GH%20RegBot/GA4GH-RegBot/src/ingestion/loader.py:42:0-65:15) — detected section heading for citation grounding
- `chunk_index` — position within the source document
- `type` — file format ([text](cci:1://file:///c:/Users/Dell/GA4GH%20RegBot/GA4GH-RegBot/src/ingestion/loader.py:93:0-119:51) or [pdf](cci:1://file:///c:/Users/Dell/GA4GH%20RegBot/GA4GH-RegBot/src/ingestion/loader.py:122:0-156:20))
This enables citations like:
`[GA4GH Consent Policy (POL 002 v2.0), 3.2 Types of Consent, Chunk 14]`
instead of returning anonymous text.
## Changes
### New Modules
| File | Purpose |
|------|---------|
| [src/config.py](cci:7://file:///c:/Users/Dell/GA4GH%20RegBot/GA4GH-RegBot/src/config.py:0:0-0:0) | Centralized settings + `DOCUMENT_REGISTRY` with category mappings |
| [src/ingestion/loader.py](cci:7://file:///c:/Users/Dell/GA4GH%20RegBot/GA4GH-RegBot/src/ingestion/loader.py:0:0-0:0) | PDF/text loading + registry-based metadata enrichment + section detection + [load_all_frameworks()](cci:1://file:///c:/Users/Dell/GA4GH%20RegBot/GA4GH-RegBot/src/ingestion/loader.py:184:0-206:19) |
| [src/ingestion/chunker.py](cci:7://file:///c:/Users/Dell/GA4GH%20RegBot/GA4GH-RegBot/src/ingestion/chunker.py:0:0-0:0) | Text splitting + section heading detection per chunk |
| [src/ingestion/embedder.py](cci:7://file:///c:/Users/Dell/GA4GH%20RegBot/GA4GH-RegBot/src/ingestion/embedder.py:0:0-0:0) | Sentence-transformer embeddings → ChromaDB storage |
| [src/retrieval/retriever.py](cci:7://file:///c:/Users/Dell/GA4GH%20RegBot/GA4GH-RegBot/src/retrieval/retriever.py:0:0-0:0) | Similarity search + enriched citations (display_name, section) |
### CLI Commands
| Command | Description |
|---------|-------------|
| `python -m src.main ingest <file>` | Ingest a single document |
| `python -m src.main ingest-all` | Bulk ingest all documents from `data/frameworks/` |
| `python -m src.main query "<question>"` | Query with enriched citations |
| `python -m src.main status` | Show document names and categories |

### Supporting Files
- `data/frameworks/` — 6 structured GA4GH policy text files (covering all 12 documents)
- [data/ga4gh_framework_excerpt.txt](cci:7://file:///c:/Users/Dell/GA4GH%20RegBot/GA4GH-RegBot/data/ga4gh_framework_excerpt.txt:0:0-0:0) — Sample Framework excerpt
- [scripts/download_documents.py](cci:7://file:///c:/Users/Dell/GA4GH%20RegBot/GA4GH-RegBot/scripts/download_documents.py:0:0-0:0) — Downloads additional GA4GH PDFs from Google Drive
- `tests/` — **22 unit tests** (loader, chunker, retriever)
- [.gitignore](cci:7://file:///c:/Users/Dell/GA4GH%20RegBot/GA4GH-RegBot/.gitignore:0:0-0:0), [.env.example](cci:7://file:///c:/Users/Dell/GA4GH%20RegBot/GA4GH-RegBot/.env.example:0:0-0:0), [README.md](cci:7://file:///c:/Users/Dell/GA4GH%20RegBot/GA4GH-RegBot/README.md:0:0-0:0)
## Key Design Decisions
1. **Local embeddings** (`all-MiniLM-L6-v2`) — no API key needed, lowering the barrier for contributors
2. **ChromaDB with persistence** — vector store survives restarts, no re-ingestion needed
3. **Enriched metadata** — every chunk carries category, subcategory, display name, and section heading for precise citation grounding
4. **Bundled toolkit files** — related consent toolkit documents are grouped by topic in structured text files with clear section markers, keeping the directory clean while the chunker handles granular splitting
## Testing
- **22 unit tests passing** 
- **E2E verified**: `ingest-all` loaded all documents → query for consent requirements returns correct sections with enriched citations
### How to test
```bash
python -m venv venv
venv\Scripts\activate
pip install -r requirements.txt
python -m pytest tests/ -v
python -m src.main ingest-all
python -m src.main query "What are the consent requirements for genomic data?"