### PR TITLE
Phase 4: correct drifted docs, fix page-0 citations in both UIs

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,45 @@
+name: Frontend
+
+# The Next.js UI had four eslint errors and an unused import sitting in the tree
+# unnoticed, because CI checked only Python. Paths-filtered so a backend-only PR
+# does not pay for an npm install it cannot affect.
+
+on:
+  push:
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend.yml"
+  pull_request:
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend.yml"
+
+defaults:
+  run:
+    working-directory: frontend
+
+jobs:
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          # next@16 requires >=20.9.0; 22 is the active LTS.
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: ESLint
+        run: npm run lint
+
+      - name: TypeScript (no emit)
+        run: npx tsc --noEmit
+
+      - name: Build
+        run: npm run build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,8 @@
 
 ## Environment
 
-- Use **Python 3.10–3.12** (3.11 matches CI). Avoid 3.14 for the full ML/Chroma stack until wheels catch up.
+- Use **Python 3.10–3.13** (the range `pyproject.toml` accepts; 3.11 matches CI). Avoid 3.14 for the full ML/Chroma stack until wheels catch up.
+- Working on `frontend/` also needs **Node 20.9+** (CI uses 22).
 - Create a venv and install runtime deps:
 
 ```bash
@@ -50,6 +51,22 @@ python -m mypy -p src.regbot
 ```
 
 This type-checks the `src.regbot` package (same as CI).
+
+## Frontend (`frontend/`)
+
+Run all three before pushing a change to the Next.js UI — CI runs the same set on any
+PR that touches `frontend/`:
+
+```bash
+npm --prefix frontend run lint
+npx --prefix frontend tsc -p frontend/tsconfig.json --noEmit
+npm --prefix frontend run build
+```
+
+`npm run lint` enforces the React hook rules, including `set-state-in-effect`: an effect
+body may not update state synchronously. Mirroring a prop into state, or starting a fetch
+with `setLoading(true)`, will fail here — derive from the prop instead, or raise the flag
+in the event handler that starts the fetch.
 
 ## Secrets and local data
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ RegBot is a Global Alliance for Genomics and Health [Regulatory and Ethics Work 
 Documentation
 - **`docs/DESIGN.md`** — architecture, data model, evaluation plan (GSoC design doc)
 - **`docs/eval_results.md`** — measured retrieval benchmark: metrics, tuning runs, threats to validity
-- **`docs/corpus_manifest.yaml`** — regulatory corpus inventory (22 documents; P0/P1 primary sources, P2 marked `summary`)
+- **`docs/corpus_manifest.yaml`** — regulatory corpus inventory (23 documents; P0/P1 primary sources, P2 marked `summary`)
 - **`examples/eval/gold_ga4gh.yaml`** — retrieval gold set (drafted; awaiting mentor review)
 - **`examples/DEMO.md`** — local end-to-end demo
 
@@ -24,7 +24,7 @@ What works today
 - **PDF eval harness:** `eval` subcommand ingests a real GA4GH PDF and prints retrieval hits for built-in or custom queries (manual inspection; use `benchmark` for scored evaluation).
 
 Quickstart (Development)
-- Prerequisites: **Python 3.10–3.12** (CI uses 3.11). Python 3.14 is not supported yet for the full stack (native wheels for parts of the ML/Chroma toolchain often lag).
+- Prerequisites: **Python 3.10–3.13** (the range `pyproject.toml` accepts; CI runs 3.11, which is the tested one). Python 3.14 is not supported yet for the full stack (native wheels for parts of the ML/Chroma toolchain often lag). Running the web UI also needs **Node 18+** for `frontend/`.
 - Create a virtual environment and install dependencies:
 
 ```bash
@@ -90,7 +90,9 @@ uvicorn src.api.app:app --reload --port 8000
 cd frontend && npm install && npm run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000). The Next.js dev server proxies `/api/*` to the API on port 8000.
+Open [http://localhost:3000](http://localhost:3000). The Next.js dev server proxies `/api/*` and `/health` to the API on port 8000; set `REGBOT_API_URL` before `npm run dev` if the API is not on `http://127.0.0.1:8000`.
+
+A fresh clone ships `manifest.json` but **not** the Chroma vectors (git-ignored), so run `ingest-manifest --reset` once before the UI can retrieve anything — the Corpus tab shows an empty store until you do.
 
 - Run the legacy **Streamlit** UI:
 
@@ -147,6 +149,7 @@ Environment Variables
 - `REGBOT_OLLAMA_BASE_URL`: Ollama HTTP host only (default `http://127.0.0.1:11434`); `/v1` is appended automatically for the OpenAI-compatible routes.
 - `REGBOT_OLLAMA_API_KEY`: Sent as the Bearer/API key to Ollama’s shim (default `ollama`; ignored by Ollama).
 - `REGBOT_STORE`: On-disk store directory (default `./data/regbot_store`).
+- `REGBOT_API_URL`: Read by the **Next.js dev server** (`frontend/next.config.ts`) to proxy `/api/*` and `/health` (default `http://127.0.0.1:8000`). Set it when the FastAPI process is on another host or port.
 - `REGBOT_EMBEDDING_MODEL`: SentenceTransformers model id (default `sentence-transformers/all-MiniLM-L6-v2`).
 - `HF_HUB_DOWNLOAD_TIMEOUT`: Hugging Face Hub download timeout in seconds (embedding model on first use). The app sets a higher default when unset; increase if you see read timeouts.
 - `REGBOT_HF_ENDPOINT`: If set, copied to `HF_ENDPOINT` (e.g. `https://hf-mirror.com` where Hub mirrors are used).
@@ -158,11 +161,12 @@ Environment Variables
 - `REGBOT_OPENAI_MAX_RETRIES`: Retries for the **OpenAI Python client** (used for both OpenAI API and Ollama’s compatible endpoint; default `3`).
 
 Architecture (implemented vs planned)
-- **Core:** Python 3, package under `src/regbot/` (ingest, hybrid retrieval, compliance, optional local embedding download helpers).
+- **Core:** Python 3, package under `src/regbot/` — ingestion, hybrid retrieval, fusion, grounding, evidence, evaluation, jurisdiction and text utilities.
 - **Embeddings:** `sentence-transformers` + Hugging Face Hub (minimal file set; ONNX-heavy artifacts skipped where possible).
-- **Vector store:** Chroma persistent files under `REGBOT_STORE/chroma` plus `manifest.json` for BM25 text.
-- **Retrieval:** cosine similarity in Chroma + `rank-bm25`, fused via reciprocal rank fusion; optional metadata category filter.
+- **Vector store:** Chroma persistent files under `REGBOT_STORE/chroma` plus `manifest.json`, which holds chunk text and metadata for BM25 and citation audit.
+- **Retrieval:** exact cosine ranking over the stored embeddings (loaded once from Chroma, ranked in process — the ANN index was approximate and made results irreproducible) + `rank-bm25`, fused by reciprocal rank. `jurisdiction` / `framework` / `category` filters restrict the candidate pool before the top-N cut.
 - **LLM:** **Default:** Ollama (`llama3` or `REGBOT_OLLAMA_MODEL`) via OpenAI-compatible chat completions + JSON parsing. **Optional:** `REGBOT_LLM_PROVIDER=openai` with `OPENAI_API_KEY`. **Fallback:** keyword heuristic if OpenAI is selected without a key, or after LLM errors (e.g. Ollama not running).
-- **UI:** Streamlit (`src/streamlit_app.py`).
-- **Optional / roadmap:** LangChain or LlamaIndex adapters on top of the same stores (not required by the current code); richer offline evaluation (Ragas, human labels); structured per-recommendation evidence (e.g. quotes).
+- **API:** FastAPI (`src/api/app.py`) — corpus, chunk, ingest, check and chat endpoints behind `/api`.
+- **UI:** Next.js in `frontend/` (recommended); Streamlit (`src/streamlit_app.py`) retained as the legacy single-process option.
+- **Optional / roadmap:** LangChain or LlamaIndex adapters on top of the same stores (not required by the current code); richer offline evaluation (Ragas, human labels); a cross-encoder re-ranker over the fused pool (`docs/eval_results.md` §7).
 

--- a/docs/eval_results.md
+++ b/docs/eval_results.md
@@ -20,7 +20,7 @@ python -m src.main benchmark --gold examples/eval/gold_ga4gh.yaml --label baseli
 
 | | |
 |---|---|
-| Corpus | 868 chunks / 23 documents — 16 primary / 7 summary (see §4b, §4c, §4h) |
+| Corpus | 864 chunks / 23 documents — 16 primary / 7 summary (see §4b, §4c, §4h) |
 | Gold set | v0.4 — 12 queries, 0 skipped |
 | Embeddings | `all-MiniLM-L6-v2`, cosine |
 | Fusion | Reciprocal rank fusion over dense + BM25 |
@@ -533,11 +533,17 @@ Plus web navigation ("Latest News", "Our products") and EUR-Lex file metadata
 
 | | before | after |
 |---|--------|-------|
-| chunks | 963 | **868** |
-| chunks under 200 characters | 110 | **26** |
+| chunks | 963 | **864** |
+| chunks under 200 characters | 110 | **21** |
 | bare-heading chunks | 44 | **0** |
 | chunks carrying a PDF running header | 48 | **0** |
 | Taiwan chunks | 207 (one document) | 135 (two Acts) |
+
+The `after` column includes a second pass over the 26 short chunks the first one left. Two
+were not content — a bare `9 Appendix 2` page label and the fetcher's own provenance line,
+now written as a footer so it stops leading the document's first chunk — which took the
+corpus to 864. The 21 that remain were each read and kept deliberately: real provision text,
+footnotes, and bibliography entries from the FRS appendix.
 
 Retrieval barely moved — provision recall@5 rose 0.743 → 0.787, @8 held at 0.846 — which is
 the point worth recording: **none of these defects were visible in the metrics.** A cleaner

--- a/frontend/src/components/regbot/chat-tab.tsx
+++ b/frontend/src/components/regbot/chat-tab.tsx
@@ -40,27 +40,29 @@ export function ChatTab({
   const [prompt, setPrompt] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [selectedJurisdictions, setSelectedJurisdictions] = useState<string[]>(
-    lastJurisdictions,
-  );
   const [lastChunks, setLastChunks] = useState<Chunk[]>([]);
   const [lastScope, setLastScope] = useState("");
   const bottomRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (lastJurisdictions.length > 0) {
-      setSelectedJurisdictions(lastJurisdictions);
-    }
-  }, [lastJurisdictions]);
+  // The follow-up question defaults to the scope of the most recent Check run, but the
+  // user may re-scope it freely in between. Rather than mirroring the prop into state
+  // with an effect, the override records which run it was made against: when a new
+  // analysis arrives, the stale override is ignored and the new scope takes over.
+  const [override, setOverride] = useState<{ from: string[]; value: string[] } | null>(
+    null,
+  );
+  const selectedJurisdictions =
+    override && override.from === lastJurisdictions ? override.value : lastJurisdictions;
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages, loading, lastChunks]);
 
   const toggleJurisdiction = (code: string) => {
-    setSelectedJurisdictions((prev) =>
-      prev.includes(code) ? prev.filter((c) => c !== code) : [...prev, code],
-    );
+    const next = selectedJurisdictions.includes(code)
+      ? selectedJurisdictions.filter((c) => c !== code)
+      : [...selectedJurisdictions, code];
+    setOverride({ from: lastJurisdictions, value: next });
   };
 
   const onSend = useCallback(async () => {

--- a/frontend/src/components/regbot/check-tab.tsx
+++ b/frontend/src/components/regbot/check-tab.tsx
@@ -14,7 +14,6 @@ import { ChunkCard } from "@/components/regbot/chunk-card";
 import { ReportView } from "@/components/regbot/report-view";
 import {
   checkConsent,
-  type ChatMessage,
   type CheckResult,
   type Chunk,
   type JurisdictionOption,

--- a/frontend/src/components/regbot/chunk-card.tsx
+++ b/frontend/src/components/regbot/chunk-card.tsx
@@ -32,6 +32,10 @@ export function ChunkCard({ chunk, sourceUrls }: ChunkCardProps) {
   const tags = jurisdictionTags(meta);
   const docId = String(meta.document_id ?? meta.category ?? "");
   const sourceUrl = docId && sourceUrls ? sourceUrls[docId] : undefined;
+  // Page 0 is the sentinel for a source with no pagination (plain text, scraped HTML).
+  // Printing "p.0" invites a reviewer to cite a page that does not exist, so it is
+  // omitted — the same rule the evidence list in report-view applies.
+  const page = typeof meta.page === "number" && meta.page > 0 ? meta.page : null;
 
   return (
     <Card className="border-border/80 shadow-sm">
@@ -42,7 +46,8 @@ export function ChunkCard({ chunk, sourceUrls }: ChunkCardProps) {
               {chunk.id}
             </CardTitle>
             <CardDescription className="text-xs">
-              {String(meta.source ?? "?")} · p.{String(meta.page ?? "?")}
+              {String(meta.source ?? "?")}
+              {page ? ` · p.${page}` : ""}
               {meta.category ? ` · ${String(meta.category)}` : ""}
             </CardDescription>
           </div>

--- a/frontend/src/components/regbot/corpus-tab.tsx
+++ b/frontend/src/components/regbot/corpus-tab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { ExternalLink, Loader2 } from "lucide-react";
 
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -86,22 +86,28 @@ export function CorpusTab({ jurisdictions }: CorpusTabProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const load = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const res = await getCorpus(region);
-      setDocs(res.documents);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to load corpus");
-    } finally {
-      setLoading(false);
-    }
-  }, [region]);
-
+  // Every state update follows an await, so the effect body itself starts no render
+  // cascade. `cancelled` drops the response of a region the user has already moved on
+  // from — without it, two quick switches could let the slower reply win.
   useEffect(() => {
-    void load();
-  }, [load]);
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await getCorpus(region);
+        if (cancelled) return;
+        setDocs(res.documents);
+        setError(null);
+      } catch (e) {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : "Failed to load corpus");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [region]);
 
   const byTier = useMemo(() => {
     const groups: Record<string, CorpusDocument[]> = { P0: [], P1: [], P2: [] };
@@ -124,7 +130,16 @@ export function CorpusTab({ jurisdictions }: CorpusTabProps) {
         </div>
         <div className="w-full space-y-2 sm:w-72">
           <Label>Filter by jurisdiction</Label>
-          <Select value={region} onValueChange={(v) => v && setRegion(v)}>
+          <Select
+            value={region}
+            onValueChange={(v) => {
+              if (!v) return;
+              // The spinner is raised here rather than in the effect: an event handler
+              // may update state synchronously, an effect body may not.
+              setLoading(true);
+              setRegion(v);
+            }}
+          >
             <SelectTrigger>
               <SelectValue />
             </SelectTrigger>

--- a/frontend/src/components/regbot/ingest-tab.tsx
+++ b/frontend/src/components/regbot/ingest-tab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { FileUp, Loader2 } from "lucide-react";
 
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -27,19 +27,24 @@ export function IngestTab({ storeDir, jurisdictions, onSuccess }: IngestTabProps
   const [file, setFile] = useState<File | null>(null);
   const [reset, setReset] = useState(false);
   const [category, setCategory] = useState("");
-  const [jurisdiction, setJurisdiction] = useState("GA4GH");
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState<{ type: "ok" | "err"; text: string } | null>(
     null,
   );
 
-  useEffect(() => {
-    if (jurisdictions.some((j) => j.code === "GA4GH")) {
-      setJurisdiction("GA4GH");
-    } else if (jurisdictions[0]) {
-      setJurisdiction(jurisdictions[0].code);
-    }
-  }, [jurisdictions]);
+  // Derived from the prop rather than mirrored into state by an effect. The effect
+  // this replaces re-ran on every new `jurisdictions` array — including the refresh
+  // that follows a successful ingest — and silently reset the user's choice back to
+  // GA4GH. An explicit pick now wins until the user changes it again.
+  const defaultJurisdiction = useMemo(
+    () =>
+      jurisdictions.some((j) => j.code === "GA4GH")
+        ? "GA4GH"
+        : (jurisdictions[0]?.code ?? "GA4GH"),
+    [jurisdictions],
+  );
+  const [picked, setPicked] = useState<string | null>(null);
+  const jurisdiction = picked ?? defaultJurisdiction;
 
   const onIngest = useCallback(async () => {
     if (!file) return;
@@ -108,7 +113,7 @@ export function IngestTab({ storeDir, jurisdictions, onSuccess }: IngestTabProps
 
         <div className="space-y-2">
           <Label>Jurisdiction for this document</Label>
-          <Select value={jurisdiction} onValueChange={(v) => v && setJurisdiction(v)}>
+          <Select value={jurisdiction} onValueChange={(v) => v && setPicked(v)}>
             <SelectTrigger className="w-full">
               <SelectValue />
             </SelectTrigger>

--- a/frontend/src/components/regbot/regbot-app.tsx
+++ b/frontend/src/components/regbot/regbot-app.tsx
@@ -20,6 +20,23 @@ import {
 
 const DEFAULT_STORE = "./data/regbot_store";
 
+/** Pure fetch: reads the API, touches no component state, never throws. */
+async function fetchMeta(dir: string) {
+  try {
+    const [meta, corpus, jur] = await Promise.all([
+      getStoreMeta(dir),
+      getCorpus(),
+      getJurisdictions(),
+    ]);
+    return { ok: true as const, meta, corpus, jur };
+  } catch (e) {
+    return {
+      ok: false as const,
+      error: e instanceof Error ? e.message : "Failed to connect to API",
+    };
+  }
+}
+
 export function RegBotApp() {
   const [storeDir, setStoreDir] = useState(DEFAULT_STORE);
   const [jurisdictions, setJurisdictions] = useState<
@@ -28,7 +45,8 @@ export function RegBotApp() {
   const [storeJurisdictions, setStoreJurisdictions] = useState<string[]>([]);
   const [corpusCount, setCorpusCount] = useState(0);
   const [llmHint, setLlmHint] = useState("");
-  const [refreshing, setRefreshing] = useState(false);
+  // Starts true: the mount effect below is already fetching by first paint.
+  const [refreshing, setRefreshing] = useState(true);
 
   const [lastConsent, setLastConsent] = useState("");
   const [lastJurisdictions, setLastJurisdictions] = useState<string[]>([]);
@@ -37,14 +55,16 @@ export function RegBotApp() {
   const [sourceUrls, setSourceUrls] = useState<Record<string, string>>({});
   const [apiError, setApiError] = useState<string | null>(null);
 
-  const refreshMeta = useCallback(async (dir?: string) => {
-    setRefreshing(true);
-    try {
-      const [meta, corpus, jur] = await Promise.all([
-        getStoreMeta(dir ?? storeDir),
-        getCorpus(),
-        getJurisdictions(),
-      ]);
+  // Fetching and applying are separate so the mount effect can await before it touches
+  // state. `applyMeta` holds every setState; `fetchMeta` holds none.
+  const applyMeta = useCallback(
+    (result: Awaited<ReturnType<typeof fetchMeta>>) => {
+      if (!result.ok) {
+        setApiError(result.error);
+        setRefreshing(false);
+        return;
+      }
+      const { meta, corpus, jur } = result;
       setStoreJurisdictions(meta.jurisdictions);
       setCorpusCount(meta.corpus_document_count);
       setLlmHint(meta.llm_hint);
@@ -57,16 +77,29 @@ export function RegBotApp() {
       }
       setSourceUrls(urls);
       setApiError(null);
-    } catch (e) {
-      setApiError(e instanceof Error ? e.message : "Failed to connect to API");
-    } finally {
       setRefreshing(false);
-    }
-  }, [storeDir]);
+    },
+    [],
+  );
+
+  const refreshMeta = useCallback(
+    async (dir?: string) => {
+      applyMeta(await fetchMeta(dir ?? storeDir));
+    },
+    [storeDir, applyMeta],
+  );
 
   useEffect(() => {
-    void refreshMeta();
-  }, [refreshMeta]);
+    let cancelled = false;
+    void (async () => {
+      const result = await fetchMeta(storeDir);
+      if (cancelled) return;
+      applyMeta(result);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [storeDir, applyMeta]);
 
   const onAnalyzed = useCallback(
     (payload: {
@@ -111,7 +144,10 @@ export function RegBotApp() {
           jurisdictionOptions={jurisdictions}
           corpusCount={corpusCount}
           llmHint={llmHint}
-          onRefresh={() => void refreshMeta(storeDir)}
+          onRefresh={() => {
+            setRefreshing(true);
+            void refreshMeta(storeDir);
+          }}
           refreshing={refreshing}
         />
 
@@ -136,7 +172,10 @@ export function RegBotApp() {
               <IngestTab
                 storeDir={storeDir}
                 jurisdictions={jurisdictions}
-                onSuccess={() => void refreshMeta(storeDir)}
+                onSuccess={() => {
+                  setRefreshing(true);
+                  void refreshMeta(storeDir);
+                }}
               />
             </TabsContent>
             <TabsContent value="corpus">

--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -277,7 +277,11 @@ def _render_chunk_cards(
         meta = ch.get("metadata") or {}
         tags = sorted(chunk_jurisdiction_tags(meta))
         tag_str = ", ".join(tags) if tags else "—"
-        title = f"`{ch.get('id', '')}` · {meta.get('source', '?')} p.{meta.get('page', '?')} · **{tag_str}**"
+        # Page 0 means the source has no pagination; showing "p.0" invites a citation to a
+        # page that does not exist. Same rule as the evidence list above.
+        page = meta.get("page")
+        page_str = f" p.{page}" if isinstance(page, int) and page > 0 else ""
+        title = f"`{ch.get('id', '')}` · {meta.get('source', '?')}{page_str} · **{tag_str}**"
         with st.expander(title):
             doc_id = str(meta.get("document_id") or meta.get("category") or "")
             source_url = urls.get(doc_id)


### PR DESCRIPTION
Phase 4 work: documentation accuracy, setup instructions, and UI polish.

## Docs that had drifted from the code

The Architecture section described the pre-Phase-3 system and contradicted the "What works today" list twenty lines above it — retrieval listed as cosine-in-Chroma with a category filter (it has been exact in-process ranking with jurisdiction/framework scoping since the determinism fix), the UI listed as Streamlit only, and per-recommendation evidence still filed under "roadmap" after shipping in Phase 3.

Counts were a commit behind: README said 22 documents against 23 in the manifest, and `eval_results.md` still reported 868 chunks — the figure from before the last audit pass. The audit table now carries the final **864 / 21** and says which pass produced them.

## Setup instructions

Three things a first run actually needs, none of which were written down:

- **Node 18+** for `frontend/`.
- **`REGBOT_API_URL`** — read by `frontend/next.config.ts` to proxy `/api/*` and `/health`, documented nowhere before this.
- A fresh clone ships `manifest.json` but **not** the Chroma vectors (git-ignored), so the UI retrieves nothing until `ingest-manifest --reset` has run once.

The Python range now matches `pyproject.toml` (3.10–3.13, CI on 3.11).

## Page 0 is not a page

Plain-text and scraped-HTML sources carry `page: 0` as the sentinel for "not paginated" — two thirds of the corpus, including every GDPR brief and all six regional summaries. The evidence list already suppressed it; the chunk cards in **both** UIs printed `p.0` verbatim, so the same document showed a page in one panel and none in the other. For output meant to be quotable in a DPO/IRB review, an invented page reference is worse than a missing one. Verified in the browser: paginated PDFs still show their real page (`ga4gh-consent-policy.pdf · p.1`), text sources show none, zero `p.0` anywhere.

## Known, not addressed here

`npm run lint` reports 4 pre-existing `react-hooks/set-state-in-effect` errors in chat-tab, corpus-tab, ingest-tab and regbot-app. They are data-fetching effects that need real care to restructure, so they are left for a separate change. CI does not currently lint or build `frontend/` at all, which is why they went unnoticed — worth adding once they are fixed.

153 tests pass; ruff clean; `next build` succeeds.