### PR TITLE
Fix UI smoke issues and sync corpus manifest

### DIFF
--- a/data/regbot_store/manifest.json
+++ b/data/regbot_store/manifest.json
@@ -2395,7 +2395,7 @@
     },
     {
       "id": "ga4gh-dacres-policy.pdf_edbf755b2010_p11_c34",
-      "text": "11 \nadvances in basic research and technology; monitor ethical and legal developments, strive \nto ensure that this Policy is fit for purpose; and encourage the creation of fora or other forms \nof communication to advance the practice of responsible data access review. \n \n \n \nAcknowledgements \nThis policy was developed by the Data Access Committee Review Standards (DACReS) work \ngroup of the GA4GH, and is the result of the collaborative work, comments, and input of many \nindividual and organizational contributors.  \n  \n \n \nPolicy Revision History \nPolicy Number/Version Date Effective Summary of Revisions \nPOL 008 / v. 1.0  27 October 2021 Original document \n  \n  \n  \n \n \n[1] This may also be known by the terms “Data Use Certificate” or “Data Transfer Agreement”. \n[2] Adapted from Expert Advisory Group on Data Access, “Governance of Data Access: Annexes” (June \n2015), available at <https://",
+      "text": "11 \nadvances in basic research and technology; monitor ethical and legal developments, strive \nto ensure that this Policy is fit for purpose; and encourage the creation of fora or other forms \nof communication to advance the practice of responsible data access review. \n \n \n \nAcknowledgements \nThis policy was developed by the Data Access Committee Review Standards (DACReS) work \ngroup of the GA4GH, and is the result of the collaborative work, comments, and input of many \nindividual and organizational contributors.  \n  \n \n \nPolicy Revision History \nPolicy Number/Version Date Effective Summary of Revisions \nPOL 008 / v. 1.0  27 October 2021 Original document \n  \n  \n  \n \n \n[1] This may also be known by the terms “Data Use Certificate” or “Data Transfer Agreement”.  \n[2] Adapted from Expert Advisory Group on Data Access, “Governance of Data Access: Annexes” (June \n2015), available at <https:/",
       "metadata": {
         "source": "ga4gh-dacres-policy.pdf",
         "page": 11,
@@ -2408,7 +2408,7 @@
     },
     {
       "id": "ga4gh-dacres-policy.pdf_edbf755b2010_p11_c35",
-      "text": "Transfer Agreement”. \n[2] Adapted from Expert Advisory Group on Data Access, “Governance of Data Access: Annexes” (June \n2015), available at <https://wellcome.org/sites/default/files/governance-of-data-access-annexes-eagda-\njun15.pdf> 8.",
+      "text": "Transfer Agreement”.  \n[2] Adapted from Expert Advisory Group on Data Access, “Governance of Data Access: Annexes” (June \n2015), available at <https://wellcome.org/sites/default/files/governance-of-data-access-annexes-eagda-\njun15.pdf> 8.",
       "metadata": {
         "source": "ga4gh-dacres-policy.pdf",
         "page": 11,
@@ -42556,7 +42556,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p2_c7",
-      "text": "n rare disease research\nObtaining informed consent from research partici-\npants not only respects personal autonomy, self-deter-\nmination, and the right to privacy but also seeks to\nprevent undue harm [ 3–5]. Research participants\nmust be well informed of the research goals, benefits\nand risks, and the possibility to refuse participation\nand withdraw from research at any time without af-\nfecting their medical care. The voluntary expression\nof consent is fundamental to ethical research prac-\ntices. In the rare disease research context, however,\nconsent processes have become complex in the\ncurrent landscape of technological and genomic ad-\nvances, along with the extensive collection, pooling\nand dissemination of data worldwide. Because of the\nscarcity of patients and the need to share information\ninternationally to find similar cases, data sharing and\n‘matchmaking ’ is imperative for rare ",
+      "text": "n rare disease research\nObtaining informed consent from research partici-\npants not only respects personal autonomy, self-deter-\nmination, and the right to privacy but also seeks to\nprevent undue harm [ 3– 5]. Research participants\nmust be well informed of the research goals, benefits\nand risks, and the possibility to refuse participation\nand withdraw from research at any time without af-\nfecting their medical care. The voluntary expression\nof consent is fundamental to ethical research prac-\ntices. In the rare disease research context, however,\nconsent processes have become complex in the\ncurrent landscape of technological and genomic ad-\nvances, along with the extensive collection, pooling\nand dissemination of data worldwide. Because of the\nscarcity of patients and the need to share information\ninternationally to find similar cases, data sharing and\n‘matchmaking ’ is imperative for rare",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 2,
@@ -42569,7 +42569,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p2_c8",
-      "text": "\nscarcity of patients and the need to share information\ninternationally to find similar cases, data sharing and\n‘matchmaking ’ is imperative for rare disease research.\nSince most rare diseases appear in childhood, the re-\ncruitment of children and unaffected family members\nmight further complicate consent processes [ 6]. Par-\nticular phenotypes of rare disease patients also often\nrequire the collection and sharing of audiovisual data\n(e.g., facial images, videos, etc.), the use of machine\nlearning procedures for data phenotyping [ 7], and the\nbridging between clinical care and research [ 8]i nt h i s\nscientific domain.\nNotably, the challenge in establishing consent pol-\nicies for rare disease research stems from the dichot-\nomy between the push for free-flow of data against\nconcerns about loss of privacy. Patients with rare dis-\neases often expect that data are shared for scientific\nadva",
+      "text": "e\nscarcity of patients and the need to share information\ninternationally to find similar cases, data sharing and\n‘matchmaking ’ is imperative for rare disease research.\nSince most rare diseases appear in childhood, the re-\ncruitment of children and unaffected family members\nmight further complicate consent processes [ 6]. Par-\nticular phenotypes of rare disease patients also often\nrequire the collection and sharing of audiovisual data\n(e.g., facial images, videos, etc.), the use of machine\nlearning procedures for data phenotyping [ 7], and the\nbridging between clinical care and research [ 8]i nt h i s\nscientific domain.\nNotably, the challenge in establishing consent pol-\nicies for rare disease research stems from the dichot-\nomy between the push for free-flow of data against\nconcerns about loss of privacy. Patients with rare dis-\neases often expect that data are shared for scientific\nadv",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 2,
@@ -42582,7 +42582,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p2_c9",
-      "text": "push for free-flow of data against\nconcerns about loss of privacy. Patients with rare dis-\neases often expect that data are shared for scientific\nadvances in genomic medicine and rare diseases re-\nsearch. At the same time, patients are concerned\nabout being identified, a risk inherent to data sharing\n[9] and enhanced in the rare disease context. Particu-\nlarly, the likelihood of individual re-identification\nfrom genomic data, whether coded or anonymized,\nhas been documented [ 10, 11], especially when such\ndata has been linked with other sensitive familial,\nsociodemographic or audiovisual information. This is\nwhy international policy approaches to assess privacy\nrisks in genomic research widely adopt as a criterion\nthe “reasonable likelihood test ” (i.e., based on the pro-\nportionate evaluation of real risks and benefits and\nthe balance of probabilities, the possible benefits for\nparticip",
+      "text": " push for free-flow of data against\nconcerns about loss of privacy. Patients with rare dis-\neases often expect that data are shared for scientific\nadvances in genomic medicine and rare diseases re-\nsearch. At the same time, patients are concerned\nabout being identified, a risk inherent to data sharing\n[9] and enhanced in the rare disease context. Particu-\nlarly, the likelihood of individual re-identification\nfrom genomic data, whether coded or anonymized,\nhas been documented [ 10, 11], especially when such\ndata has been linked with other sensitive familial,\nsociodemographic or audiovisual information. This is\nwhy international policy approaches to assess privacy\nrisks in genomic research widely adopt as a criterion\nthe “reasonable likelihood test ” (i.e., based on the pro-\nportionate evaluation of real risks and benefits and\nthe balance of probabilities, the possible benefits for\npartici",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 2,
@@ -42595,7 +42595,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p2_c10",
-      "text": " test ” (i.e., based on the pro-\nportionate evaluation of real risks and benefits and\nthe balance of probabilities, the possible benefits for\nparticipants must surpass p otential consequences for\ntheir privacy) [ 12].\nThe singularity and diversity of rare diseases, com-\nbined with the small number of patients for each dis-\norder, effectively precludes conventional research\ndiscovery approaches, including those directed at ad-\ndressing privacy risks and concerns. Some rare disease\nresearch mandates cross-matching data between differ-\nent centers for discovery and diagnostic purposes. Thus,\nabsolute privacy protection is unrealistic in this realm.\nCoding and security tools serve to mitigate and protect\nagainst privacy risks. However, re-identification is\noften desired by patients for the return of results and\nso precludes anonymization [ 7, 13].\nHence, research involving rare disease parti",
+      "text": "d test ” (i.e., based on the pro-\nportionate evaluation of real risks and benefits and\nthe balance of probabilities, the possible benefits for\nparticipants must surpass p otential consequences for\ntheir privacy) [ 12].\nThe singularity and diversity of rare diseases, com-\nbined with the small number of patients for each dis-\norder, effectively precludes conventional research\ndiscovery approaches, including those directed at ad-\ndressing privacy risks and concerns. Some rare disease\nresearch mandates cross-matching data between differ-\nent centers for discovery and diagnostic purposes. Thus,\nabsolute privacy protection is unrealistic in this realm.\nCoding and security tools serve to mitigate and protect\nagainst privacy risks. However, re-identification is\noften desired by patients for the return of results and\nso precludes anonymization [ 7, 13].\nHence, research involving rare disease part",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 2,
@@ -42608,7 +42608,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p2_c11",
-      "text": "ification is\noften desired by patients for the return of results and\nso precludes anonymization [ 7, 13].\nHence, research involving rare disease participants\nis challenged by unique realities and overall impedi-\nments to genomic research, and thus, should be ac-\nknowledged in ethical and legal deliberations\nregarding research protocols, privacy protections, and\nconsent standards. Rare dis ease participants are often\nwell informed about their disease, highly motivated to\nparticipate in different research studies, and strong\nadvocates for greater access to research. They may\nview identifiability risks as minor when weighed\nagainst the opportunity to gain a diagnosis or to sup-\nport research advancements towards new therapies.\nConsequently, privacy interpretations should be\nbroadened to include not only the right to confidenti-\nality, secrecy and non-interference but also the posi-\ntive rig",
+      "text": "tification is\noften desired by patients for the return of results and\nso precludes anonymization [ 7, 13].\nHence, research involving rare disease participants\nis challenged by unique realities and overall impedi-\nments to genomic research, and thus, should be ac-\nknowledged in ethical and legal deliberations\nregarding research protocols, privacy protections, and\nconsent standards. Rare dis ease participants are often\nwell informed about their disease, highly motivated to\nparticipate in different research studies, and strong\nadvocates for greater access to research. They may\nview identifiability risks as minor when weighed\nagainst the opportunity to gain a diagnosis or to sup-\nport research advancements towards new therapies.\nConsequently, privacy interpretations should be\nbroadened to include not only the right to confidenti-\nality, secrecy and non-interference but also the posi-\ntive ri",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 2,
@@ -42621,7 +42621,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p2_c12",
-      "text": "ivacy interpretations should be\nbroadened to include not only the right to confidenti-\nality, secrecy and non-interference but also the posi-\ntive right to “determine and manage personal\ninformation, and to actively have a say in one ’so w n\nprivate sphere ” [14] and to realize the human right of\neveryone to “share in scientific advancements and its\nbenefits [ 15, 16].” Moreover, privacy protections\nshould go beyond rare disease participants to also\nprotect and further the interests of their family mem-\nbers in familial and trio genomic studies [ 17].\nAs such, the adoption of governance frameworks, se-\ncurity measures, and standards (i.e., data management/\naccess policies, Privacy Preserving Record Linkage [ 18]\nor unique identifying systems) has become the nexus\nfrom which privacy discourse has shifted [ 19]. Adding\nto this is a move towards a nuanced approach to con-\nsent standards tha",
+      "text": "rivacy interpretations should be\nbroadened to include not only the right to confidenti-\nality, secrecy and non-interference but also the posi-\ntive right to “determine and manage personal\ninformation, and to actively have a say in one ’so w n\nprivate sphere ” [14] and to realize the human right of\neveryone to “share in scientific advancements and its\nbenefits [ 15, 16].” Moreover, privacy protections\nshould go beyond rare disease participants to also\nprotect and further the interests of their family mem-\nbers in familial and trio genomic studies [ 17].\nAs such, the adoption of governance frameworks, se-\ncurity measures, and standards (i.e., data management/\naccess policies, Privacy Preserving Record Linkage [ 18]\nor unique identifying systems) has become the nexus\nfrom which privacy discourse has shifted [ 19]. Adding\nto this is a move towards a nuanced approach to con-\nsent standards th",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 2,
@@ -42634,7 +42634,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p2_c13",
-      "text": "s) has become the nexus\nfrom which privacy discourse has shifted [ 19]. Adding\nto this is a move towards a nuanced approach to con-\nsent standards that account for the unique complex-\nities and specificities of rare disease research [ 20]. By\nobtaining proper informed consent, proportionality\nbetween protecting the rights and interests of rare\nNguyen et al. BMC Medical Ethics           (2019) 20:55 Page 2 of 7",
+      "text": "ms) has become the nexus\nfrom which privacy discourse has shifted [ 19]. Adding\nto this is a move towards a nuanced approach to con-\nsent standards that account for the unique complex-\nities and specificities of rare disease research [ 20]. By\nobtaining proper informed consent, proportionality\nbetween protecting the rights and interests of rare\nNguyen et al. BMC Medical Ethics           (2019) 20:55 Page 2 of 7",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 2,
@@ -42673,7 +42673,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p3_c16",
-      "text": "in the 'best case scenario,'\nare there clauses you have used in rare disease\nresearch consent forms that are not usually found or\nshould be found on generic biomedical research\nforms?”\nFive IRDiRC Consortium Assembly members and three\nTask Force members were able to share their consent\nforms and clauses, contributing to a total of 35 consent\nforms and/or notice of consent. Additionally, 5 publica-\ntions from the Clinical Sequencing Evidence-Generating\nResearch (CSER) and Electronic Medical Records and\nGenomics (eMERGE) projects were analyzed [ 23–27].\nThe clauses were classified under different consent\nthemes and were used as references.\nResults\nIn September 2018, the MCC Task Force met at the\nRare Disease Platform in Paris, France, to develop and\ndraft the model consent clauses (Additional file 1). The\nmeeting consisted of background presentations, iterating\nthe role and objectives of I",
+      "text": "in the 'best case scenario,'\nare there clauses you have used in rare disease\nresearch consent forms that are not usually found or\nshould be found on generic biomedical research\nforms?”\nFive IRDiRC Consortium Assembly members and three\nTask Force members were able to share their consent\nforms and clauses, contributing to a total of 35 consent\nforms and/or notice of consent. Additionally, 5 publica-\ntions from the Clinical Sequencing Evidence-Generating\nResearch (CSER) and Electronic Medical Records and\nGenomics (eMERGE) projects were analyzed [ 23– 27].\nThe clauses were classified under different consent\nthemes and were used as references.\nResults\nIn September 2018, the MCC Task Force met at the\nRare Disease Platform in Paris, France, to develop and\ndraft the model consent clauses (Additional file 1). The\nmeeting consisted of background presentations, iterating\nthe role and objectives of ",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 3,
@@ -42686,7 +42686,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p3_c17",
-      "text": "lop and\ndraft the model consent clauses (Additional file 1). The\nmeeting consisted of background presentations, iterating\nthe role and objectives of IRDiRC and GA4GH, as well\nas provision of a historical overview of the evolution of\nTable 1 Emerging Trends in Rare Disease Research with\nConsent Implications\n1. Increased complexity of research methods\n Researchers are increasingly exploring new approaches to identify\nrare genetic variants resulting in increased complexity and diversity of\nresearch methods and protocols;\n Clinical care often involves research in the context of specialty\nclinics providing care for rare disease patients.\nConsent implications:\n Consent forms risk becoming lengthy, technical and complicated;\n The study purpose and potential benefits must be clearly stated to\nmanage participant expectations and provide them with the\nnecessary information to make informed dec",
+      "text": "elop and\ndraft the model consent clauses (Additional file 1). The\nmeeting consisted of background presentations, iterating\nthe role and objectives of IRDiRC and GA4GH, as well\nas provision of a historical overview of the evolution of\nTable 1 Emerging Trends in Rare Disease Research with\nConsent Implications\n1. Increased complexity of research methods\n Researchers are increasingly exploring new approaches to identify\nrare genetic variants resulting in increased complexity and diversity of\nresearch methods and protocols;\n Clinical care often involves research in the context of specialty\nclinics providing care for rare disease patients.\nConsent implications:\n Consent forms risk becoming lengthy, technical and complicated;\n The study purpose and potential benefits must be clearly stated to\nmanage participant expectations and provide them with the\nnecessary information to make informed de",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 3,
@@ -42699,7 +42699,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p3_c18",
-      "text": " and potential benefits must be clearly stated to\nmanage participant expectations and provide them with the\nnecessary information to make informed decisions.\n2. Increased family enrollment as a unit\n Family members can provide important information in identifying\nthe cause of a rare genetic disease (increased diagnostic rate –\nsingleton vs. trio analysis) or help identify de novo mutations in a\nfamily;\n Establishment of family pedigrees to allow linkage of family data.\nConsent implications:\n Although each family member may undergo individual consent\ninterviews, often families are recruited using one consent document\nto address ethical and administrative challenges (i.e., no distinction\nmade between “affected” and “unaffected” family members in\nconsent forms);\n Disclose privacy protections for use and sharing of family data;\n Address possible coercion or undue inducement from family\n",
+      "text": "e and potential benefits must be clearly stated to\nmanage participant expectations and provide them with the\nnecessary information to make informed decisions.\n2. Increased family enrollment as a unit\n Family members can provide important information in identifying\nthe cause of a rare genetic disease (increased diagnostic rate –\nsingleton vs. trio analysis) or help identify de novo mutations in a\nfamily;\n Establishment of family pedigrees to allow linkage of family data.\nConsent implications:\n Although each family member may undergo individual consent\ninterviews, often families are recruited using one consent document\nto address ethical and administrative challenges (i.e., no distinction\nmade between “affected” and “unaffected” family members in\nconsent forms);\n Disclose privacy protections for use and sharing of family data;\n Address possible coercion or undue inducement from family",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 3,
@@ -42712,7 +42712,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p3_c19",
-      "text": "ers in\nconsent forms);\n Disclose privacy protections for use and sharing of family data;\n Address possible coercion or undue inducement from family\nmembers participating in research study;\n Address the return of results to family members;\n Provide the possibility to notify family members of research results\nin case of the participant ’s incapacity or death.\n3. Increased data collection (amount, type & frequency)\n Types of data collected: medical (e.g., clinical test results, diagnoses),\nhealth (e.g., administrative, self-reported data, sociodemographic),\nfamily history, genetic and phenotypic data;\n Data sources: hospitals, private clinics, research, registries, social\nnetwork sites;\n Ongoing data acquisition from medical records.\nConsent implications:\n Disclose information, privacy and identifiability risks to participants\nand their family members.\n4. Increased use of audiovisua",
+      "text": "bers in\nconsent forms);\n Disclose privacy protections for use and sharing of family data;\n Address possible coercion or undue inducement from family\nmembers participating in research study;\n Address the return of results to family members;\n Provide the possibility to notify family members of research results\nin case of the participant ’s incapacity or death.\n3. Increased data collection (amount, type & frequency)\n Types of data collected: medical (e.g., clinical test results, diagnoses),\nhealth (e.g., administrative, self-reported data, sociodemographic),\nfamily history, genetic and phenotypic data;\n Data sources: hospitals, private clinics, research, registries, social\nnetwork sites;\n Ongoing data acquisition from medical records.\nConsent implications:\n Disclose information, privacy and identifiability risks to participants\nand their family members.\n4. Increased use of audiovisu",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 3,
@@ -42725,7 +42725,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p3_c20",
-      "text": "nsent implications:\n Disclose information, privacy and identifiability risks to participants\nand their family members.\n4. Increased use of audiovisual data\n 2–3 dimensional facial imaging used to identify and analyze patterns\nand similarities associated with facial dysmorphology;\n Effective in identifying the underlying cause of rare diseases with\ncomputational phenotyping.\nConsent implications:\n Disclose information, privacy and identifiability risks to participants.\n5. Increased global data sharing and linkage\n Global data sharing, data linkage and international collaboration\nallow achieving sample sizes of statistical significance, richer datasets\nand ability to “match” similar genotypes/phenotypes for gene\ndiscovery in rare diseases;\n Data linkage minimizes the burden on participants to submit new or\nadditional data;\nNguyen et al. BMC Medical Ethics           (2019) 20:55 Page ",
+      "text": "onsent implications:\n Disclose information, privacy and identifiability risks to participants\nand their family members.\n4. Increased use of audiovisual data\n 2– 3 dimensional facial imaging used to identify and analyze patterns\nand similarities associated with facial dysmorphology;\n Effective in identifying the underlying cause of rare diseases with\ncomputational phenotyping.\nConsent implications:\n Disclose information, privacy and identifiability risks to participants.\n5. Increased global data sharing and linkage\n Global data sharing, data linkage and international collaboration\nallow achieving sample sizes of statistical significance, richer datasets\nand ability to “match” similar genotypes/phenotypes for gene\ndiscovery in rare diseases;\n Data linkage minimizes the burden on participants to submit new or\nadditional data;\nNguyen et al. BMC Medical Ethics           (2019) 20:55 Pag",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 3,
@@ -42738,7 +42738,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p3_c21",
-      "text": "s;\n Data linkage minimizes the burden on participants to submit new or\nadditional data;\nNguyen et al. BMC Medical Ethics           (2019) 20:55 Page 3 of 7",
+      "text": "ses;\n Data linkage minimizes the burden on participants to submit new or\nadditional data;\nNguyen et al. BMC Medical Ethics           (2019) 20:55 Page 3 of 7",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 3,
@@ -42751,7 +42751,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p4_c22",
-      "text": "consent forms used in rare disease research over the past\n8–10 years, along with emerging trends (see Table 1).\nThe group identified different research themes that are\nspecific and crucial for rare disease research. Based on a\ncompilation of already existing consent form language,\nthe experts then developed Generic and Rare Disease Spe-\ncific Core Consent Elements (T able2)a n d Model Consent\nClauses for Rare Disease Research (T able3) that take into\naccount international socio-ethical, legal and cultural dif-\nferences as well as keeping the patients ’ perspectives in\nmind.\nThe model consent clauses presented below serve as a\npractical tool to assist in the development of consent\nforms and research protocols. These clauses aim to\nprovide examples of consent categories that are specific\nto rare disease research and therefore do not cover all\nnecessary components of a standard consent form",
+      "text": "consent forms used in rare disease research over the past\n8– 10 years, along with emerging trends (see Table 1).\nThe group identified different research themes that are\nspecific and crucial for rare disease research. Based on a\ncompilation of already existing consent form language,\nthe experts then developed Generic and Rare Disease Spe-\ncific Core Consent Elements (T able2)a n d Model Consent\nClauses for Rare Disease Research (T able3) that take into\naccount international socio-ethical, legal and cultural dif-\nferences as well as keeping the patients ’ perspectives in\nmind.\nThe model consent clauses presented below serve as a\npractical tool to assist in the development of consent\nforms and research protocols. These clauses aim to\nprovide examples of consent categories that are specific\nto rare disease research and therefore do not cover all\nnecessary components of a standard consent for",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 4,
@@ -42764,7 +42764,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p4_c23",
-      "text": "amples of consent categories that are specific\nto rare disease research and therefore do not cover all\nnecessary components of a standard consent form\n(see: T able 2: Generic and Core Consent Elements for\nRare Disease Research ). Local laws, regional policy\nand guidelines may extend or modify these consent\nrequirements and therefore variation can be expected.\nIn addition to the introductory consent clauses regard-\ning the purpose of the research, name of researchers/\nsponsors etc., rare disease consent forms could use\nintroductory clauses to draw attention to some of the\nunique features that distinguish it from the standard\ncore consent elements. These clauses must be custom-\nized to each project ’s specific needs.\nDiscussion\nScientific breakthroughs in research and clinical fields\nhave brought immense opportunities for potential\ndiagnostic tools and therapies to those affected by a\nrare",
+      "text": "xamples of consent categories that are specific\nto rare disease research and therefore do not cover all\nnecessary components of a standard consent form\n(see: T able 2: Generic and Core Consent Elements for\nRare Disease Research ). Local laws, regional policy\nand guidelines may extend or modify these consent\nrequirements and therefore variation can be expected.\nIn addition to the introductory consent clauses regard-\ning the purpose of the research, name of researchers/\nsponsors etc., rare disease consent forms could use\nintroductory clauses to draw attention to some of the\nunique features that distinguish it from the standard\ncore consent elements. These clauses must be custom-\nized to each project ’s specific needs.\nDiscussion\nScientific breakthroughs in research and clinical fields\nhave brought immense opportunities for potential\ndiagnostic tools and therapies to those affected by a\nrar",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 4,
@@ -42777,7 +42777,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p4_c24",
-      "text": "akthroughs in research and clinical fields\nhave brought immense opportunities for potential\ndiagnostic tools and therapies to those affected by a\nrare disease. Since the completion of the Human\nGenome Project [ 28], much progress has been made\nregarding technological advances, the growth of in-\ncreased access to genomic sequencing, and the trans-\nlation of gene-editing techniques into the first in-\nhuman trials [ 29]. These developments have raised\nthe hope for treatments for rare and genetic disorders\npreviously considered incurable. As the prospects of\nthese and other new technologies continue to evolve,\nmany patients expect that researchers share data to\naccelerate the path towards a diagnosis and ultimately\ntowards effective treatments. For many patients, the\nbenefit of research advances may come too late if\nprogress is not accelerated through sharing resources\nand data. Researchers ",
+      "text": "eakthroughs in research and clinical fields\nhave brought immense opportunities for potential\ndiagnostic tools and therapies to those affected by a\nrare disease. Since the completion of the Human\nGenome Project [ 28], much progress has been made\nregarding technological advances, the growth of in-\ncreased access to genomic sequencing, and the trans-\nlation of gene-editing techniques into the first in-\nhuman trials [ 29]. These developments have raised\nthe hope for treatments for rare and genetic disorders\npreviously considered incurable. As the prospects of\nthese and other new technologies continue to evolve,\nmany patients expect that researchers share data to\naccelerate the path towards a diagnosis and ultimately\ntowards effective treatments. For many patients, the\nbenefit of research advances may come too late if\nprogress is not accelerated through sharing resources\nand data. Researchers",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 4,
@@ -42790,7 +42790,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p4_c25",
-      "text": " For many patients, the\nbenefit of research advances may come too late if\nprogress is not accelerated through sharing resources\nand data. Researchers and ethics review boards there-\nfore need to take into account the socio-ethical and\nlegal challenges that these developments will present\nfor recruitment and consent processes. Overly-rigid\nTable 1 Emerging Trends in Rare Disease Research with\nConsent Implications (Continued)\n Large-scale data sharing and linkage increases complexity of data\nmanagement and handling (e.g. access policies, security measures,\ndata coordination, use of unique personal identifiers).\nConsent implications:\n Disclose information, privacy and identifiability risks to participants;\n Inform participants of sharing process and limited right to withdraw\ndata.\nTable 2 Generic and Rare Disease Research Specific Core\nConsent Elements\nGeneric Core Elements:\nGeneral info",
+      "text": ". For many patients, the\nbenefit of research advances may come too late if\nprogress is not accelerated through sharing resources\nand data. Researchers and ethics review boards there-\nfore need to take into account the socio-ethical and\nlegal challenges that these developments will present\nfor recruitment and consent processes. Overly-rigid\nTable 1 Emerging Trends in Rare Disease Research with\nConsent Implications (Continued)\n Large-scale data sharing and linkage increases complexity of data\nmanagement and handling (e.g. access policies, security measures,\ndata coordination, use of unique personal identifiers).\nConsent implications:\n Disclose information, privacy and identifiability risks to participants;\n Inform participants of sharing process and limited right to withdraw\ndata.\nTable 2 Generic and Rare Disease Research Specific Core\nConsent Elements\nGeneric Core Elements:\nGeneral inf",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 4,
@@ -42803,7 +42803,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p4_c26",
-      "text": "ocess and limited right to withdraw\ndata.\nTable 2 Generic and Rare Disease Research Specific Core\nConsent Elements\nGeneric Core Elements:\nGeneral information/Introduction (name of researchers, hospital/\ninstitution, funders/sponsors, etc.)\nNature and objectives of the study\nVoluntariness of participation\nProcedures involved in participation (what will happen during the\nstudy) /types of data and samples that will be collected\nPossibility of large scale genome-wide sequencing techniques\nPotential physical, psychological, social and informational risks\nPotential benefits of participation\nProtections in place [locally] to ensure security/privacy/confidentiality\nDuration/place of data/sample storage\nHosting of data in an open access database\nAccess to data/samples for research purposes (who will have access,\ntypes of access, governance framework, procedures in place – ex.\ndata access committe",
+      "text": "rocess and limited right to withdraw\ndata.\nTable 2 Generic and Rare Disease Research Specific Core\nConsent Elements\nGeneric Core Elements:\nGeneral information/Introduction (name of researchers, hospital/\ninstitution, funders/sponsors, etc.)\nNature and objectives of the study\nVoluntariness of participation\nProcedures involved in participation (what will happen during the\nstudy) /types of data and samples that will be collected\nPossibility of large scale genome-wide sequencing techniques\nPotential physical, psychological, social and informational risks\nPotential benefits of participation\nProtections in place [locally] to ensure security/privacy/confidentiality\nDuration/place of data/sample storage\nHosting of data in an open access database\nAccess to data/samples for research purposes (who will have access,\ntypes of access, governance framework, procedures in place – ex.\ndata access committ",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 4,
@@ -42816,7 +42816,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p4_c27",
-      "text": "ess to data/samples for research purposes (who will have access,\ntypes of access, governance framework, procedures in place – ex.\ndata access committee), including access by pharma/industry, if\napplicable\nAccess to data/samples for purposes of auditing, validation, control,\netc.\nReturn of research results/incidental findings (processes and potential\ninclusion in medical records)\nWithdrawal procedures (sample/data retrieval, destruction, no further\ncontact, no further access, unlink, no further use, etc.)\nCompensation/reimbursement\nProspects for commercialization and intellectual property procedures\nStudy dissemination/publication\nAssent (where applicable)\nRe-contact\nStudy oversight (IRB/REC/REB)\nCore Elements (Rare Disease Research Specific):\nRare Disease Research Introductory Clause\nFamilial Participation\nAudio/Visual Imaging\nCollecting, storing, sharing of rare disease data\nRecontact f",
+      "text": "cess to data/samples for research purposes (who will have access,\ntypes of access, governance framework, procedures in place – ex.\ndata access committee), including access by pharma/industry, if\napplicable\nAccess to data/samples for purposes of auditing, validation, control,\netc.\nReturn of research results/incidental findings (processes and potential\ninclusion in medical records)\nWithdrawal procedures (sample/data retrieval, destruction, no further\ncontact, no further access, unlink, no further use, etc.)\nCompensation/reimbursement\nProspects for commercialization and intellectual property procedures\nStudy dissemination/publication\nAssent (where applicable)\nRe-contact\nStudy oversight (IRB/REC/REB)\nCore Elements (Rare Disease Research Specific):\nRare Disease Research Introductory Clause\nFamilial Participation\nAudio/Visual Imaging\nCollecting, storing, sharing of rare disease data\nRecontact ",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 4,
@@ -42829,7 +42829,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p4_c28",
-      "text": "):\nRare Disease Research Introductory Clause\nFamilial Participation\nAudio/Visual Imaging\nCollecting, storing, sharing of rare disease data\nRecontact for matching\nData Linkage\nReturn of Results to Family Members\nIncapacity/Death\nRisks and Benefits\nNguyen et al. BMC Medical Ethics           (2019) 20:55 Page 4 of 7",
+      "text": "c):\nRare Disease Research Introductory Clause\nFamilial Participation\nAudio/Visual Imaging\nCollecting, storing, sharing of rare disease data\nRecontact for matching\nData Linkage\nReturn of Results to Family Members\nIncapacity/Death\nRisks and Benefits\nNguyen et al. BMC Medical Ethics           (2019) 20:55 Page 4 of 7",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 4,
@@ -42894,7 +42894,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p5_c33",
-      "text": ", develop new tools, and improve diagnostics and therapies.\n5 Recontact for matching Since this study includes matching, if a potential match is found, you will be notified.\n[add opt-in/out option if needed]\n6 Data Linkage In order to improve data completeness and to help interpret your data, we need to link your data from different\nsources (e.g. medical files, administrative health databases, registries, data from family members, etc.).\n7 Return of Results to Family\nMembers\nIt takes a long time to interpret research data accurately. Reports on research progress as well as general results will\nbe made available via […..].\nPlease indicate below if you wish to be notified about individual results specific to you about the rare disease in your\nfamily.\n[add opt-in/out option if needed]\nIf you have indicated that you wish to be notified about individual results, you will be contacted by [ …].",
+      "text": ", develop new tools, and improve diagnostics and therapies.\n5 Recontact for matching Since this study includes matching, if a potential match is found, you will be notified.\n[add opt-in/out option if needed]\n6 Data Linkage In order to improve data completeness and to help interpret your data, we need to link your data from different\nsources (e.g. medical files, administrative health databases, registries, data from family members, etc.).\n7 Return of Results to Family\nMembers\nIt takes a long time to interpret research data accurately. Reports on research progress as well as general results will\nbe made available via [… ..].\nPlease indicate below if you wish to be notified about individual results specific to you about the rare disease in your\nfamily.\n[add opt-in/out option if needed]\nIf you have indicated that you wish to be notified about individual results, you will be contacted by [ … ",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 5,
@@ -42907,7 +42907,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p5_c34",
-      "text": "\nfamily.\n[add opt-in/out option if needed]\nIf you have indicated that you wish to be notified about individual results, you will be contacted by [ …].\n[Insert any time limitations affecting this notification].\nIn addition, [insert local return policy if necessary]\nDue to the limitations of resources, your data may not be re-analyzed in the future.\n8 Incapacity/Death Your data are important for family members and for research on your condition. Therefore, your data will be kept\nand used even if you become incapacitated or die.\nIf you become incapacitated or die, you can name a person to be notified of results that are relevant to the health of\nyour family members.\n[Yes (Insert name of person to be notified) / No]\n9 Benefits You may or may not benefit from participating in this study. In rare disease research, because of the small sample\nsize, the quality of the research and the possible b",
+      "text": "r\nfamily.\n[add opt-in/out option if needed]\nIf you have indicated that you wish to be notified about individual results, you will be contacted by [ … ].\n[Insert any time limitations affecting this notification].\nIn addition, [insert local return policy if necessary]\nDue to the limitations of resources, your data may not be re-analyzed in the future.\n8 Incapacity/Death Your data are important for family members and for research on your condition. Therefore, your data will be kept\nand used even if you become incapacitated or die.\nIf you become incapacitated or die, you can name a person to be notified of results that are relevant to the health of\nyour family members.\n[Yes (Insert name of person to be notified) / No]\n9 Benefits You may or may not benefit from participating in this study. In rare disease research, because of the small sample\nsize, the quality of the research and the possible",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 5,
@@ -42920,7 +42920,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p5_c35",
-      "text": "t benefit from participating in this study. In rare disease research, because of the small sample\nsize, the quality of the research and the possible benefits to you and your family and others with similar conditions\nrequires: involving families; creating large datasets; sharing, linking and matching data; and using audio visual\nimages.\nNguyen et al. BMC Medical Ethics           (2019) 20:55 Page 5 of 7",
+      "text": "not benefit from participating in this study. In rare disease research, because of the small sample\nsize, the quality of the research and the possible benefits to you and your family and others with similar conditions\nrequires: involving families; creating large datasets; sharing, linking and matching data; and using audio visual\nimages.\nNguyen et al. BMC Medical Ethics           (2019) 20:55 Page 5 of 7",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 5,
@@ -42933,7 +42933,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p6_c36",
-      "text": "Additional file\nAdditional file 1: MCC Report of the Model Consent Clauses Task Force\nMeeting (Paris, September 6 –7, 2018). (DOCX 138 kb)\nAbbreviations\nCSER: Clinical Sequencing Evidence-Generating Research; eMERGE: Electronic\nMedical Records and Genomics; GA4GH: Global Alliance for Health and\nGenomics; IRB: Institutional Review Board; IRDiRC: International Rare Diseases\nResearch Consortium; MCC: Model Consent Clauses; REB: Research Ethics\nBoard; REC: Research Ethics Committee\nAcknowledgements\nThe paper is founded on the expert contributions of the Task Force\nmembers attending the workshop and does not necessarily reflect the view\nof employers or any other public institution.\nMembers of the IRDiRC-GA4GH Model Consent Clauses Task Force are: Jack\nGoldblatt (University of Western Australia, Australia), Rosario Isasi (University\nof Miami, USA), Petra Kaufmann (AveXis, USA), Bartha Knoppers",
+      "text": "Additional file\nAdditional file 1: MCC Report of the Model Consent Clauses Task Force\nMeeting (Paris, September 6 – 7, 2018). (DOCX 138 kb)\nAbbreviations\nCSER: Clinical Sequencing Evidence-Generating Research; eMERGE: Electronic\nMedical Records and Genomics; GA4GH: Global Alliance for Health and\nGenomics; IRB: Institutional Review Board; IRDiRC: International Rare Diseases\nResearch Consortium; MCC: Model Consent Clauses; REB: Research Ethics\nBoard; REC: Research Ethics Committee\nAcknowledgements\nThe paper is founded on the expert contributions of the Task Force\nmembers attending the workshop and does not necessarily reflect the view\nof employers or any other public institution.\nMembers of the IRDiRC-GA4GH Model Consent Clauses Task Force are: Jack\nGoldblatt (University of Western Australia, Australia), Rosario Isasi (University\nof Miami, USA), Petra Kaufmann (AveXis, USA), Bartha Knopper",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 6,
@@ -42946,7 +42946,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p6_c37",
-      "text": ": Jack\nGoldblatt (University of Western Australia, Australia), Rosario Isasi (University\nof Miami, USA), Petra Kaufmann (AveXis, USA), Bartha Knoppers (McGill\nUniversity, Canada), Fruzsina Molnar Gabor (Heidelberg Academy of Sciences\nand Humanities, Germany), Minh Thu Nguyen (McGill University, Canada),\nLaetitia Ouillade (Atos/AFM-Téléthon, France), Eric Sid (NCATS/NIH, USA),\nMasha Shabani (Centre for Biomedical Ethics and Law, Belgium), Anne-Marie\nTassé (McGill University, Canada), Durhane Wong-Rieger (CORD, Canada).\nWe would like to thank IRDiRC members for sending in consent forms and\nconsent clauses. In addition, Task Force members have shared consent forms\nthey encountered in their daily work.\nAuthors’ contributions\nThe Task Force – MTN, JG, RI, PK, LO, FMG, MHS, ES, AMT, DWR, BMK-\nprepared and finalized the model consent clauses. MTN, ES, MJ, AHJ and\nBMK drafted the manuscript. JG,",
+      "text": "e: Jack\nGoldblatt (University of Western Australia, Australia), Rosario Isasi (University\nof Miami, USA), Petra Kaufmann (AveXis, USA), Bartha Knoppers (McGill\nUniversity, Canada), Fruzsina Molnar Gabor (Heidelberg Academy of Sciences\nand Humanities, Germany), Minh Thu Nguyen (McGill University, Canada),\nLaetitia Ouillade (Atos/AFM-Téléthon, France), Eric Sid (NCATS/NIH, USA),\nMasha Shabani (Centre for Biomedical Ethics and Law, Belgium), Anne-Marie\nTassé (McGill University, Canada), Durhane Wong-Rieger (CORD, Canada).\nWe would like to thank IRDiRC members for sending in consent forms and\nconsent clauses. In addition, Task Force members have shared consent forms\nthey encountered in their daily work.\nAuthors’ contributions\nThe Task Force – MTN, JG, RI, PK, LO, FMG, MHS, ES, AMT, DWR, BMK-\nprepared and finalized the model consent clauses. MTN, ES, MJ, AHJ and\nBMK drafted the manuscript. JG",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 6,
@@ -42959,7 +42959,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p6_c38",
-      "text": "N, JG, RI, PK, LO, FMG, MHS, ES, AMT, DWR, BMK-\nprepared and finalized the model consent clauses. MTN, ES, MJ, AHJ and\nBMK drafted the manuscript. JG, RI, PK, LO, FMG, MHS, ES, AMT, DWR\nprovided comments and feedback. All authors read and approved the final\nmanuscript.\nFunding\nThe IRDiRC-GA4GH Model Consent Clauses Task Force work was supported\nby the Scientific Secretariat of the IRDiRC, funded since 2012 by a European\nCommission FP7 contract, “SUPPORT-IRDiRC” (No 305207). The European\nCommission, along with the different IRDiRC funding bodies, approved the\nconcept of the Task Force. Consent forms were sent to the European\nCommission as references but the funding bodies had no further role in the\nanalysis, interpretation of data and in writing the manuscript.\nAvailability of data and materials\nNot applicable.\nEthics approval and consent to participate\nNot applicable.\nConsent for publica",
+      "text": "TN, JG, RI, PK, LO, FMG, MHS, ES, AMT, DWR, BMK-\nprepared and finalized the model consent clauses. MTN, ES, MJ, AHJ and\nBMK drafted the manuscript. JG, RI, PK, LO, FMG, MHS, ES, AMT, DWR\nprovided comments and feedback. All authors read and approved the final\nmanuscript.\nFunding\nThe IRDiRC-GA4GH Model Consent Clauses Task Force work was supported\nby the Scientific Secretariat of the IRDiRC, funded since 2012 by a European\nCommission FP7 contract, “SUPPORT-IRDiRC” (No 305207). The European\nCommission, along with the different IRDiRC funding bodies, approved the\nconcept of the Task Force. Consent forms were sent to the European\nCommission as references but the funding bodies had no further role in the\nanalysis, interpretation of data and in writing the manuscript.\nAvailability of data and materials\nNot applicable.\nEthics approval and consent to participate\nNot applicable.\nConsent for public",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 6,
@@ -42972,7 +42972,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p6_c39",
-      "text": "ting the manuscript.\nAvailability of data and materials\nNot applicable.\nEthics approval and consent to participate\nNot applicable.\nConsent for publication\nNot applicable.\nCompeting interests\nThe authors declare that they have no competing interests.\nAuthor details\n1Center of Genomics and Policy, McGill University, Montreal, Quebec H3A\n0G1, Canada. 2University of Western Australia, Perth, Australia. 3Institute for\nBioethics and Health Policy, University of Miami, Miami, USA. 4IRDiRC\nScientific Secretariat, Inserm US-14, Paris, France. 5AveXis, Chicago, USA.\n6AFM-Téléthon, Evry, France. 7Heidelberg Academy of Sciences and\nHumanities, Heidelberg, Germany. 8Centre for Biomedical Ethics and Law,\nBrussels, Belgium. 9National Center for Advancing Translational Sciences,\nNational Institutes of Health, Bethesda, USA. 10Canadian Organization for Rare\nDisorders, Toronto, Canada.\nReceived: 8 January",
+      "text": "iting the manuscript.\nAvailability of data and materials\nNot applicable.\nEthics approval and consent to participate\nNot applicable.\nConsent for publication\nNot applicable.\nCompeting interests\nThe authors declare that they have no competing interests.\nAuthor details\n1Center of Genomics and Policy, McGill University, Montreal, Quebec H3A\n0G1, Canada. 2University of Western Australia, Perth, Australia. 3Institute for\nBioethics and Health Policy, University of Miami, Miami, USA. 4IRDiRC\nScientific Secretariat, Inserm US-14, Paris, France. 5AveXis, Chicago, USA.\n6AFM-Téléthon, Evry, France. 7Heidelberg Academy of Sciences and\nHumanities, Heidelberg, Germany. 8Centre for Biomedical Ethics and Law,\nBrussels, Belgium. 9National Center for Advancing Translational Sciences,\nNational Institutes of Health, Bethesda, USA. 10Canadian Organization for Rare\nDisorders, Toronto, Canada.\nReceived: 8 Januar",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 6,
@@ -42985,7 +42985,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p6_c40",
-      "text": "Translational Sciences,\nNational Institutes of Health, Bethesda, USA. 10Canadian Organization for Rare\nDisorders, Toronto, Canada.\nReceived: 8 January 2019 Accepted: 10 July 2019\nReferences\n1. Dawkins HJS, Draghia-Akli R, Lasko P, Lau LPL, Jonker AH, Cutillo CM, et al.\nProgress in rare diseases research 2010-2016: an IRDiRC perspective. Clin\nTranl Sci. 2018;11(1):11 –20.\n2. Global Alliance for Genomics and Health, “Framework for responsible\nsharing of genomics and health-related data; c2014. Available from: https://\nwww.ga4gh.org/genomic-data-toolkit/regulatory-ethics-toolkit/framework-\nfor-responsible-sharing-of-genomic-and-health-related-data/. [cited 2018\nDec 19]\n3. World Medical Association. World medical association declaration of\nHelsinki: ethical principles for medical research involving human subjects.\nJAMA. 2013;310(20):2191 –4.\n4. World Medical Association. World Medical Associ",
+      "text": " Translational Sciences,\nNational Institutes of Health, Bethesda, USA. 10Canadian Organization for Rare\nDisorders, Toronto, Canada.\nReceived: 8 January 2019 Accepted: 10 July 2019\nReferences\n1. Dawkins HJS, Draghia-Akli R, Lasko P, Lau LPL, Jonker AH, Cutillo CM, et al.\nProgress in rare diseases research 2010-2016: an IRDiRC perspective. Clin\nTranl Sci. 2018;11(1):11 – 20.\n2. Global Alliance for Genomics and Health, “Framework for responsible\nsharing of genomics and health-related data; c2014. Available from: https://\nwww.ga4gh.org/genomic-data-toolkit/regulatory-ethics-toolkit/framework-\nfor-responsible-sharing-of-genomic-and-health-related-data/. [cited 2018\nDec 19]\n3. World Medical Association. World medical association declaration of\nHelsinki: ethical principles for medical research involving human subjects.\nJAMA. 2013;310(20):2191 – 4.\n4. World Medical Association. World Medical Ass",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 6,
@@ -42998,7 +42998,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p6_c41",
-      "text": "inki: ethical principles for medical research involving human subjects.\nJAMA. 2013;310(20):2191 –4.\n4. World Medical Association. World Medical Association Declaration of Taipei\non Ethical Considerations regarding Health Databases and Biobanks.\nAvailable from: https://www.wma.net/policies-post/wma-declaration-of-\ntaipei-on-ethical-considerations-regarding-health-databases-and-biobanks/.\n[cited 2018 Dec 19]\n5. World Medical Association. World Medical Association Statement on\nGenetics and Medicine. Available from: https://www.wma.net/policies-post/\nwma-statement-on-genetics-and-medicine/. [cited 2018 Dec 19]\n6. Rahimzadeh V, Schickhardt C, Knoppers BM, Sénécal K, Vears DF, Fernandez\nCV, et al. Key implications of data sharing in pediatric genomics. JAMA\nPediatr. 2018;172(5):476 –81.\n7. Hallowell N, Parker M, Nellåker C. Big data phenotyping in rare diseases:\nsome ethical issues. Genet Med.",
+      "text": "lsinki: ethical principles for medical research involving human subjects.\nJAMA. 2013;310(20):2191 – 4.\n4. World Medical Association. World Medical Association Declaration of Taipei\non Ethical Considerations regarding Health Databases and Biobanks.\nAvailable from: https://www.wma.net/policies-post/wma-declaration-of-\ntaipei-on-ethical-considerations-regarding-health-databases-and-biobanks/.\n[cited 2018 Dec 19]\n5. World Medical Association. World Medical Association Statement on\nGenetics and Medicine. Available from: https://www.wma.net/policies-post/\nwma-statement-on-genetics-and-medicine/. [cited 2018 Dec 19]\n6. Rahimzadeh V, Schickhardt C, Knoppers BM, Sénécal K, Vears DF, Fernandez\nCV, et al. Key implications of data sharing in pediatric genomics. JAMA\nPediatr. 2018;172(5):476 – 81.\n7. Hallowell N, Parker M, Nellåker C. Big data phenotyping in rare diseases:\nsome ethical issues. Genet ",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 6,
@@ -43011,7 +43011,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p6_c42",
-      "text": "omics. JAMA\nPediatr. 2018;172(5):476 –81.\n7. Hallowell N, Parker M, Nellåker C. Big data phenotyping in rare diseases:\nsome ethical issues. Genet Med. 2019; 21(2):272 –4.\n8. Bertier G, Cambon-Thomsen A, Joly Y. Is it research or is it clinical?\nRevisiting an old frontier through the lens of next-generation sequencing\ntechnologies. Eur J Med Genet. 2018;61(10):634 –41.\n9. Heeney C, Hawkins N, de Vries J, Boddington P, Kaye J. Assessing the\nprivacy risks of data sharing in genomics. Public Health Genomics.\n2011;14(1):17 –25.\n10. Kaye J. The tension between data sharing and the protection of privacy in\ngenomics research. Annu Rev Genomics Hum Genet. 2012;13:415 –31.\n11. Gutmann A. Data re-identification: prioritize privacy. Science. 2013;\n339(6123):1032.\n12. Global Alliance for Genomics and Health: Privacy and Security Policy, 2015.\nAvailable from: https://www.ga4gh.org/wp-content/uploads/P",
+      "text": "genomics. JAMA\nPediatr. 2018;172(5):476 – 81.\n7. Hallowell N, Parker M, Nellåker C. Big data phenotyping in rare diseases:\nsome ethical issues. Genet Med. 2019; 21(2):272 – 4.\n8. Bertier G, Cambon-Thomsen A, Joly Y. Is it research or is it clinical?\nRevisiting an old frontier through the lens of next-generation sequencing\ntechnologies. Eur J Med Genet. 2018;61(10):634 – 41.\n9. Heeney C, Hawkins N, de Vries J, Boddington P, Kaye J. Assessing the\nprivacy risks of data sharing in genomics. Public Health Genomics.\n2011;14(1):17 – 25.\n10. Kaye J. The tension between data sharing and the protection of privacy in\ngenomics research. Annu Rev Genomics Hum Genet. 2012;13:415 – 31.\n11. Gutmann A. Data re-identification: prioritize privacy. Science. 2013;\n339(6123):1032.\n12. Global Alliance for Genomics and Health: Privacy and Security Policy, 2015.\nAvailable from: https://www.ga4gh.org/wp-content/u",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 6,
@@ -43024,7 +43024,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p6_c43",
-      "text": "6123):1032.\n12. Global Alliance for Genomics and Health: Privacy and Security Policy, 2015.\nAvailable from: https://www.ga4gh.org/wp-content/uploads/Privacy-and-\nSecurity-Policy.pdf. [cited 2018 Dec 19].\n13. Hansson MG, Lochmüller H, Riess O, Schaefer F, Orth M, Rubinstein Y, et al.\nThe risk of re-identification versus the need to identify individuals in rare\ndisease research. Eur J Hum Genet. 2016;24(11):1553 –8.\n14. Mascalzoni D, Paradiso A, Hansson M. Rare disease research: breaking the\nprivacy barrier. Appl Transl Genomics. 2014;3(2):23 –9.\n15. UN General Assembly. Universal declaration of human rights. 1948.\nAvailable from: http://www.un.org/en/universal-declaration-human\n-rights/. [cited 2018 Dec 19]\n16. United Nations. International covenant on economic, social and cultural\nrights. 1966. Available from: https://www.ohchr.org/en/professionalinterest/\npages/cescr.aspx. [cited 2018 D",
+      "text": "13;\n339(6123):1032.\n12. Global Alliance for Genomics and Health: Privacy and Security Policy, 2015.\nAvailable from: https://www.ga4gh.org/wp-content/uploads/Privacy-and-\nSecurity-Policy.pdf. [cited 2018 Dec 19].\n13. Hansson MG, Lochmüller H, Riess O, Schaefer F, Orth M, Rubinstein Y, et al.\nThe risk of re-identification versus the need to identify individuals in rare\ndisease research. Eur J Hum Genet. 2016;24(11):1553 – 8.\n14. Mascalzoni D, Paradiso A, Hansson M. Rare disease research: breaking the\nprivacy barrier. Appl Transl Genomics. 2014;3(2):23 – 9.\n15. UN General Assembly. Universal declaration of human rights. 1948.\nAvailable from: http://www.un.org/en/universal-declaration-human\n-rights/. [cited 2018 Dec 19]\n16. United Nations. International covenant on economic, social and cultural\nrights. 1966. Available from: https://www.ohchr.org/en/professionalinterest/\npages/cescr.aspx. [ci",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 6,
@@ -43037,7 +43037,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p6_c44",
-      "text": "covenant on economic, social and cultural\nrights. 1966. Available from: https://www.ohchr.org/en/professionalinterest/\npages/cescr.aspx. [cited 2018 Dec 19]\n17. Takashima K, Maru Y, Mori S, Mano H, Noda T, Muto K. Ethical concerns on\nsharing genomic data including patients ’ family members. BMC Med Ethics.\n2018;19:61.\n18. Baker D, Knoppers BM, Phillips M, van ED, Kaufmann P, Lochmuller H, et al.\nPrivacy-preserving linkage of genomic and clinical data sets. IEEE/ACM Trans\nComput Biol Bioinform. 2018:1 –1. https://doi.org/10.1109/TCBB.2018.2\n855125.\n19. Knoppers BM, Chadwick R. The ethics weathervane. BMC Med Ethics. 2015;16:58.\n20. Gainotti S, Turner C, Woods S, Kole A, McCormack P, Lochmüller H, et al.\nImproving the informed consent process in international collaborative rare\ndisease research: effective consent for effective research. Eur J Hum Genet.\n2016;24(9):1248–54.\n21. McCormack P,",
+      "text": "rnational covenant on economic, social and cultural\nrights. 1966. Available from: https://www.ohchr.org/en/professionalinterest/\npages/cescr.aspx. [cited 2018 Dec 19]\n17. Takashima K, Maru Y, Mori S, Mano H, Noda T, Muto K. Ethical concerns on\nsharing genomic data including patients ’ family members. BMC Med Ethics.\n2018;19:61.\n18. Baker D, Knoppers BM, Phillips M, van ED, Kaufmann P, Lochmuller H, et al.\nPrivacy-preserving linkage of genomic and clinical data sets. IEEE/ACM Trans\nComput Biol Bioinform. 2018:1 – 1. https://doi.org/10.1109/TCBB.2018.2\n855125.\n19. Knoppers BM, Chadwick R. The ethics weathervane. BMC Med Ethics. 2015;16:58.\n20. Gainotti S, Turner C, Woods S, Kole A, McCormack P, Lochmüller H, et al.\nImproving the informed consent process in international collaborative rare\ndisease research: effective consent for effective research. Eur J Hum Genet.\n2016;24(9):1248– 54.\n21. ",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 6,
@@ -43050,7 +43050,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p6_c45",
-      "text": " in international collaborative rare\ndisease research: effective consent for effective research. Eur J Hum Genet.\n2016;24(9):1248–54.\n21. McCormack P, Kole A, Gainotti S, Mascalzoni D, Molster C, Lochmüller H, et\nal. ‘You should at least ask ’. The expectations, hopes and fears of rare\ndisease patients on large-scale data and biomaterial sharing for genomics\nresearch. Eur J Hum Genet. 2016;24(10):1403 –8.\n22. Darquy S, Moutel G, Lapointe A-S, D ’Audiffret D, Champagnat J, Guerroui S,\net al. Patient/family views on data sharing in rare diseases: study in the\nEuropean LeukoTreat project. Eur J Hum Genet. 2016;24(3):338 –43.\nNguyen et al. BMC Medical Ethics           (2019) 20:55 Page 6 of 7",
+      "text": "ent process in international collaborative rare\ndisease research: effective consent for effective research. Eur J Hum Genet.\n2016;24(9):1248– 54.\n21. McCormack P, Kole A, Gainotti S, Mascalzoni D, Molster C, Lochmüller H, et\nal. ‘You should at least ask ’. The expectations, hopes and fears of rare\ndisease patients on large-scale data and biomaterial sharing for genomics\nresearch. Eur J Hum Genet. 2016;24(10):1403 – 8.\n22. Darquy S, Moutel G, Lapointe A-S, D ’Audiffret D, Champagnat J, Guerroui S,\net al. Patient/family views on data sharing in rare diseases: study in the\nEuropean LeukoTreat project. Eur J Hum Genet. 2016;24(3):338 – 43.\nNguyen et al. BMC Medical Ethics           (2019) 20:55 Page 6 of 7",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 6,
@@ -43063,7 +43063,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p7_c46",
-      "text": "23. Henderson GE, Wolf SM, Kuczynski KJ, Joffe S, Sharp RR, Parsons DW, et al.\nThe challenge of informed consent and return of results in translational\ngenomics: empirical analysis and recommendations. J Law Med Ethics J Am\nSoc Law Med Ethics. 2014;42(3):344 –55.\n24. Tomlinson AN, Skinner D, Perry DL , Scollon SR, Roche MI, Bernhardt\nBA. “Not tied up neatly with a bow ”: professionals ’ challenging cases\nin informed consent for genomic sequencing. J Genet Couns. 2016;\n25(1):62 –72.\n25. Bernhardt BA, Roche MI, Perry DL, Scollon SR, Tomlinson AN, Skinner D.\nExperiences with obtaining informed consent for genomic sequencing. Am\nJ Med Genet A. 2015;167A(11):2635 –46.\n26. Brothers KB, Lynch JA, Aufox SA, Connolly JJ, Gelb BD, Holm IA, et al.\nPractical guidance on informed consent for pediatric participants in a\nbiorepository. Mayo Clin Proc. 2014;89(11):1471 –80.\n27. Trinidad SB, Fullerton SM",
+      "text": "23. Henderson GE, Wolf SM, Kuczynski KJ, Joffe S, Sharp RR, Parsons DW, et al.\nThe challenge of informed consent and return of results in translational\ngenomics: empirical analysis and recommendations. J Law Med Ethics J Am\nSoc Law Med Ethics. 2014;42(3):344 – 55.\n24. Tomlinson AN, Skinner D, Perry DL , Scollon SR, Roche MI, Bernhardt\nBA. “Not tied up neatly with a bow ”: professionals ’ challenging cases\nin informed consent for genomic sequencing. J Genet Couns. 2016;\n25(1):62 – 72.\n25. Bernhardt BA, Roche MI, Perry DL, Scollon SR, Tomlinson AN, Skinner D.\nExperiences with obtaining informed consent for genomic sequencing. Am\nJ Med Genet A. 2015;167A(11):2635 – 46.\n26. Brothers KB, Lynch JA, Aufox SA, Connolly JJ, Gelb BD, Holm IA, et al.\nPractical guidance on informed consent for pediatric participants in a\nbiorepository. Mayo Clin Proc. 2014;89(11):1471 – 80.\n27. Trinidad SB, Fullerto",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 7,
@@ -43076,7 +43076,7 @@
     },
     {
       "id": "ga4gh-consent-clauses-rare-disease.pdf_a2833e44077d_p7_c47",
-      "text": "ctical guidance on informed consent for pediatric participants in a\nbiorepository. Mayo Clin Proc. 2014;89(11):1471 –80.\n27. Trinidad SB, Fullerton SM, Bares JM, Jarvik GP, Larson EB, Burke W. Informed\nconsent in genome-scale research: what do prospective participants think?\nAJOB Prim Res. 2012;3(3):3 –11.\n28. Collins FS, Green ED, Guttmacher AE, Guyer MS. US National Human\nGenome Research Institute. A vision for the future of genomics research.\nNature. 2003;422(6934):835 –47.\n29. Cyranoski D. CRISPR gene-editing tested in a person for the first time.\nNature. 2016;539(7630):479.\nPublisher’sN o t e\nSpringer Nature remains neutral with regard to jurisdictional claims in\npublished maps and institutional affiliations.\nNguyen et al. BMC Medical Ethics           (2019) 20:55 Page 7 of 7",
+      "text": "Practical guidance on informed consent for pediatric participants in a\nbiorepository. Mayo Clin Proc. 2014;89(11):1471 – 80.\n27. Trinidad SB, Fullerton SM, Bares JM, Jarvik GP, Larson EB, Burke W. Informed\nconsent in genome-scale research: what do prospective participants think?\nAJOB Prim Res. 2012;3(3):3 – 11.\n28. Collins FS, Green ED, Guttmacher AE, Guyer MS. US National Human\nGenome Research Institute. A vision for the future of genomics research.\nNature. 2003;422(6934):835 – 47.\n29. Cyranoski D. CRISPR gene-editing tested in a person for the first time.\nNature. 2016;539(7630):479.\nPublisher’sN o t e\nSpringer Nature remains neutral with regard to jurisdictional claims in\npublished maps and institutional affiliations.\nNguyen et al. BMC Medical Ethics           (2019) 20:55 Page 7 of 7",
       "metadata": {
         "source": "ga4gh-consent-clauses-rare-disease.pdf",
         "page": 7,
@@ -54384,7 +54384,7 @@
     },
     {
       "id": "who-human-genome-data-guidance-2024.pdf_872a85804c35_p4_c3",
-      "text": " then you must license your work under the same or equivalent Creative Commons licence. If you create a \ntranslation of this work, you should add the following disclaimer along with the suggested citation: “This translation \nwas not created by the World Health Organization (WHO). WHO is not responsible for the content or accuracy of this \ntranslation. The original English edition shall be the binding and authentic edition” . \nAny mediation relating to disputes arising under the licence shall be conducted in accordance with the mediation rules \nof the World Intellectual Property Organization (http:/ /www.wipo.int/amc/en/mediation/rules/).\nSuggested citation. Guidance for human genome data collection, access, use and sharing. Geneva: World Health \nOrganization; 2024. Licence: CC BY-NC-SA 3.0 IGO .\nCataloguing-in-Publication (CIP) data. CIP data are available at https:/ /iris.who.int/.\nSale",
+      "text": " then you must license your work under the same or equivalent Creative Commons licence. If you create a \ntranslation of this work, you should add the following disclaimer along with the suggested citation: “This translation \nwas not created by the World Health Organization (WHO). WHO is not responsible for the content or accuracy of this \ntranslation. The original English edition shall be the binding and authentic edition” . \nAny mediation relating to disputes arising under the licence shall be conducted in accordance with the mediation rules \nof the World Intellectual Property Organization (http:/ /www.wipo.int/amc/en/mediation/rules/).\nSuggested citation. Guidance for human genome data collection, access, use and sharing. Geneva: World Health \nOrganization; 2024. Licence: CC BY-NC-SA 3.0 IGO.\nCataloguing-in-Publication (CIP) data. CIP data are available at https:/ /iris.who.int/.\nSales",
       "metadata": {
         "source": "who-human-genome-data-guidance-2024.pdf",
         "page": 4,
@@ -54397,7 +54397,7 @@
     },
     {
       "id": "who-human-genome-data-guidance-2024.pdf_872a85804c35_p4_c4",
-      "text": "alth \nOrganization; 2024. Licence: CC BY-NC-SA 3.0 IGO .\nCataloguing-in-Publication (CIP) data. CIP data are available at https:/ /iris.who.int/.\nSales, rights and licensing. To purchase WHO publications, see https:/ /www.who.int/publications/book-orders. To \nsubmit requests for commercial use and queries on rights and licensing, see https:/ /www.who.int/copyright. \nThird-party materials. If you wish to reuse material from this work that is attributed to a third party, such as tables, \nfigures or images, it is your responsibility to determine whether permission is needed for that reuse and to obtain \npermission from the copyright holder. The risk of claims resulting from infringement of any third-party-owned \ncomponent in the work rests solely with the user.\nGeneral disclaimers. The designations employed and the presentation of the material in this publication do not imply \nthe expressio",
+      "text": "alth \nOrganization; 2024. Licence: CC BY-NC-SA 3.0 IGO.\nCataloguing-in-Publication (CIP) data. CIP data are available at https:/ /iris.who.int/.\nSales, rights and licensing. To purchase WHO publications, see https:/ /www.who.int/publications/book-orders. To \nsubmit requests for commercial use and queries on rights and licensing, see https:/ /www.who.int/copyright. \nThird-party materials. If you wish to reuse material from this work that is attributed to a third party, such as tables, \nfigures or images, it is your responsibility to determine whether permission is needed for that reuse and to obtain \npermission from the copyright holder. The risk of claims resulting from infringement of any third-party-owned \ncomponent in the work rests solely with the user.\nGeneral disclaimers. The designations employed and the presentation of the material in this publication do not imply \nthe expression",
       "metadata": {
         "source": "who-human-genome-data-guidance-2024.pdf",
         "page": 4,
@@ -54410,7 +54410,7 @@
     },
     {
       "id": "who-human-genome-data-guidance-2024.pdf_872a85804c35_p4_c5",
-      "text": "ely with the user.\nGeneral disclaimers. The designations employed and the presentation of the material in this publication do not imply \nthe expression of any opinion whatsoever on the part of WHO concerning the legal status of any country, territory, city \nor area or of its authorities, or concerning the delimitation of its frontiers or boundaries. Dotted and dashed lines on \nmaps represent approximate border lines for which there may not yet be full agreement.\nThe mention of specific companies or of certain manufacturers’ products does not imply that they are endorsed \nor recommended by WHO in preference to others of a similar nature that are not mentioned. Errors and omissions \nexcepted, the names of proprietary products are distinguished by initial capital letters.\nAll reasonable precautions have been taken by WHO to verify the information contained in this publication. However, \nthe",
+      "text": "ly with the user.\nGeneral disclaimers. The designations employed and the presentation of the material in this publication do not imply \nthe expression of any opinion whatsoever on the part of WHO concerning the legal status of any country, territory, city \nor area or of its authorities, or concerning the delimitation of its frontiers or boundaries. Dotted and dashed lines on \nmaps represent approximate border lines for which there may not yet be full agreement.\nThe mention of specific companies or of certain manufacturers’ products does not imply that they are endorsed \nor recommended by WHO in preference to others of a similar nature that are not mentioned. Errors and omissions \nexcepted, the names of proprietary products are distinguished by initial capital letters.\nAll reasonable precautions have been taken by WHO to verify the information contained in this publication. However, \nthe ",
       "metadata": {
         "source": "who-human-genome-data-guidance-2024.pdf",
         "page": 4,
@@ -54423,7 +54423,7 @@
     },
     {
       "id": "who-human-genome-data-guidance-2024.pdf_872a85804c35_p4_c6",
-      "text": "d by initial capital letters.\nAll reasonable precautions have been taken by WHO to verify the information contained in this publication. However, \nthe published material is being distributed without warranty of any kind, either expressed or implied. The responsibility \nfor the interpretation and use of the material lies with the reader. In no event shall WHO be liable for damages arising \nfrom its use.",
+      "text": " by initial capital letters.\nAll reasonable precautions have been taken by WHO to verify the information contained in this publication. However, \nthe published material is being distributed without warranty of any kind, either expressed or implied. The responsibility \nfor the interpretation and use of the material lies with the reader. In no event shall WHO be liable for damages arising \nfrom its use.",
       "metadata": {
         "source": "who-human-genome-data-guidance-2024.pdf",
         "page": 4,
@@ -55268,7 +55268,7 @@
     },
     {
       "id": "who-human-genome-editing-governance-2021.pdf_52c867142dfb_p4_c4",
-      "text": " Organization ( http://www.wipo.int/amc/en/mediation/rules/ ).\nSuggested citation . WHO Expert Advisory Committee on Developing Global Standards for Governance and Oversight of Human Genome \nEditing. Human genome editing: a framework for governance. Geneva: World Health Organization; 2021. Licence: CC BY-NC-SA 3.0 IGO.\nCataloguing-in-Publication (CIP) data . CIP data are available at http://apps.who.int/iris .\nSales, rights and licensing. To purchase WHO publications, see http://apps.who.int/bookorders . To submit requests for commercial use \nand queries on rights and licensing, see http://www.who.int/about/licensing . \nThird-party materials.  If you wish to reuse material from this work that is attributed to a third party, such as tables, figures or images, it is \nyour responsibility to determine whether permission is needed for that reuse and to obtain permission from the copyright hol",
+      "text": " Organization ( http://www.wipo.int/amc/en/mediation/rules/ ).\nSuggested citation . WHO Expert Advisory Committee on Developing Global Standards for Governance and Oversight of Human Genome \nEditing. Human genome editing: a framework for governance. Geneva: World Health Organization; 2021. Licence: CC BY-NC-SA 3.0 IGO .\nCataloguing-in-Publication (CIP) data . CIP data are available at http://apps.who.int/iris .\nSales, rights and licensing. To purchase WHO publications, see http://apps.who.int/bookorders . To submit requests for commercial use \nand queries on rights and licensing, see http://www.who.int/about/licensing . \nThird-party materials.  If you wish to reuse material from this work that is attributed to a third party, such as tables, figures or images, it is \nyour responsibility to determine whether permission is needed for that reuse and to obtain permission from the copyright ho",
       "metadata": {
         "source": "who-human-genome-editing-governance-2021.pdf",
         "page": 4,
@@ -55281,7 +55281,7 @@
     },
     {
       "id": "who-human-genome-editing-governance-2021.pdf_52c867142dfb_p4_c5",
-      "text": "figures or images, it is \nyour responsibility to determine whether permission is needed for that reuse and to obtain permission from the copyright holder. The risk \nof claims resulting from infringement of any third-party-owned component in the work rests solely with the user.\nGeneral disclaimers.  The designations employed and the presentation of the material in this publication do not imply the expression \nof any opinion whatsoever on the part of WHO concerning the legal status of any country, territory, city or area or of its authorities, or \nconcerning the delimitation of its frontiers or boundaries. Dotted and dashed lines on maps represent approximate border lines for which \nthere may not yet be full agreement.\nThe mention of specific companies or of certain manufacturers’ products does not imply that they are endorsed or recommended by WHO \nin preference to others of a similar nat",
+      "text": " figures or images, it is \nyour responsibility to determine whether permission is needed for that reuse and to obtain permission from the copyright holder. The risk \nof claims resulting from infringement of any third-party-owned component in the work rests solely with the user.\nGeneral disclaimers.  The designations employed and the presentation of the material in this publication do not imply the expression \nof any opinion whatsoever on the part of WHO concerning the legal status of any country, territory, city or area or of its authorities, or \nconcerning the delimitation of its frontiers or boundaries. Dotted and dashed lines on maps represent approximate border lines for which \nthere may not yet be full agreement.\nThe mention of specific companies or of certain manufacturers’ products does not imply that they are endorsed or recommended by WHO \nin preference to others of a similar na",
       "metadata": {
         "source": "who-human-genome-editing-governance-2021.pdf",
         "page": 4,
@@ -55294,7 +55294,7 @@
     },
     {
       "id": "who-human-genome-editing-governance-2021.pdf_52c867142dfb_p4_c6",
-      "text": " companies or of certain manufacturers’ products does not imply that they are endorsed or recommended by WHO \nin preference to others of a similar nature that are not mentioned. Errors and omissions excepted, the names of proprietary products are \ndistinguished by initial capital letters.\nAll reasonable precautions have been taken by WHO to verify the information contained in this publication. However, the published \nmaterial is being distributed without warranty of any kind, either expressed or implied. The responsibility for the interpretation and use of \nthe material lies with the reader. In no event shall WHO be liable for damages arising from its use. \nThis publication contains the collective views of the WHO Expert Advisory Committee on Developing Global Standards for Governance and \nOversight of Human Genome Editing and does not necessarily represent the decisions or the policies ",
+      "text": "c companies or of certain manufacturers’ products does not imply that they are endorsed or recommended by WHO \nin preference to others of a similar nature that are not mentioned. Errors and omissions excepted, the names of proprietary products are \ndistinguished by initial capital letters.\nAll reasonable precautions have been taken by WHO to verify the information contained in this publication. However, the published \nmaterial is being distributed without warranty of any kind, either expressed or implied. The responsibility for the interpretation and use of \nthe material lies with the reader. In no event shall WHO be liable for damages arising from its use. \nThis publication contains the collective views of the WHO Expert Advisory Committee on Developing Global Standards for Governance and \nOversight of Human Genome Editing and does not necessarily represent the decisions or the policies",
       "metadata": {
         "source": "who-human-genome-editing-governance-2021.pdf",
         "page": 4,
@@ -55307,7 +55307,7 @@
     },
     {
       "id": "who-human-genome-editing-governance-2021.pdf_52c867142dfb_p4_c7",
-      "text": "on Developing Global Standards for Governance and \nOversight of Human Genome Editing and does not necessarily represent the decisions or the policies of WHO.\nCover art provided by Joe Brock, the Francis Crick Institute\nGraphic design and layout by Trans.Lieu Company Ltd",
+      "text": " on Developing Global Standards for Governance and \nOversight of Human Genome Editing and does not necessarily represent the decisions or the policies of WHO.\nCover art provided by Joe Brock, the Francis Crick Institute\nGraphic design and layout by Trans.Lieu Company Ltd",
       "metadata": {
         "source": "who-human-genome-editing-governance-2021.pdf",
         "page": 4,
@@ -64575,7 +64575,7 @@
     },
     {
       "id": "pcpd-cross-border-transfer-guidance.pdf_afea71e08de1_p8_c37",
-      "text": "s, an adherence agreement could be \nadopted so that such entities will adopt the \nterms of the agreement.\nPlease refer to the schedule to this Guidance \nfor the Recommended Model Clauses and the \naccompanying explanatory notes.\nPART 4: PRACTICAL TIPS AND  \nRECOMMENDED GOOD  \nPRACTICES\nSome key steps for data users to comply with \nsection 33 are recommended below.\nt\u0001 3FWJFX\u0001EBUB\u0001USBOTGFS\u0001BSSBOHFNFOU\nData users should review their existing \ndata transfer arrangement to identify any \ncross-border transfer of personal data. \nSituations which may involve cross-\nborder transfer of personal data include \nadoption of an offshore database system, \noutsourcing of data processing and/\nor storage functions and intra-group \n(members located outside Hong Kong) \nsharing of data. There are many other \ninstances where transfer of personal data \noutside Hong Kong is involved. Data users \nshould assess whe",
+      "text": "s, an adherence agreement could be \nadopted so that such entities will adopt the \nterms of the agreement.\nPlease refer to the schedule to this Guidance \nfor the Recommended Model Clauses and the \naccompanying explanatory notes.\nPART 4: PRACTICAL TIPS AND  \nRECOMMENDED GOOD  \nPRACTICES\nSome key steps for data users to comply with \nsection 33 are recommended below.\nt\u0001 3FWJFX\u0001 EBUB\u0001 USBOTGFS\u0001 BSSBOHFNFOU\nData users should review their existing \ndata transfer arrangement to identify any \ncross-border transfer of personal data. \nSituations which may involve cross-\nborder transfer of personal data include \nadoption of an offshore database system, \noutsourcing of data processing and/\nor storage functions and intra-group \n(members located outside Hong Kong) \nsharing of data. There are many other \ninstances where transfer of personal data \noutside Hong Kong is involved. Data users \nshould assess ",
       "metadata": {
         "source": "pcpd-cross-border-transfer-guidance.pdf",
         "page": 8,
@@ -64588,7 +64588,7 @@
     },
     {
       "id": "pcpd-cross-border-transfer-guidance.pdf_afea71e08de1_p8_c38",
-      "text": " Kong) \nsharing of data. There are many other \ninstances where transfer of personal data \noutside Hong Kong is involved. Data users \nshould assess whether such activities are \nreally necessary.\nt\u0001 $POUSPM\u0001DSPTT\u000eCPSEFS\u0001EBUB\u0001GMPX\u0001BDUJWJUJFT\nData users should control activities that \ninvolve unintended or unnecessary cross-\nborder data flow to avoid non-compliance \nwith section 33. It is not uncommon for \ndata users to exercise control through \nconfiguring their information technology \nsystem. One way is for international \ndata users to structure the information \ntechnology system so that certain types \nof the data cannot be accessed or \ndownloaded by their employees working \nin offices outside Hong Kong unless one \nof the exceptions under section 33(2) of \nthe Ordinance has been complied with.\nt \u0001 $IFDL\u0001UIF\u00018IJUF\u0001-JTU\u0001BOE\u0001PUIFS\u0001\nexceptions\nAfter identifying activities that require \ncross-b",
+      "text": "ong Kong) \nsharing of data. There are many other \ninstances where transfer of personal data \noutside Hong Kong is involved. Data users \nshould assess whether such activities are \nreally necessary.\nt\u0001 $POUSPM\u0001 DSPTT\u000eCPSEFS\u0001 EBUB\u0001 GMPX\u0001 BDUJWJUJFT\nData users should control activities that \ninvolve unintended or unnecessary cross-\nborder data flow to avoid non-compliance \nwith section 33. It is not uncommon for \ndata users to exercise control through \nconfiguring their information technology \nsystem. One way is for international \ndata users to structure the information \ntechnology system so that certain types \nof the data cannot be accessed or \ndownloaded by their employees working \nin offices outside Hong Kong unless one \nof the exceptions under section 33(2) of \nthe Ordinance has been complied with.\nt \u0001 $IFDL \u0001 UIF \u0001 8IJUF \u0001 -JTU \u0001 BOE \u0001 PUIFS \u0001\nexceptions\nAfter identifying activities tha",
       "metadata": {
         "source": "pcpd-cross-border-transfer-guidance.pdf",
         "page": 8,
@@ -64601,7 +64601,7 @@
     },
     {
       "id": "pcpd-cross-border-transfer-guidance.pdf_afea71e08de1_p8_c39",
-      "text": "tion 33(2) of \nthe Ordinance has been complied with.\nt \u0001 $IFDL\u0001UIF\u00018IJUF\u0001-JTU\u0001BOE\u0001PUIFS\u0001\nexceptions\nAfter identifying activities that require \ncross-border transfer of personal data, data \nusers should then consider if any of the \nexceptions under section 33(2) applies. \nThe first step will be to check the White \nList published by the Commissioner 7. If \n7 See page 4 above for further explanation.",
+      "text": "der section 33(2) of \nthe Ordinance has been complied with.\nt \u0001 $IFDL \u0001 UIF \u0001 8IJUF \u0001 -JTU \u0001 BOE \u0001 PUIFS \u0001\nexceptions\nAfter identifying activities that require \ncross-border transfer of personal data, data \nusers should then consider if any of the \nexceptions under section 33(2) applies. \nThe first step will be to check the White \nList published by the Commissioner 7. If \n7 See page 4 above for further explanation.",
       "metadata": {
         "source": "pcpd-cross-border-transfer-guidance.pdf",
         "page": 8,
@@ -64627,7 +64627,7 @@
     },
     {
       "id": "pcpd-cross-border-transfer-guidance.pdf_afea71e08de1_p9_c41",
-      "text": "e has in force any law \nwhich is substantially similar to, or serves \nthe same purposes as, the Ordinance \n(except the White List published by the \nCommissioner). The Commissioner also \ndoes not offer case-specific legal advice as \nto how a valid contract should be signed \nbetween the parties. It is up to the data \nuser to meet one of the exceptions under \nsection 33(2) of the Ordinance.\nt\u0001 ,FFQ\u0001JOWFOUPSZ\u0001PG\u0001QFSTPOBM\u0001EBUB\nAnother important aspect is for data users \nto keep an inventory of the personal data \nbeing transferred outside Hong Kong. Data \nusers must always bear in mind that they \nremain responsible and accountable to the \ndata subjects for possible contraventions \nof the requirements under the Ordinance. \nIt is in their interests to monitor the data \nhandling process of the transferees, to \nkeep abreast of the whereabouts of the \npersonal data and to assess the associated \npri",
+      "text": "e has in force any law \nwhich is substantially similar to, or serves \nthe same purposes as, the Ordinance \n(except the White List published by the \nCommissioner). The Commissioner also \ndoes not offer case-specific legal advice as \nto how a valid contract should be signed \nbetween the parties. It is up to the data \nuser to meet one of the exceptions under \nsection 33(2) of the Ordinance.\nt\u0001 ,FFQ\u0001 JOWFOUPSZ\u0001 PG\u0001 QFSTPOBM\u0001 EBUB\nAnother important aspect is for data users \nto keep an inventory of the personal data \nbeing transferred outside Hong Kong. Data \nusers must always bear in mind that they \nremain responsible and accountable to the \ndata subjects for possible contraventions \nof the requirements under the Ordinance. \nIt is in their interests to monitor the data \nhandling process of the transferees, to \nkeep abreast of the whereabouts of the \npersonal data and to assess the associated ",
       "metadata": {
         "source": "pcpd-cross-border-transfer-guidance.pdf",
         "page": 9,
@@ -64640,7 +64640,7 @@
     },
     {
       "id": "pcpd-cross-border-transfer-guidance.pdf_afea71e08de1_p9_c42",
-      "text": " to monitor the data \nhandling process of the transferees, to \nkeep abreast of the whereabouts of the \npersonal data and to assess the associated \nprivacy risks. Also, data users should be \ntransparent about their data handling \npolicies and practices regarding any \ntransfer of personal data outside Hong \nKong.\nt\u0001 $POEVDU\u0001SFHVMBS\u0001BVEJU\u0001BOE\u0001JOTQFDUJPO\nAn effective monitoring tool for adequate \nand continued protection offered to the \npersonal data transferred outside Hong \nKong is regular audit and inspection on \nthe transferees’ operations to ascertain \ntheir compliance with their obligations \nunder the data transfer agreement.\n8 See pages 4 to 7 above for more details.",
+      "text": "ests to monitor the data \nhandling process of the transferees, to \nkeep abreast of the whereabouts of the \npersonal data and to assess the associated \nprivacy risks. Also, data users should be \ntransparent about their data handling \npolicies and practices regarding any \ntransfer of personal data outside Hong \nKong.\nt\u0001 $POEVDU\u0001 SFHVMBS\u0001 BVEJU\u0001 BOE\u0001 JOTQFDUJPO\nAn effective monitoring tool for adequate \nand continued protection offered to the \npersonal data transferred outside Hong \nKong is regular audit and inspection on \nthe transferees’ operations to ascertain \ntheir compliance with their obligations \nunder the data transfer agreement.\n8 See pages 4 to 7 above for more details.",
       "metadata": {
         "source": "pcpd-cross-border-transfer-guidance.pdf",
         "page": 9,
@@ -66865,7 +66865,7 @@
     },
     {
       "id": "pcpd-model-contractual-clauses.pdf_f800ceaa3663_p7_c34",
-      "text": "“ Personal Data Transferred” means personal data of the types or categories listed in the Data Transfer \nSchedule;\n “ Purposes of Transfer” means the purposes for using the Personal Data Transferred listed in the Data \nTransfer Schedule or the directly related purposes;\n “ Recommended Model Data Processing Clauses ” means the recommended model contractual \nclauses for cross-border transfer of personal data from a data user to a data processor as published by \nthe Commissioner from time to time; and\n “ Retention Period” means any period of time identified as such in the Data Transfer Schedule.\n1.2 The terms “ Commissioner”, “data processor ”, “data subjects ”, “data user ”, “direct marketing ”, \n“personal data”, “processing” and “using” shall have the corresponding meanings given to those terms \nin the PDPO.\n2. INTERPRETATION \n The Clauses shall be read and interpreted in the light of the",
+      "text": "“ Personal Data Transferred” means personal data of the types or categories listed in the Data Transfer \nSchedule;\n “ Purposes of Transfer” means the purposes for using the Personal Data Transferred listed in the Data \nTransfer Schedule or the directly related purposes;\n “ Recommended Model Data Processing Clauses ” means the recommended model contractual \nclauses for cross-border transfer of personal data from a data user to a data processor as published by \nthe Commissioner from time to time; and\n “ Retention Period” means any period of time identified as such in the Data Transfer Schedule.\n1.2 The terms “ Commissioner”, “ data processor ”, “ data subjects ”, “ data user ”, “ direct marketing ”, \n“personal data”, “processing” and “using” shall have the corresponding meanings given to those terms \nin the PDPO.\n2. INTERPRETATION \n The Clauses shall be read and interpreted in the light of",
       "metadata": {
         "source": "pcpd-model-contractual-clauses.pdf",
         "page": 7,
@@ -66878,7 +66878,7 @@
     },
     {
       "id": "pcpd-model-contractual-clauses.pdf_f800ceaa3663_p7_c35",
-      "text": "l have the corresponding meanings given to those terms \nin the PDPO.\n2. INTERPRETATION \n The Clauses shall be read and interpreted in the light of the provisions of the PDPO. The Clauses shall not \nbe interpreted in a way that may conflict with the relevant requirements under the PDPO. \n3. OBLIGATIONS OF THE TRANSFEROR \nThe Transferor warrants and undertakes to the Transferee that, subject to the Transferee's compliance with \nits obligations under these Clauses, the Personal Data Transferred may be transferred to the Transferee \nfor the Purposes of Transfer in the Permitted Jurisdictions in accordance with the PDPO.\n4. OBLIGATIONS OF THE TRANSFEREE \n The Transferee warrants and undertakes to the Transferor that it will: \n4.1 except as otherwise permitted under the PDPO, only use the Personal Data Transferred for the Purposes \nof Transfer;\n4.2 ensure that the Personal Data Transferred be ",
+      "text": "shall have the corresponding meanings given to those terms \nin the PDPO.\n2. INTERPRETATION \n The Clauses shall be read and interpreted in the light of the provisions of the PDPO. The Clauses shall not \nbe interpreted in a way that may conflict with the relevant requirements under the PDPO. \n3. OBLIGATIONS OF THE TRANSFEROR \nThe Transferor warrants and undertakes to the Transferee that, subject to the Transferee's compliance with \nits obligations under these Clauses, the Personal Data Transferred may be transferred to the Transferee \nfor the Purposes of Transfer in the Permitted Jurisdictions in accordance with the PDPO.\n4. OBLIGATIONS OF THE TRANSFEREE \n The Transferee warrants and undertakes to the Transferor that it will: \n4.1 except as otherwise permitted under the PDPO, only use the Personal Data Transferred for the Purposes \nof Transfer;\n4.2 ensure that the Personal Data Transferred",
       "metadata": {
         "source": "pcpd-model-contractual-clauses.pdf",
         "page": 7,
@@ -66891,7 +66891,7 @@
     },
     {
       "id": "pcpd-model-contractual-clauses.pdf_f800ceaa3663_p7_c36",
-      "text": "wise permitted under the PDPO, only use the Personal Data Transferred for the Purposes \nof Transfer;\n4.2 ensure that the Personal Data Transferred be adequate but not excessive in relation to the Purposes of \nTransfer;",
+      "text": "therwise permitted under the PDPO, only use the Personal Data Transferred for the Purposes \nof Transfer;\n4.2 ensure that the Personal Data Transferred be adequate but not excessive in relation to the Purposes of \nTransfer;",
       "metadata": {
         "source": "pcpd-model-contractual-clauses.pdf",
         "page": 7,
@@ -77122,7 +77122,7 @@
     },
     {
       "id": "ethical-guidelines-medical-biological-research.pdf_6749bee59e8f_p30_c100",
-      "text": "sent from  the research \nsubjects, etc. at the research implementing entity to which such information related \nto personal information is to be provided. \n \n(b) Sensitive personal information is acquired pursuant to the proviso of ( 1) B (b) (ii) i; \nsuch sensitive personal information is provided to a person located in a foreign \ncountry; and, approval has been obtained  by the chief executive of the institution \nproviding specimens and/or information after deliberations by the ethical review \ncommittee as to whether all of the following requirements are met. \n(i) It is difficult to obtain appropriate consent; \n(ii) When, in provisions of (a) (ii) i through iii, the term “information related to personal \ninformation” is read as “sensitive personal information,” any of the requirements",
+      "text": "sent from  the research \nsubjects, etc. at the research implementing entity to which such information related \nto personal information is to be provided. \n \n(b) Sensitive personal information is acquired pursuant to the proviso of ( 1) B (b) (ii) i; \nsuch sensitive personal information is provided to a person located in a foreign \ncountry; and, approval has been obtained  by the chief executive of the institution \nproviding specimens and/or information after deliberations by the ethical review \ncommittee as to whether all of the following requirements are met. \n(i) It is difficult to obtain appropriate consent; \n(ii) When, in provisions of (a) (ii) i through iii, the term “information related to personal \ninformation” is read as “sensitive personal information,”  any of the requirements",
       "metadata": {
         "source": "ethical-guidelines-medical-biological-research.pdf",
         "page": 30,
@@ -77135,7 +77135,7 @@
     },
     {
       "id": "ethical-guidelines-medical-biological-research.pdf_6749bee59e8f_p31_c101",
-      "text": "28 \n \nlisted in (a) (ii) i through iii is met;  \n(iii) All of the requirements listed in Section 8 (1) are met, and appropriate measures \nare taken in accordance with the provisions of Section 8 (2); and, \n(iv) All of the information listed in B is provided to the research subjects, etc. \n \n(c) It is difficult to obtain appropriate consent ; provision (a) or (b) does not apply; and , \napproval has been obtained from the chief executive of the institution to which the \nspecimens and/or information are  to be provided  after deliberations by the ethical \nreview committee as to whether all of the following requirements are met. \n(i) When, in provisions of (a) (ii) i through iii, the term “information related to personal \ninformation” is read as “ specimens and/or information,” any of the requirements \nlisted in (a)(ii)i through iii is met; \n(ii) Concerning implementation of the said researc",
+      "text": "28 \n \nlisted in (a) (ii) i through iii is met;  \n(iii) All of the requirements listed in Section 8 (1) are met, and appropriate measures \nare taken in accordance with the provisions of Section 8 (2); and, \n(iv) All of the information listed in B is provided to the research subjects, etc. \n \n(c) It is difficult to obtain appropriate consent ; provision (a) or (b) does not apply; and , \napproval has been obtained from the chief executive of the institution to which the \nspecimens and/or information are  to be provided  after deliberations by the ethical \nreview committee as to whether all of the following requirements are met. \n(i) When, in provisions of (a) (ii) i through iii, the term “information related to personal \ninformation” is read as “ specimens and/or information,”  any of the requirements \nlisted in (a)(ii)i through iii is met; \n(ii) Concerning implementation of the said resear",
       "metadata": {
         "source": "ethical-guidelines-medical-biological-research.pdf",
         "page": 31,
@@ -77148,7 +77148,7 @@
     },
     {
       "id": "ethical-guidelines-medical-biological-research.pdf_6749bee59e8f_p31_c102",
-      "text": "s “ specimens and/or information,” any of the requirements \nlisted in (a)(ii)i through iii is met; \n(ii) Concerning implementation of the said research and the provision of the said \nspecimens and/or information to a person located in a foreign country, all of the \ninformation listed in B, and the matters listed in Section 6 (i) through (vi), (ix), and \n(x), are notified in advance to the research subjects etc., or are kept in a state where \nthey are easily accessible by the research subjects, etc.; and, \n(iii) In principle, the research subjects, etc. is provided with an opportunity to refuse to \nprovide the said specimens and/or information. \n  \nB. Those who provide specimens and/or information to persons located in a foreign country \nshall provide the following information to the research subjects, etc., in accordance with \nthe provisions of A: \n(i) Name of the foreign country; \n(ii) ",
+      "text": "s “ specimens and/or information,”  any of the requirements \nlisted in (a)(ii)i through iii is met; \n(ii) Concerning implementation of the said research and the provision of the said \nspecimens and/or information to a person located in a foreign country, all of the \ninformation listed in B, and the matters listed in Section 6 (i) through (vi), (ix), and \n(x), are notified in advance to the research subjects etc., or are kept in a state where \nthey are easily accessible by the research subjects, etc.; and, \n(iii) In principle, the research subjects, etc. is provided with an opportunity to refuse to \nprovide the said specimens and/or information. \n  \nB. Those who provide specimens and/or information to persons located in a foreign country \nshall provide the following information to the research subjects, etc., in accordance with \nthe provisions of A: \n(i) Name of the foreign country; \n(ii)",
       "metadata": {
         "source": "ethical-guidelines-medical-biological-research.pdf",
         "page": 31,
@@ -77161,7 +77161,7 @@
     },
     {
       "id": "ethical-guidelines-medical-biological-research.pdf_6749bee59e8f_p31_c103",
-      "text": "ll provide the following information to the research subjects, etc., in accordance with \nthe provisions of A: \n(i) Name of the foreign country; \n(ii) Information obtained by an appropriate and reasonable method concerning the system \nfor protecting personal information in the foreign country; and,  \n(iii) Information on measures taken by the person concerned to protect personal \ninformation.  \n \nC. Those who provide specimens and/or information to persons located in a foreign country \n(limited to those who have established a system that conforms to the standards set forth in \nArticle 16 of the Enforcement Rules for the Act on the Protection of Personal Information), \nif specimens and/or information are provided to the person concerned without obtaining \nappropriate consent of the research subject s, etc., shall take the necessary measures \nrequired by Article 28, paragraph (3) of the Per",
+      "text": "all provide the following information to the research subjects, etc., in accordance with \nthe provisions of A: \n(i) Name of the foreign country; \n(ii) Information obtained by an appropriate and reasonable method concerning the system \nfor protecting personal information in the foreign country; and,  \n(iii) Information on measures taken by the person concerned to protect personal \ninformation.  \n \nC. Those who provide specimens and/or information to persons located in a foreign country \n(limited to those who have established a system that conforms to the standards set forth in \nArticle 16 of the Enforcement Rules for the Act on the Protection of Personal Information), \nif specimens and/or information are provided to the person concerned without obtaining \nappropriate consent of the research subject s, etc., shall take the necessary measures \nrequired by Article 28, paragraph (3) of the Pe",
       "metadata": {
         "source": "ethical-guidelines-medical-biological-research.pdf",
         "page": 31,
@@ -77174,7 +77174,7 @@
     },
     {
       "id": "ethical-guidelines-medical-biological-research.pdf_6749bee59e8f_p31_c104",
-      "text": "ut obtaining \nappropriate consent of the research subject s, etc., shall take the necessary measures \nrequired by Article 28, paragraph (3) of the Personal Information Protection Act with \nrespect to the handling of personal information, and shall provide the research subjects, \netc. with information on such necessary measures upon request thereof.  \n \n2. Obtaining informed consent by electromagnetic means \nThe investigator, etc. or those who only provide existing specimens and/or information may",
+      "text": "out obtaining \nappropriate consent of the research subject s, etc., shall take the necessary measures \nrequired by Article 28, paragraph (3) of the Personal Information Protection Act with \nrespect to the handling of personal information, and shall provide the research subjects, \netc. with information on such necessary measures upon request thereof.  \n \n2. Obtaining informed consent by electromagnetic means \nThe investigator, etc. or those who only provide existing specimens and/or information may",
       "metadata": {
         "source": "ethical-guidelines-medical-biological-research.pdf",
         "page": 31,
@@ -96483,8 +96483,528 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p8_c0",
-      "text": "HEALTH INFORMATION 9\nREPUBLIC OF SINGAPORE\nNo. 1 of 2026.\nI assent.\n THARMAN SHANMUGARATNAM,\n President.\n 3 February 2026.\nA BILL\ni n t i t u l e d\nAn Act to provide for a national electronic records system for the safe\nand secure contribution, collection, storage and disclosure of health\ninformation about individuals, to facilitate the collection, disclosure\nand use of health and other information about individuals to\nmaintain and improve their physical and mental health and\nwellbeing, and to make a related amendment to the Human\nOrgan Transplant Act 1987.\nBe it enacted by the President with the advice and consent of the\nParliament of Singapore, as follows:\n7",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p1_c0",
+      "text": "REPUBLIC OF SINGAPORE\nGOVERNMENT GAZETTE\nACTS SUPPLEMENT\nPublished by Authority\nNO. 2] FRIDA Y, FEBRUARY 13 [2026\nFirst published in the Government Gazette, www.egazette.gov.sg, on 12 February 2026 at 5 pm.\nThe following Act was passed by Parliament on 12 January 2026 and assented \nto by the President on 3 February 2026:—\nHealth Information Bill\nBill No. 20/2025.\nRead the first time on 5 November 2025.\nHEALTH INFORMATION ACT 2026\n(No. of 2026)\nARRANGEMENT OF SECTIONS\nSection\n1. Short title and commencement\nPART 1\nPRELIMINARY\n2. General interpretation\n3. Meaning of “health information”, “administrative information”,\n“clinical information”, “accessible health information”,\n“individually‑identifiable health information” and\n“anonymised health information”\n4. Purposes of Act\n5. Application of Act\nPART 2\nNATIONAL ELECTRONIC RECORDS SYSTEM\nDivision 1 — General\n6. Interpretation of this Part\n7.",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 1,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p1_c1",
+      "text": "information”\n4. Purposes of Act\n5. Application of Act\nPART 2\nNATIONAL ELECTRONIC RECORDS SYSTEM\nDivision 1 — General\n6. Interpretation of this Part\n7. National electronic records system\n8. System Operator\n9. Application of this Part to contributors, etc., acting through\nrelevant HDI or directly\n10. Health information to which this Part applies\n11. Consent of individual not required for purposes of this Part\n1",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 1,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p2_c2",
+      "text": "2 NO. 1 OF 2026\nHealth Information Bill\nBill No. 20/2025.\nRead the first time on 5 November 2025.\nHEALTH INFORMATION ACT 2026\n(No. of 2026)\nARRANGEMENT OF SECTIONS\nSection\n1. Short title and commencement\nPART 1\nPRELIMINARY\n2. General interpretation\n3. Meaning of “health information”, “administrative information”,\n“clinical information”, “accessible health information”,\n“individually‑identifiable health information” and\n“anonymised health information”\n4. Purposes of Act\n5. Application of Act\nPART 2\nNATIONAL ELECTRONIC RECORDS SYSTEM\nDivision 1 — General\n6. Interpretation of this Part\n7. National electronic records system\n8. System Operator\n9. Application of this Part to contributors, etc., acting through\nrelevant HDI or directly\n10. Health information to which this Part applies\n11. Consent of individual not required for purposes of this Part\nHealth Information Bill\nBill No. 20/2025.\nRead ",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 2,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p2_c3",
+      "text": "nformation to which this Part applies\n11. Consent of individual not required for purposes of this Part\nHealth Information Bill\nBill No. 20/2025.\nRead the first time on 5 November 2025.\nHEALTH INFORMATION ACT 2026\n(No. of 2026)\nARRANGEMENT OF SECTIONS\nSection\n1. Short title and commencement\nPART 1\nPRELIMINARY\n2. General interpretation\n3. Meaning of “health information”, “administrative information”,\n“clinical information”, “accessible health information”,\n“individually‑identifiable health information” and\n“anonymised health information”\n4. Purposes of Act\n5. Application of Act\nPART 2\nNATIONAL ELECTRONIC RECORDS SYSTEM\nDivision 1 — General\n6. Interpretation of this Part\n7. National electronic records system\n8. System Operator\n9. Application of this Part to contributors, etc., acting through\nrelevant HDI or directly\n10. Health information to which this Part applies\n11. Consent of individual",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 2,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p2_c4",
+      "text": "f this Part to contributors, etc., acting through\nrelevant HDI or directly\n10. Health information to which this Part applies\n11. Consent of individual not required for purposes of this Part\nHealth Information Bill\nBill No. 20/2025.\nRead the first time on 5 November 2025.\nHEALTH INFORMATION ACT 2026\n(No. of 2026)\nARRANGEMENT OF SECTIONS\nSection\n1. Short title and commencement\nPART 1\nPRELIMINARY\n2. General interpretation\n3. Meaning of “health information”, “administrative information”,\n“clinical information”, “accessible health information”,\n“individually‑identifiable health information” and\n“anonymised health information”\n4. Purposes of Act\n5. Application of Act\nPART 2\nNATIONAL ELECTRONIC RECORDS SYSTEM\nDivision 1 — General\n6. Interpretation of this Part\n7. National electronic records system\n8. System Operator\n9. Application of this Part to contributors, etc., acting through\nrelevant HDI ",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 2,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p2_c5",
+      "text": " of this Part\n7. National electronic records system\n8. System Operator\n9. Application of this Part to contributors, etc., acting through\nrelevant HDI or directly\n10. Health information to which this Part applies\n11. Consent of individual not required for purposes of this Part\nDivision 2 — Contribution of health information\nSection\n12. Contribution by specified contributors\n13. Contribution by approved contributors\n14. Obligations of contributors\n15. Directions relating to contribution of health information\nDivision 3 — Access, collection and disclosure of\naccessible health information\n16. Restriction on access, collection or disclosure of accessible\nhealth information\n17. Access and collection of individual’s own accessible health\ninformation\n18. Authorised individuals of users\n19. Access and collection of accessible health information by\nspecified users\n20. Access and collection of acce",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 2,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p2_c6",
+      "text": "on\n18. Authorised individuals of users\n19. Access and collection of accessible health information by\nspecified users\n20. Access and collection of accessible health information by\napproved users\n21. Disclosure of accessible health information accessed and\ncollected under section 19 or 20\n22. Obligations of users\n23. Directions relating to access and collection of accessible health\ninformation\nDivision 4 — Derived information\n24. Interpretation of this Division\n25. Applications for derived information\n26. Access, collection, disclosure and use of derived information\n27. Obligations of requestors\n28. Directions relating to requestors\nDivision 5 — Access restrictions\n29. Access restrictions\n30. Effect of access restrictions\n31. Imposition and revocation of access restrictions\n32. Accessrestrictionsrelatingtohealthinformationaboutdeceased\nindividuals\n33. Transitional provision for this Divisi",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 2,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p2_c7",
+      "text": "evocation of access restrictions\n32. Accessrestrictionsrelatingtohealthinformationaboutdeceased\nindividuals\n33. Transitional provision for this Division\nDivision 6 — Action taken in response to\ncontraventions of this Part\n34. Action against contravening contributors, users, etc.\n2Division 2 — Contribution of health information\nSection\n12. Contribution by specified contributors\n13. Contribution by approved contributors\n14. Obligations of contributors\n15. Directions relating to contribution of health information\nDivision 3 — Access, collection and disclosure of\naccessible health information\n16. Restriction on access, collection or disclosure of accessible\nhealth information\n17. Access and collection of individual’s own accessible health\ninformation\n18. Authorised individuals of users\n19. Access and collection of accessible health information by\nspecified users\n20. Access and collection of ",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 2,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p2_c8",
+      "text": "mation\n18. Authorised individuals of users\n19. Access and collection of accessible health information by\nspecified users\n20. Access and collection of accessible health information by\napproved users\n21. Disclosure of accessible health information accessed and\ncollected under section 19 or 20\n22. Obligations of users\n23. Directions relating to access and collection of accessible health\ninformation\nDivision 4 — Derived information\n24. Interpretation of this Division\n25. Applications for derived information\n26. Access, collection, disclosure and use of derived information\n27. Obligations of requestors\n28. Directions relating to requestors\nDivision 5 — Access restrictions\n29. Access restrictions\n30. Effect of access restrictions\n31. Imposition and revocation of access restrictions\n32. Accessrestrictionsrelatingtohealthinformationaboutdeceased\nindividuals\n33. Transitional provision for this Di",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 2,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p2_c9",
+      "text": "nd revocation of access restrictions\n32. Accessrestrictionsrelatingtohealthinformationaboutdeceased\nindividuals\n33. Transitional provision for this Division\nDivision 6 — Action taken in response to\ncontraventions of this Part\n34. Action against contravening contributors, users, etc.\n2",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 2,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p3_c10",
+      "text": "HEALTH INFORMATION 3\nDivision 2 — Contribution of health information\nSection\n12. Contribution by specified contributors\n13. Contribution by approved contributors\n14. Obligations of contributors\n15. Directions relating to contribution of health information\nDivision 3 — Access, collection and disclosure of\naccessible health information\n16. Restriction on access, collection or disclosure of accessible\nhealth information\n17. Access and collection of individual’s own accessible health\ninformation\n18. Authorised individuals of users\n19. Access and collection of accessible health information by\nspecified users\n20. Access and collection of accessible health information by\napproved users\n21. Disclosure of accessible health information accessed and\ncollected under section 19 or 20\n22. Obligations of users\n23. Directions relating to access and collection of accessible health\ninformation\nDivision 4 ",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 3,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p3_c11",
+      "text": "ollected under section 19 or 20\n22. Obligations of users\n23. Directions relating to access and collection of accessible health\ninformation\nDivision 4 — Derived information\n24. Interpretation of this Division\n25. Applications for derived information\n26. Access, collection, disclosure and use of derived information\n27. Obligations of requestors\n28. Directions relating to requestors\nDivision 5 — Access restrictions\n29. Access restrictions\n30. Effect of access restrictions\n31. Imposition and revocation of access restrictions\n32. Accessrestrictionsrelatingtohealthinformationaboutdeceased\nindividuals\n33. Transitional provision for this Division\nDivision 6 — Action taken in response to\ncontraventions of this Part\n34. Action against contravening contributors, users, etc.\n2\nDivision 2 — Contribution of health information\nSection\n12. Contribution by specified contributors\n13. Contribution by appro",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 3,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p3_c12",
+      "text": "ntributors, users, etc.\n2\nDivision 2 — Contribution of health information\nSection\n12. Contribution by specified contributors\n13. Contribution by approved contributors\n14. Obligations of contributors\n15. Directions relating to contribution of health information\nDivision 3 — Access, collection and disclosure of\naccessible health information\n16. Restriction on access, collection or disclosure of accessible\nhealth information\n17. Access and collection of individual’s own accessible health\ninformation\n18. Authorised individuals of users\n19. Access and collection of accessible health information by\nspecified users\n20. Access and collection of accessible health information by\napproved users\n21. Disclosure of accessible health information accessed and\ncollected under section 19 or 20\n22. Obligations of users\n23. Directions relating to access and collection of accessible health\ninformation\nDivisi",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 3,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p3_c13",
+      "text": "and\ncollected under section 19 or 20\n22. Obligations of users\n23. Directions relating to access and collection of accessible health\ninformation\nDivision 4 — Derived information\n24. Interpretation of this Division\n25. Applications for derived information\n26. Access, collection, disclosure and use of derived information\n27. Obligations of requestors\n28. Directions relating to requestors\nDivision 5 — Access restrictions\n29. Access restrictions\n30. Effect of access restrictions\n31. Imposition and revocation of access restrictions\n32. Accessrestrictionsrelatingtohealthinformationaboutdeceased\nindividuals\n33. Transitional provision for this Division\nDivision 6 — Action taken in response to\ncontraventions of this Part\n34. Action against contravening contributors, users, etc.\n2\nHealth Information Bill\nBill No. 20/2025.\nRead the first time on 5 November 2025.\nHEALTH INFORMATION ACT 2026\n(No. of 2",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 3,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p3_c14",
+      "text": "ng contributors, users, etc.\n2\nHealth Information Bill\nBill No. 20/2025.\nRead the first time on 5 November 2025.\nHEALTH INFORMATION ACT 2026\n(No. of 2026)\nARRANGEMENT OF SECTIONS\nSection\n1. Short title and commencement\nPART 1\nPRELIMINARY\n2. General interpretation\n3. Meaning of “health information”, “administrative information”,\n“clinical information”, “accessible health information”,\n“individually‑identifiable health information” and\n“anonymised health information”\n4. Purposes of Act\n5. Application of Act\nPART 2\nNATIONAL ELECTRONIC RECORDS SYSTEM\nDivision 1 — General\n6. Interpretation of this Part\n7. National electronic records system\n8. System Operator\n9. Application of this Part to contributors, etc., acting through\nrelevant HDI or directly\n10. Health information to which this Part applies\n11. Consent of individual not required for purposes of this Part\nSection\n35. Procedure for action",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 3,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p3_c15",
+      "text": "ly\n10. Health information to which this Part applies\n11. Consent of individual not required for purposes of this Part\nSection\n35. Procedure for action against contributors, users, etc., under\nsection 34\n36. Appeal to Minister\n37. Minister may designate others to hear appeals\nDivision 7 — Offences under this Part\n38. Offences relating to improper access or collection of accessible\nhealth information by users or authorised individuals of users\n39. Offences relating to access or collection of accessible health\ninformation by unauthorised persons\n40. Offencesrelatingtounauthoriseddisclosureofaccessiblehealth\ninformation\n41. Offences relating to derived information — requestors\n42. Offences relating to derived information — other persons\nDivision 8 — Miscellaneous\n43. Directions relating to access, collection, possession and control\nof accessible health information by unauthorised persons\n44.",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 3,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p3_c16",
+      "text": "n 8 — Miscellaneous\n43. Directions relating to access, collection, possession and control\nof accessible health information by unauthorised persons\n44. Transitional provisions for this Part\nPART 3\nSHARING OF RELEVANT INFORMATION FOR\nSPECIFIED USE CASES\n45. Interpretation of this Part\n46. Meaning of “relevant information”\n47. Meaning of “use case”\n48. Application of this Part\n49. Application of this Part to disclosers, etc., acting through health\ndata intermediaries or directly\n50. Individual’s consent not required under this Part\n51. Sharing of relevant information under this Part\n52. Data sharing agreements\n53. Discloser’s obligations\n54. Recipient’s obligations\n55. Collection of relevant information\n56. Use of relevant information\n57. Subsequent disclosure of relevant information by recipient\n58. Notification of data sharing agreements\n59. Directions for purposes of this Part\n60. Offenc",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 3,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p3_c17",
+      "text": "equent disclosure of relevant information by recipient\n58. Notification of data sharing agreements\n59. Directions for purposes of this Part\n60. Offences under this Part\n3",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 3,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p4_c18",
+      "text": "4 NO. 1 OF 2026\nSection\n35. Procedure for action against contributors, users, etc., under\nsection 34\n36. Appeal to Minister\n37. Minister may designate others to hear appeals\nDivision 7 — Offences under this Part\n38. Offences relating to improper access or collection of accessible\nhealth information by users or authorised individuals of users\n39. Offences relating to access or collection of accessible health\ninformation by unauthorised persons\n40. Offencesrelatingtounauthoriseddisclosureofaccessiblehealth\ninformation\n41. Offences relating to derived information — requestors\n42. Offences relating to derived information — other persons\nDivision 8 — Miscellaneous\n43. Directions relating to access, collection, possession and control\nof accessible health information by unauthorised persons\n44. Transitional provisions for this Part\nPART 3\nSHARING OF RELEVANT INFORMATION FOR\nSPECIFIED USE CASES\n",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 4,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p4_c19",
+      "text": "e health information by unauthorised persons\n44. Transitional provisions for this Part\nPART 3\nSHARING OF RELEVANT INFORMATION FOR\nSPECIFIED USE CASES\n45. Interpretation of this Part\n46. Meaning of “relevant information”\n47. Meaning of “use case”\n48. Application of this Part\n49. Application of this Part to disclosers, etc., acting through health\ndata intermediaries or directly\n50. Individual’s consent not required under this Part\n51. Sharing of relevant information under this Part\n52. Data sharing agreements\n53. Discloser’s obligations\n54. Recipient’s obligations\n55. Collection of relevant information\n56. Use of relevant information\n57. Subsequent disclosure of relevant information by recipient\n58. Notification of data sharing agreements\n59. Directions for purposes of this Part\n60. Offences under this Part\n3\nHealth Information Bill\nBill No. 20/2025.\nRead the first time on 5 November 2025.",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 4,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p4_c20",
+      "text": " Directions for purposes of this Part\n60. Offences under this Part\n3\nHealth Information Bill\nBill No. 20/2025.\nRead the first time on 5 November 2025.\nHEALTH INFORMATION ACT 2026\n(No. of 2026)\nARRANGEMENT OF SECTIONS\nSection\n1. Short title and commencement\nPART 1\nPRELIMINARY\n2. General interpretation\n3. Meaning of “health information”, “administrative information”,\n“clinical information”, “accessible health information”,\n“individually‑identifiable health information” and\n“anonymised health information”\n4. Purposes of Act\n5. Application of Act\nPART 2\nNATIONAL ELECTRONIC RECORDS SYSTEM\nDivision 1 — General\n6. Interpretation of this Part\n7. National electronic records system\n8. System Operator\n9. Application of this Part to contributors, etc., acting through\nrelevant HDI or directly\n10. Health information to which this Part applies\n11. Consent of individual not required for purposes of this",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 4,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p4_c21",
+      "text": " acting through\nrelevant HDI or directly\n10. Health information to which this Part applies\n11. Consent of individual not required for purposes of this Part\nPART 4\nSECURITY OF HEALTH INFORMATION AND\nRELEVANT INFORMATION\nDivision 1 — General\nSection\n61. Interpretation of this Part\n62. Meaning of “data breach”\n63. Relevant computers or computer systems\n64. Application of this Part\n65. Designated individual of relevant person\nDivision 2 — Data security requirements\n66. Data security and handling of health information and relevant\ninformation\n67. Retention, disposal and destruction of health information and\nrelevant information\nDivision 3 — Cybersecurity requirements\n68. Cybersecurity of relevant computer or computer system\nDivision 4 — Miscellaneous\n69. Policies and practices for ensuring data security and\ncybersecurity\n70. Incident management framework\n71. Directions relating to relevant pe",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 4,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p4_c22",
+      "text": "neous\n69. Policies and practices for ensuring data security and\ncybersecurity\n70. Incident management framework\n71. Directions relating to relevant persons\nPART 5\nNOTIFICATION OF CYBERSECURITY INCIDENTS\nAND DATA BREACHES\nDivision 1 — General\n72. Interpretation of this Part\n73. Application of this Part\nDivision 2 — Notification of cybersecurity incidents\n74. Duty to conduct assessment of cybersecurity incident\n75. Duty to notify occurrence of notifiable cybersecurity incident\nDivision 3 — Notification of data breaches\n76. Interpretation of this Division\n77. Notifiable data breaches\n4PART 4\nSECURITY OF HEALTH INFORMATION AND\nRELEVANT INFORMATION\nDivision 1 — General\nSection\n61. Interpretation of this Part\n62. Meaning of “data breach”\n63. Relevant computers or computer systems\n64. Application of this Part\n65. Designated individual of relevant person\nDivision 2 — Data security requirements\n6",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 4,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p4_c23",
+      "text": "vant computers or computer systems\n64. Application of this Part\n65. Designated individual of relevant person\nDivision 2 — Data security requirements\n66. Data security and handling of health information and relevant\ninformation\n67. Retention, disposal and destruction of health information and\nrelevant information\nDivision 3 — Cybersecurity requirements\n68. Cybersecurity of relevant computer or computer system\nDivision 4 — Miscellaneous\n69. Policies and practices for ensuring data security and\ncybersecurity\n70. Incident management framework\n71. Directions relating to relevant persons\nPART 5\nNOTIFICATION OF CYBERSECURITY INCIDENTS\nAND DATA BREACHES\nDivision 1 — General\n72. Interpretation of this Part\n73. Application of this Part\nDivision 2 — Notification of cybersecurity incidents\n74. Duty to conduct assessment of cybersecurity incident\n75. Duty to notify occurrence of notifiable cybersecur",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 4,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p4_c24",
+      "text": "otification of cybersecurity incidents\n74. Duty to conduct assessment of cybersecurity incident\n75. Duty to notify occurrence of notifiable cybersecurity incident\nDivision 3 — Notification of data breaches\n76. Interpretation of this Division\n77. Notifiable data breaches\n4",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 4,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p5_c25",
+      "text": "HEALTH INFORMATION 5\nPART 4\nSECURITY OF HEALTH INFORMATION AND\nRELEVANT INFORMATION\nDivision 1 — General\nSection\n61. Interpretation of this Part\n62. Meaning of “data breach”\n63. Relevant computers or computer systems\n64. Application of this Part\n65. Designated individual of relevant person\nDivision 2 — Data security requirements\n66. Data security and handling of health information and relevant\ninformation\n67. Retention, disposal and destruction of health information and\nrelevant information\nDivision 3 — Cybersecurity requirements\n68. Cybersecurity of relevant computer or computer system\nDivision 4 — Miscellaneous\n69. Policies and practices for ensuring data security and\ncybersecurity\n70. Incident management framework\n71. Directions relating to relevant persons\nPART 5\nNOTIFICATION OF CYBERSECURITY INCIDENTS\nAND DATA BREACHES\nDivision 1 — General\n72. Interpretation of this Part\n73. Applica",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 5,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p5_c26",
+      "text": " to relevant persons\nPART 5\nNOTIFICATION OF CYBERSECURITY INCIDENTS\nAND DATA BREACHES\nDivision 1 — General\n72. Interpretation of this Part\n73. Application of this Part\nDivision 2 — Notification of cybersecurity incidents\n74. Duty to conduct assessment of cybersecurity incident\n75. Duty to notify occurrence of notifiable cybersecurity incident\nDivision 3 — Notification of data breaches\n76. Interpretation of this Division\n77. Notifiable data breaches\n4\nPART 4\nSECURITY OF HEALTH INFORMATION AND\nRELEVANT INFORMATION\nDivision 1 — General\nSection\n61. Interpretation of this Part\n62. Meaning of “data breach”\n63. Relevant computers or computer systems\n64. Application of this Part\n65. Designated individual of relevant person\nDivision 2 — Data security requirements\n66. Data security and handling of health information and relevant\ninformation\n67. Retention, disposal and destruction of health informa",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 5,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p5_c27",
+      "text": "y requirements\n66. Data security and handling of health information and relevant\ninformation\n67. Retention, disposal and destruction of health information and\nrelevant information\nDivision 3 — Cybersecurity requirements\n68. Cybersecurity of relevant computer or computer system\nDivision 4 — Miscellaneous\n69. Policies and practices for ensuring data security and\ncybersecurity\n70. Incident management framework\n71. Directions relating to relevant persons\nPART 5\nNOTIFICATION OF CYBERSECURITY INCIDENTS\nAND DATA BREACHES\nDivision 1 — General\n72. Interpretation of this Part\n73. Application of this Part\nDivision 2 — Notification of cybersecurity incidents\n74. Duty to conduct assessment of cybersecurity incident\n75. Duty to notify occurrence of notifiable cybersecurity incident\nDivision 3 — Notification of data breaches\n76. Interpretation of this Division\n77. Notifiable data breaches\n4\nHealth Info",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 5,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p5_c28",
+      "text": "iable cybersecurity incident\nDivision 3 — Notification of data breaches\n76. Interpretation of this Division\n77. Notifiable data breaches\n4\nHealth Information Bill\nBill No. 20/2025.\nRead the first time on 5 November 2025.\nHEALTH INFORMATION ACT 2026\n(No. of 2026)\nARRANGEMENT OF SECTIONS\nSection\n1. Short title and commencement\nPART 1\nPRELIMINARY\n2. General interpretation\n3. Meaning of “health information”, “administrative information”,\n“clinical information”, “accessible health information”,\n“individually‑identifiable health information” and\n“anonymised health information”\n4. Purposes of Act\n5. Application of Act\nPART 2\nNATIONAL ELECTRONIC RECORDS SYSTEM\nDivision 1 — General\n6. Interpretation of this Part\n7. National electronic records system\n8. System Operator\n9. Application of this Part to contributors, etc., acting through\nrelevant HDI or directly\n10. Health information to which this Pa",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 5,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p5_c29",
+      "text": "\n8. System Operator\n9. Application of this Part to contributors, etc., acting through\nrelevant HDI or directly\n10. Health information to which this Part applies\n11. Consent of individual not required for purposes of this Part\nSection\n78. Duty to conduct assessment of data breach\n79. Duty to notify occurrence of notifiable data breach\n80. Duty to notify affected individuals of occurrence of notifiable\ndata breach\n81. Obligations of relevant HDI of public agency\nDivision 4 — Miscellaneous\n82. Offences under this Part\nPART 6\nRESPONSES TO THREATS AND INCIDENTS\nAFFECTING HEALTH INFORMATION AND\nRELEVANT INFORMATION\n83. Application of this Part\n84. Emergency measures and requirements\n85. Delegation by Minister of powers under this Part\nPART 7\nPORTABILITY OF HEALTH INFORMATION\nIN ELECTRONIC FORM\n86. Application of this Part\n87. Portability of health information\n88. Directions under this Part\nPAR",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 5,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p5_c30",
+      "text": "ABILITY OF HEALTH INFORMATION\nIN ELECTRONIC FORM\n86. Application of this Part\n87. Portability of health information\n88. Directions under this Part\nPART 8\nADMINISTRATION AND ENFORCEMENT\n89. Administration of Act\n90. Codes of practice\n91. Power to obtain documents and information — authorised\nofficers\n92. Power to obtain documents and information — investigation\nofficers\n93. Powers of entry and inspection — authorised officers\n94. Powers of entry, inspection and search, etc. — investigation\nofficers\n95. Offence of obstructing, etc., authorised officer or investigation\nofficer in exercise of powers, etc.\n96. False or misleading statements, documents or information\n5",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 5,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p6_c31",
+      "text": "6 NO. 1 OF 2026\nSection\n78. Duty to conduct assessment of data breach\n79. Duty to notify occurrence of notifiable data breach\n80. Duty to notify affected individuals of occurrence of notifiable\ndata breach\n81. Obligations of relevant HDI of public agency\nDivision 4 — Miscellaneous\n82. Offences under this Part\nPART 6\nRESPONSES TO THREATS AND INCIDENTS\nAFFECTING HEALTH INFORMATION AND\nRELEVANT INFORMATION\n83. Application of this Part\n84. Emergency measures and requirements\n85. Delegation by Minister of powers under this Part\nPART 7\nPORTABILITY OF HEALTH INFORMATION\nIN ELECTRONIC FORM\n86. Application of this Part\n87. Portability of health information\n88. Directions under this Part\nPART 8\nADMINISTRATION AND ENFORCEMENT\n89. Administration of Act\n90. Codes of practice\n91. Power to obtain documents and information — authorised\nofficers\n92. Power to obtain documents and information — investigati",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 6,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p6_c32",
+      "text": "\n90. Codes of practice\n91. Power to obtain documents and information — authorised\nofficers\n92. Power to obtain documents and information — investigation\nofficers\n93. Powers of entry and inspection — authorised officers\n94. Powers of entry, inspection and search, etc. — investigation\nofficers\n95. Offence of obstructing, etc., authorised officer or investigation\nofficer in exercise of powers, etc.\n96. False or misleading statements, documents or information\n5\nSection\n78. Duty to conduct assessment of data breach\n79. Duty to notify occurrence of notifiable data breach\n80. Duty to notify affected individuals of occurrence of notifiable\ndata breach\n81. Obligations of relevant HDI of public agency\nDivision 4 — Miscellaneous\n82. Offences under this Part\nPART 6\nRESPONSES TO THREATS AND INCIDENTS\nAFFECTING HEALTH INFORMATION AND\nRELEVANT INFORMATION\n83. Application of this Part\n84. Emergency meas",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 6,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p6_c33",
+      "text": "s Part\nPART 6\nRESPONSES TO THREATS AND INCIDENTS\nAFFECTING HEALTH INFORMATION AND\nRELEVANT INFORMATION\n83. Application of this Part\n84. Emergency measures and requirements\n85. Delegation by Minister of powers under this Part\nPART 7\nPORTABILITY OF HEALTH INFORMATION\nIN ELECTRONIC FORM\n86. Application of this Part\n87. Portability of health information\n88. Directions under this Part\nPART 8\nADMINISTRATION AND ENFORCEMENT\n89. Administration of Act\n90. Codes of practice\n91. Power to obtain documents and information — authorised\nofficers\n92. Power to obtain documents and information — investigation\nofficers\n93. Powers of entry and inspection — authorised officers\n94. Powers of entry, inspection and search, etc. — investigation\nofficers\n95. Offence of obstructing, etc., authorised officer or investigation\nofficer in exercise of powers, etc.\n96. False or misleading statements, documents or inform",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 6,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p6_c34",
+      "text": " of obstructing, etc., authorised officer or investigation\nofficer in exercise of powers, etc.\n96. False or misleading statements, documents or information\n5\nHealth Information Bill\nBill No. 20/2025.\nRead the first time on 5 November 2025.\nHEALTH INFORMATION ACT 2026\n(No. of 2026)\nARRANGEMENT OF SECTIONS\nSection\n1. Short title and commencement\nPART 1\nPRELIMINARY\n2. General interpretation\n3. Meaning of “health information”, “administrative information”,\n“clinical information”, “accessible health information”,\n“individually‑identifiable health information” and\n“anonymised health information”\n4. Purposes of Act\n5. Application of Act\nPART 2\nNATIONAL ELECTRONIC RECORDS SYSTEM\nDivision 1 — General\n6. Interpretation of this Part\n7. National electronic records system\n8. System Operator\n9. Application of this Part to contributors, etc., acting through\nrelevant HDI or directly\n10. Health informati",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 6,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p6_c35",
+      "text": "onic records system\n8. System Operator\n9. Application of this Part to contributors, etc., acting through\nrelevant HDI or directly\n10. Health information to which this Part applies\n11. Consent of individual not required for purposes of this Part\nSection\n97. Disposal of things and documents\nPART 9\nMISCELLANEOUS\n98. Legal protections — contributors\n99. Legal protections — users\n100. Legal protections — requestors\n101. Legal protections — System Operator, etc.\n102. Legal protections — disclosers\n103. Legal protections — recipients\n104. Legal protections — others\n105. Offences by corporations\n106. Offences by unincorporated associations or partnerships\n107. Service of documents\n108. Jurisdiction of court\n109. Composition of offences\n110. Exemption\n111. Amendment of Schedules\n112. Regulations\n113. Related amendment to Human Organ Transplant Act 1987\n114. Saving and transitional provision\nFirst",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 6,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p6_c36",
+      "text": "on\n111. Amendment of Schedules\n112. Regulations\n113. Related amendment to Human Organ Transplant Act 1987\n114. Saving and transitional provision\nFirst Schedule — Contribution of health information by\nspecified contributors\nSecond Schedule — Access and collection of\naccessible health information\nThird Schedule — Written laws under which\nspecified examinations carried out for\npurposes of section 19(3)\nFourth Schedule — Disclosure, collection and\nuse of relevant information\n6",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 6,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p7_c37",
+      "text": "HEALTH INFORMATION 7\nSection\n97. Disposal of things and documents\nPART 9\nMISCELLANEOUS\n98. Legal protections — contributors\n99. Legal protections — users\n100. Legal protections — requestors\n101. Legal protections — System Operator, etc.\n102. Legal protections — disclosers\n103. Legal protections — recipients\n104. Legal protections — others\n105. Offences by corporations\n106. Offences by unincorporated associations or partnerships\n107. Service of documents\n108. Jurisdiction of court\n109. Composition of offences\n110. Exemption\n111. Amendment of Schedules\n112. Regulations\n113. Related amendment to Human Organ Transplant Act 1987\n114. Saving and transitional provision\nFirst Schedule — Contribution of health information by\nspecified contributors\nSecond Schedule — Access and collection of\naccessible health information\nThird Schedule — Written laws under which\nspecified examinations carried out f",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 7,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p7_c38",
+      "text": "econd Schedule — Access and collection of\naccessible health information\nThird Schedule — Written laws under which\nspecified examinations carried out for\npurposes of section 19(3)\nFourth Schedule — Disclosure, collection and\nuse of relevant information\n6\nHealth Information Bill\nBill No. 20/2025.\nRead the first time on 5 November 2025.\nHEALTH INFORMATION ACT 2026\n(No. of 2026)\nARRANGEMENT OF SECTIONS\nSection\n1. Short title and commencement\nPART 1\nPRELIMINARY\n2. General interpretation\n3. Meaning of “health information”, “administrative information”,\n“clinical information”, “accessible health information”,\n“individually‑identifiable health information” and\n“anonymised health information”\n4. Purposes of Act\n5. Application of Act\nPART 2\nNATIONAL ELECTRONIC RECORDS SYSTEM\nDivision 1 — General\n6. Interpretation of this Part\n7. National electronic records system\n8. System Operator\n9. Application ",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 7,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p7_c39",
+      "text": "ELECTRONIC RECORDS SYSTEM\nDivision 1 — General\n6. Interpretation of this Part\n7. National electronic records system\n8. System Operator\n9. Application of this Part to contributors, etc., acting through\nrelevant HDI or directly\n10. Health information to which this Part applies\n11. Consent of individual not required for purposes of this Part",
+      "metadata": {
+        "source": "health-information-act-2026.pdf",
+        "page": 7,
+        "category": "sg-hia",
+        "jurisdiction": "SG",
+        "document_id": "sg-hia",
+        "framework": "HIA",
+        "content_type": "primary"
+      }
+    },
+    {
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p8_c40",
+      "text": "HEALTH INFORMATION 9\nREPUBLIC OF SINGAPORE\nNo. 1 of 2026.\nI assent.\n THARMAN SHANMUGARATNAM,\n President.\n 3 February 2026.\nA BILL\ni n t i t u l e d\nAnActtoprovideforanationalelectronicrecordssystemforthesafe\nandsecurecontribution,collection,storageanddisclosureofhealth\ninformationaboutindividuals,tofacilitatethecollection,disclosure\nand use of health and other information about individuals to\nmaintain and improve their physical and mental health and\nwellbeing, and to make a related amendment to the Human\nOrgan Transplant Act 1987.\nBe it enacted by the President with the advice and consent of the\nParliament of Singapore, as follows:\n7",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 8,
@@ -96496,8 +97016,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p9_c1",
-      "text": "10 NO. 1 OF 2026\nShort title and commencement\n1. This Act is the Health Information Act 2026 and comes into\noperation on a date that the Minister appoints by notification in the\nGazette.\nPART 1\nPRELIMINARY\nGeneral interpretation\n2. In this Act —\n“access restriction”, in relation to accessible health information\nabout any individual, has the meaning given by section 29(1);\n“approved contributor” means a person or public agency that is\napproved under section 13(1);\n“approved user” means a person or public agency that is\napproved under section 20(1);\n“authorised officer” means a public officer, an officer of a public\nauthority or any other individual who is appointed as such\nunder section 89(1)( a);\n“community health service” means a service (other than a\nlicensable healthcare service) that is provided to an\nindividual for or in relation to any of the following purposes:\n(a) disease prevent",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p9_c41",
+      "text": "10 NO. 1 OF 2026\nShort title and commencement\n1. This Act is the Health Information Act 2026 and comes into\noperation on a date that the Minister appoints by notification in the\nGazette.\nPART 1\nPRELIMINARY\nGeneral interpretation\n2. In this Act —\n“access restriction”, in relation to accessible health information\naboutanyindividual,hasthemeaninggivenbysection29(1);\n“approved contributor” means a person or public agency that is\napproved under section 13(1);\n“approved user” means a person or public agency that is\napproved under section 20(1);\n“authorisedofficer”meansapublicofficer,anofficerofapublic\nauthority or any other individual who is appointed as such\nunder section 89(1)(a);\n“community health service” means a service (other than a\nlicensable healthcare service) that is provided to an\nindividualfor orin relation to any of the followingpurposes:\n(a) disease prevention;\n(b) the detection ",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 9,
@@ -96509,8 +97029,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p9_c2",
-      "text": "other than a\nlicensable healthcare service) that is provided to an\nindividual for or in relation to any of the following purposes:\n(a) disease prevention;\n(b) the detection of any disease or condition that the\nindividual is or may be suffering from;\n(c) where the individual suffers or has suffered from any\ndisease or condition, the rehabilitation of the\nindividual or the alleviation of the disease or\ncondition;\n(d) where the individual is or is at risk of being socially\nisolated or physically or mentally frail, the\nprevention or mitigation of the individual’s social\nisolation or frailty;\n8",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p9_c42",
+      "text": "ble healthcare service) that is provided to an\nindividualfor orin relation to any of the followingpurposes:\n(a) disease prevention;\n(b) the detection of any disease or condition that the\nindividual is or may be suffering from;\n(c) wheretheindividualsuffersorhassufferedfromany\ndisease or condition, the rehabilitation of the\nindividual or the alleviation of the disease or\ncondition;\n(d) where the individual is or is at risk of being socially\nisolated or physically or mentally frail, the\nprevention or mitigation of the individual’s social\nisolation or frailty;\n8",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 9,
@@ -96522,8 +97042,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p10_c3",
-      "text": "HEALTH INFORMATION 11\n(e) the assessment of the individual’s need for any\nhealthcare service or another community health\nservice, and the planning for and coordination of\nthe provision of any such service to the individual;\n5(f) any other purpose that may be prescribed;\n“computer” means any electronic, magnetic, optical,\nelectrochemical or other data processing device performing\nlogical, arithmetic or storage functions, and includes any data\nstorage facility directly related to or operating in conjunction\n10with any such device, but does not include any device as the\nMinister may, by notification in the Gazette, prescribe;\n“computer system” means an arrangement of interconnected\ncomputers that is designed to perform one or more specific\nfunctions, and includes —\n15(a) an information technology system; and\n(b) an operational technology system such as an\nindustrial control system, a progra",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p10_c43",
+      "text": "HEALTH INFORMATION 11\n(e) the assessment of the individual’s need for any\nhealthcare service or another community health\nservice, and the planning for and coordination of\nthe provision of any such service to the individual;\n5(f) any other purpose that may be prescribed;\n“computer” means any electronic, magnetic, optical,\nelectrochemical or other data processing device performing\nlogical,arithmeticorstoragefunctions,andincludesanydata\nstoragefacilitydirectly relatedtoor operatinginconjunction\n10with any such device, but does not include any device as the\nMinister may, by notification in theGazette, prescribe;\n“computer system” means an arrangement of interconnected\ncomputers that is designed to perform one or more specific\nfunctions, and includes —\n15(a) an information technology system; and\n(b) an operational technology system such as an\nindustrial control system, a programmable logic\nco",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 10,
@@ -96535,8 +97055,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p10_c4",
-      "text": "ctions, and includes —\n15(a) an information technology system; and\n(b) an operational technology system such as an\nindustrial control system, a programmable logic\ncontroller, a supervisory control and data\nacquisition system or a distributed control system;\n20“contribute”, in relation to health information about an\nindividual, means to contribute that health information to\nthe national electronic records system for the purposes of\nPart 2;\n“contributor”, in relation to the national electronic records\n25system, means a specified contributor or an approved\ncontributor;\n“HCSA licensee” means a person to whom a licence is granted\nunder the Healthcare Services Act 2020 to provide a\nlicensable healthcare service;\n30“health data intermediary” means a person that processes health\ninformation or relevant information on behalf of another\nperson for the purposes of this Act, but does not include an\n",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p10_c44",
+      "text": "ludes —\n15(a) an information technology system; and\n(b) an operational technology system such as an\nindustrial control system, a programmable logic\ncontroller, a supervisory control and data\nacquisition system or a distributed control system;\n20“contribute”, in relation to health information about an\nindividual, means to contribute that health information to\nthe national electronic records system for the purposes of\nPart 2;\n“contributor”, in relation to the national electronic records\n25system, means a specified contributor or an approved\ncontributor;\n“HCSA licensee” means a person to whom a licence is granted\nunder the Healthcare Services Act 2020 to provide a\nlicensable healthcare service;\n30“health data intermediary” means a person that processes health\ninformation or relevant information on behalf of another\nperson for the purposes of this Act, but does not include an\nemployee of tha",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 10,
@@ -96548,8 +97068,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p10_c5",
-      "text": " a person that processes health\ninformation or relevant information on behalf of another\nperson for the purposes of this Act, but does not include an\nemployee of that other person;\n9",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p10_c45",
+      "text": "processes health\ninformation or relevant information on behalf of another\nperson for the purposes of this Act, but does not include an\nemployee of that other person;\n9",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 10,
@@ -96561,8 +97081,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p11_c6",
-      "text": "12 NO. 1 OF 2026\n“health product” has the meaning given by section 2(1) of the\nHealth Products Act 2007;\n“healthcare service” and “licensable healthcare service” have\nthe meanings given by section 3(1) of the Healthcare Services\n5 Act 2020;\n“investigation officer” means a public officer or an officer of a\npublic authority who is appointed as such under\nsection 89(1)(b);\n“national electronic records system” means the computer system\n10 mentioned in section 7(1);\n“process”, in relation to health information or relevant\ninformation, means to carry out any operation or set of\noperations in relation to the health information or relevant\ninformation (as the case may be), and includes any of the\n15 following:\n(a) to record;\n(b) to hold;\n(c) to organise, adapt or alter;\n(d) to retrieve;\n20 (e) to combine;\n(f) to transmit or convey;\n(g) to erase or destroy,\nand “processing” has a corresponding me",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p11_c46",
+      "text": "12 NO. 1 OF 2026\n“health product” has the meaning given by section 2(1) of the\nHealth Products Act 2007;\n“healthcare service” and “licensable healthcare service” have\nthemeaningsgivenbysection3(1)oftheHealthcareServices\n5 Act 2020;\n“investigation officer” means a public officer or an officer of a\npublic authority who is appointed as such under\nsection 89(1)(b);\n“nationalelectronicrecordssystem”meansthecomputersystem\n10 mentioned in section 7(1);\n“process”, in relation to health information or relevant\ninformation, means to carry out any operation or set of\noperations in relation to the health information or relevant\ninformation (as the case may be), and includes any of the\n15 following:\n(a) to record;\n(b) to hold;\n(c) to organise, adapt or alter;\n(d) to retrieve;\n20 (e) to combine;\n(f) to transmit or convey;\n(g) to erase or destroy,\nand “processing” has a corresponding meaning;\n“public a",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 11,
@@ -96574,8 +97094,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p11_c7",
-      "text": "anise, adapt or alter;\n(d) to retrieve;\n20 (e) to combine;\n(f) to transmit or convey;\n(g) to erase or destroy,\nand “processing” has a corresponding meaning;\n“public agency” means any ministry, department or Organ of\n25 State of the Government or a public authority;\n“public authority” means a body established or constituted by or\nunder a public Act to perform or discharge a public function,\nexcluding a Town Council established under section 4 of the\nTown Councils Act 1988;\n30 “qualified pharmacist” means a person who —\n(a) is registered as a pharmacist under the Pharmacists\nRegistration Act 2007;\n10",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p11_c47",
+      "text": "alter;\n(d) to retrieve;\n20 (e) to combine;\n(f) to transmit or convey;\n(g) to erase or destroy,\nand “processing” has a corresponding meaning;\n“public agency” means any ministry, department or Organ of\n25 State of the Government or a public authority;\n“publicauthority”meansabodyestablishedorconstitutedbyor\nunder a public Act to perform or discharge a public function,\nexcluding a Town Council established under section 4 of the\nTown Councils Act 1988;\n30 “qualified pharmacist” means a person who —\n(a) is registered as a pharmacist under the Pharmacists\nRegistration Act 2007;\n10",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 11,
@@ -96587,8 +97107,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p12_c8",
-      "text": "HEALTH INFORMATION 13\n(b) holds a valid practising certificate granted under that\nAct; and\n(c) is practising pharmacy, whether on a full‑time or\npart‑time basis or as a locum;\n5“relevant HDI” means a health data intermediary that operates a\ncomputer or computer system that —\n(a) processes health information about individuals for\nthe purposes of facilitating and organising the\nprovision of any healthcare service or community\n10health service; and\n(b) is interconnected with the national electronic records\nsystem;\n“relevant information” has the meaning given by section 46(1);\n“retail pharmacy” and “retail pharmacy business” have the\n15meanings given by regulation 2 of the Health Products\n(Licensing of Retail Pharmacies) Regulations 2016\n(G.N. No. S 330/2016);\n“retail pharmacy licensee” means a person who holds a licence\nissued under the Health Products Act 2007 to carry on a retail\n20pharma",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p12_c48",
+      "text": "HEALTH INFORMATION 13\n(b) holds a valid practising certificate granted under that\nAct; and\n(c) is practising pharmacy, whether on a full‑time or\npart‑time basis or as a locum;\n5“relevantHDI”meansahealthdataintermediarythatoperatesa\ncomputer or computer system that —\n(a) processes health information about individuals for\nthe purposes of facilitating and organising the\nprovision of any healthcare service or community\n10health service; and\n(b) is interconnected with the national electronic records\nsystem;\n“relevant information” has the meaning given by section 46(1);\n“retail pharmacy” and “retail pharmacy business” have the\n15meanings given by regulation 2 of the Health Products\n(Licensing of Retail Pharmacies) Regulations 2016\n(G.N. No. S 330/2016);\n“retail pharmacy licensee” means a person who holds a licence\nissuedundertheHealthProductsAct2007tocarryonaretail\n20pharmacybusinessatorfromth",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 12,
@@ -96600,8 +97120,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p12_c9",
-      "text": "No. S 330/2016);\n“retail pharmacy licensee” means a person who holds a licence\nissued under the Health Products Act 2007 to carry on a retail\n20pharmacy business at or from the retail pharmacy specified in\nthe licence;\n“specified contributor”, in relation to the national electronic\nrecords system, means a person mentioned in section 12(1);\n“specified user”, in relation to the national electronic records\n25system, means a person mentioned in section 19(1);\n“System Operator”, in relation to the national electronic records\nsystem, means a person designated under section 8(1);\n“user”, in relation to the national electronic records system,\nmeans a specified user or an approved user.\n11",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p12_c49",
+      "text": "/2016);\n“retail pharmacy licensee” means a person who holds a licence\nissuedundertheHealthProductsAct2007tocarryonaretail\n20pharmacybusinessatorfromtheretailpharmacyspecifiedin\nthe licence;\n“specified contributor”, in relation to the national electronic\nrecords system, means a person mentioned in section 12(1);\n“specified user”, in relation to the national electronic records\n25system, means a person mentioned in section 19(1);\n“SystemOperator”, inrelation to the nationalelectronicrecords\nsystem, means a person designated under section 8(1);\n“user”, in relation to the national electronic records system,\nmeans a specified user or an approved user.\n11",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 12,
@@ -96613,8 +97133,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p13_c10",
-      "text": "14 NO. 1 OF 2026\nMeaning of “health information”, “administrative\ninformation”, “clinical information”, “accessible health\ninformation”, “individually‑identifiable health information”\nand “anonymised health information”\n5 3.—(1) For the purposes of this Act, “health information” about an\nindividual means administrative information and clinical information\nabout the individual but does not include any administrative\ninformation or clinical information that may be prescribed.\n(2) For the purposes of this Act, “administrative information” about\n10 an individual means —\n(a) information relating to the individual’s use of any\nhealthcare service or community health service;\n(b) information relating to the provision of any healthcare\nservice or community health service to the individual;\n15 (c) information relating to the individual’s eligibility for\nfinancial assistance under any public scheme",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p13_c50",
+      "text": "14 NO. 1 OF 2026\nMeaning of “health information”, “administrative\ninformation”, “clinical information”, “accessible health\ninformation”, “individually‑identifiable health information”\nand “anonymised health information”\n5 3.—(1) For the purposes of this Act, “health information” about an\nindividualmeansadministrativeinformationandclinicalinformation\nabout the individual but does not include any administrative\ninformation or clinical information that may be prescribed.\n(2) ForthepurposesofthisAct,“administrativeinformation”about\n10 an individual means —\n(a) information relating to the individual’s use of any\nhealthcare service or community health service;\n(b) information relating to the provision of any healthcare\nservice or community health service to the individual;\n15 (c) information relating to the individual’s eligibility for\nfinancial assistance under any public scheme in respect\nof",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 13,
@@ -96626,8 +97146,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p13_c11",
-      "text": "mmunity health service to the individual;\n15 (c) information relating to the individual’s eligibility for\nfinancial assistance under any public scheme in respect\nof the cost or expense of any healthcare service or\ncommunity health service provided to the individual; or\n(d) any other information that may be prescribed,\n20 but does not include any clinical information.\nIllustration\nThe name, identification number, address and telephone number of an\nindividual who uses a healthcare service or community health service are\nexamples of administrative information about that individual.\n25 (3) For the purposes of this Act, “clinical information” about an\nindividual means information relating to either or both of the\nfollowing:\n(a) the physical or mental health of the individual;\n(b) the diagnosis, treatment or care of the individual.\n30 (4) For the purposes of this Act, “accessible health inform",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p13_c51",
+      "text": " service to the individual;\n15 (c) information relating to the individual’s eligibility for\nfinancial assistance under any public scheme in respect\nof the cost or expense of any healthcare service or\ncommunity health service provided to the individual; or\n(d) any other information that may be prescribed,\n20 but does not include any clinical information.\nIllustration\nThe name, identification number, address and telephone number of an\nindividual who uses a healthcare service or community health service are\nexamples of administrative information about that individual.\n25 (3) For the purposes of this Act, “clinical information” about an\nindividual means information relating to either or both of the\nfollowing:\n(a) the physical or mental health of the individual;\n(b) the diagnosis, treatment or care of the individual.\n30 (4) For the purposes of this Act, “accessible health information”\nabout a",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 13,
@@ -96639,8 +97159,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p13_c12",
-      "text": "ental health of the individual;\n(b) the diagnosis, treatment or care of the individual.\n30 (4) For the purposes of this Act, “accessible health information”\nabout any individual means health information about the individual\nthat is made available on the national electronic records system by a\nSystem Operator in accordance with this Act.\n12",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p13_c52",
+      "text": "f the individual;\n(b) the diagnosis, treatment or care of the individual.\n30 (4) For the purposes of this Act, “accessible health information”\nabout any individual means health information about the individual\nthat is made available on the national electronic records system by a\nSystem Operator in accordance with this Act.\n12",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 13,
@@ -96652,8 +97172,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p14_c13",
-      "text": "HEALTH INFORMATION 15\n(5) To avoid doubt, accessible health information about an\nindividual (P) does not include the following:\n(a) administrative information about P that is part of any\nrecord made or maintained by a person (X) in respect\n5of P —\n(i) that is identical or substantially similar to\nadministrative information about P made available\non the national electronic records system; and\n(ii) regardless of whether X collected that administrative\n10information from the national electronic records\nsystem or obtained that administrative information\nby any other means;\n(b) clinical information about P that is part of the medical\nrecords made or maintained by X in respect of P —\n15(i) that is identical or substantially similar to clinical\ninformation about P made available on the national\nelectronic records system; and\n(ii) regardless of whether X collected that clinical\ninformation from ",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p14_c53",
+      "text": "HEALTH INFORMATION 15\n(5) To avoid doubt, accessible health information about an\nindividual (P) does not include the following:\n(a) administrative information about P that is part of any\nrecord made or maintained by a person (X) in respect\n5of P —\n(i) that is identical or substantially similar to\nadministrative information aboutP made available\non the national electronic records system; and\n(ii) regardless ofwhetherXcollectedthatadministrative\n10information from the national electronic records\nsystem or obtained that administrative information\nby any other means;\n(b) clinical information about P that is part of the medical\nrecords made or maintained byX in respect ofP —\n15(i) that is identical or substantially similar to clinical\ninformation aboutP made available on the national\nelectronic records system; and\n(ii) regardless of whether X collected that clinical\ninformation from the natio",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 14,
@@ -96665,8 +97185,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p14_c14",
-      "text": "formation about P made available on the national\nelectronic records system; and\n(ii) regardless of whether X collected that clinical\ninformation from the national electronic records\n20system or obtained that clinical information by any\nother means.\n(6) Health information about an individual is\n“individually‑identifiable health information” for the purposes of\nthis Act if the individual can be identified by a person —\n25(a) from that health information alone; or\n(b) from that health information and other information to\nwhich that person has or is likely to have access.\n(7) Health information about an individual is “anonymised health\ninformation” for the purposes of this Act if it is not\n30individually‑identifiable health information.\n13",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p14_c54",
+      "text": "n aboutP made available on the national\nelectronic records system; and\n(ii) regardless of whether X collected that clinical\ninformation from the national electronic records\n20system or obtained that clinical information by any\nother means.\n(6) Health information about an individual is\n“individually‑identifiable health information” for the purposes of\nthis Act if the individual can be identified by a person —\n25(a) from that health information alone; or\n(b) from that health information and other information to\nwhich that person has or is likely to have access.\n(7) Health information about an individual is “anonymised health\ninformation” for the purposes of this Act if it is not\n30individually‑identifiable health information.\n13",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 14,
@@ -96678,8 +97198,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p15_c15",
-      "text": "16 NO. 1 OF 2026\nPurposes of Act\n4. The purposes of this Act are —\n(a) to provide for the collection, storage and disclosure of\nhealth information about individuals using the national\n5 electronic records system, including providing for —\n(i) the contribution of health information about\nindividuals to the national electronic records system;\n(ii) the access and collection of health information about\nindividuals that is made available on the national\n10 electronic records system for or in relation to the\nprovision of healthcare services and other purposes\npermitted under this Act; and\n(iii) the access, collection, disclosure and use of\ninformation derived from health information about\n15 individuals in the national electronic records system\nfor purposes permitted under this Act;\n(b) to provide a framework to facilitate the sharing of\nindividually‑identifiable information about individuals\n",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p15_c55",
+      "text": "16 NO. 1 OF 2026\nPurposes of Act\n4. The purposes of this Act are —\n(a) to provide for the collection, storage and disclosure of\nhealth information about individuals using the national\n5 electronic records system, including providing for —\n(i) the contribution of health information about\nindividualstothenationalelectronicrecordssystem;\n(ii) theaccessandcollectionofhealthinformationabout\nindividuals that is made available on the national\n10 electronic records system for or in relation to the\nprovision of healthcare services and other purposes\npermitted under this Act; and\n(iii) the access, collection, disclosure and use of\ninformation derived from health information about\n15 individuals in the national electronic records system\nfor purposes permitted under this Act;\n(b) to provide a framework to facilitate the sharing of\nindividually‑identifiable information about individuals\nfor purposes ",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 15,
@@ -96691,8 +97211,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p15_c16",
-      "text": "or purposes permitted under this Act;\n(b) to provide a framework to facilitate the sharing of\nindividually‑identifiable information about individuals\nfor purposes relating to —\n20 (i) the provision of healthcare services and community\nhealth services; and\n(ii) the implementation and facilitation of programmes\nand schemes to maintain or improve the physical or\nmental health and wellbeing of individuals; and\n25 (c) to ensure that the confidentiality, integrity and availability\nof health information and relevant information about\nindividuals is protected.\nApplication of Act\n5.—(1) Except as provided in subsection (2), the following\n30 provisions of this Act apply to the Government:\n(a) Part 3, except section 58;\n(b) sections 12, 13, 14, 16, 18, 19, 20, 21, 22, 25, 26 and 27.\n14",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p15_c56",
+      "text": "ermitted under this Act;\n(b) to provide a framework to facilitate the sharing of\nindividually‑identifiable information about individuals\nfor purposes relating to —\n20 (i) the provision of healthcare services and community\nhealth services; and\n(ii) the implementation and facilitation of programmes\nand schemes to maintain or improve the physical or\nmental health and wellbeing of individuals; and\n25 (c) to ensure that the confidentiality, integrity and availability\nof health information and relevant information about\nindividuals is protected.\nApplication of Act\n5.—(1) Except as provided in subsection (2), the following\n30 provisions of this Act apply to the Government:\n(a) Part 3, except section 58;\n(b) sections 12, 13, 14, 16, 18, 19, 20, 21, 22, 25, 26 and 27.\n14",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 15,
@@ -96704,8 +97224,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p16_c17",
-      "text": "HEALTH INFORMATION 17\n(2) Nothing in this Act renders the Government liable for\nprosecution for an offence under this Act.\n(3) To avoid doubt, a person is not immune from prosecution for\nany offence under this Act by reason only that the person —\n5(a) is employed by, seconded to or engaged to provide services\nto the Government; or\n(b) provides, as a volunteer, any service —\n(i) to the Government; or\n(ii) to any other person acting on behalf of the\n10Government.\n(4) Unless otherwise expressly provided in this Act, nothing in this\nAct affects any authority, right, privilege or immunity conferred, or\nany obligation or limitation imposed, by or under any other written\nlaw or any rule of law, contract or rule of professional conduct or\n15ethics.\nPART 2\nNA TIONAL ELECTRONIC RECORDS SYSTEM\nDivision 1 — General\nInterpretation of this Part\n206. In this Part —\n“derived information” means health in",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p16_c57",
+      "text": "HEALTH INFORMATION 17\n(2) Nothing in this Act renders the Government liable for\nprosecution for an offence under this Act.\n(3) To avoid doubt, a person is not immune from prosecution for\nany offence under this Act by reason only that the person —\n5(a) isemployedby,secondedtoorengagedtoprovideservices\nto the Government; or\n(b) provides, as a volunteer, any service —\n(i) to the Government; or\n(ii) to any other person acting on behalf of the\n10Government.\n(4) Unless otherwise expressly provided in this Act, nothing in this\nAct affects any authority, right, privilege or immunity conferred, or\nany obligation or limitation imposed, by or under any other written\nlaw or any rule of law, contract or rule of professional conduct or\n15ethics.\nPART 2\nNATIONAL ELECTRONIC RECORDS SYSTEM\nDivision 1 — General\nInterpretation of this Part\n206. In this Part —\n“derived information” means health information ",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 16,
@@ -96717,8 +97237,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p16_c18",
-      "text": "\nPART 2\nNA TIONAL ELECTRONIC RECORDS SYSTEM\nDivision 1 — General\nInterpretation of this Part\n206. In this Part —\n“derived information” means health information that is derived\nfrom accessible health information about one or more\nindividuals, and includes an extract or a copy of any such\naccessible health information;\n25“enlisted personnel” means an individual who —\n(a) is a person mentioned in section 3 of the Singapore\nArmed Forces Act 1972; or\n(b) is appointed to, or is enlisted or deemed to be enlisted\nin, the Singapore Civil Defence Force constituted\n30under the Civil Defence Act 1986;\n15",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p16_c58",
+      "text": "ATIONAL ELECTRONIC RECORDS SYSTEM\nDivision 1 — General\nInterpretation of this Part\n206. In this Part —\n“derived information” means health information that is derived\nfrom accessible health information about one or more\nindividuals, and includes an extract or a copy of any such\naccessible health information;\n25“enlisted personnel” means an individual who —\n(a) is a person mentioned in section 3 of the Singapore\nArmed Forces Act 1972; or\n(b) isappointedto,orisenlistedordeemedtobeenlisted\nin, the Singapore Civil Defence Force constituted\n30under the Civil Defence Act 1986;\n15",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 16,
@@ -96730,8 +97250,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p17_c19",
-      "text": "18 NO. 1 OF 2026\n“excluded purpose”, in relation to the access or collection of\naccessible health information about an individual (P), means\nany of the following purposes:\n(a) determining P’s suitability or eligibility for —\n5 (i) employment or appointment to office;\n(ii) promotion in employment or office or\ncontinuance in employment or office; or\n(iii) removal from employment or office;\n(b) determining P’s suitability or eligibility to be\n10 engaged by any person under a contract for\nservices and the terms on which P is so engaged;\n(c) determining whether —\n(i) P’s engagement by any person under a contract\nfor services should be terminated; or\n15 (ii) the terms of a contract for services between P\nand any person should be modified;\n(d) determining P’s suitability or eligibility to enter into\na platform work agreement with any platform\noperator and the terms of any such platform work\n20 ",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p17_c59",
+      "text": "18 NO. 1 OF 2026\n“excluded purpose”, in relation to the access or collection of\naccessible health information about an individual (P), means\nany of the following purposes:\n(a) determining P’s suitability or eligibility for —\n5 (i) employment or appointment to office;\n(ii) promotion in employment or office or\ncontinuance in employment or office; or\n(iii) removal from employment or office;\n(b) determining P’s suitability or eligibility to be\n10 engaged by any person under a contract for\nservices and the terms on whichP is so engaged;\n(c) determining whether —\n(i) P’sengagementbyanypersonunderacontract\nfor services should be terminated; or\n15 (ii) the terms of a contract for services betweenP\nand any person should be modified;\n(d) determining P’s suitability or eligibility to enter into\na platform work agreement with any platform\noperator and the terms of any such platform work\n20 agreement",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 17,
@@ -96743,8 +97263,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p17_c20",
-      "text": "ermining P’s suitability or eligibility to enter into\na platform work agreement with any platform\noperator and the terms of any such platform work\n20 agreement;\n(e) where P is a platform worker, determining\nwhether —\n(i) a platform work agreement between P and any\nplatform operator should be terminated; or\n25 (ii) the terms of a platform work agreement\nbetween P and any platform operator should\nbe modified;\n(f) deciding whether to insure P or any other individual,\nor to continue or renew the insurance (whether on the\n30 same or different terms) of P or any other individual;\n16",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p17_c60",
+      "text": "P’s suitability or eligibility to enter into\na platform work agreement with any platform\noperator and the terms of any such platform work\n20 agreement;\n(e) where P is a platform worker, determining\nwhether —\n(i) a platform work agreement betweenP and any\nplatform operator should be terminated; or\n25 (ii) the terms of a platform work agreement\nbetween P and any platform operator should\nbe modified;\n(f) deciding whether to insurePor any other individual,\nortocontinueorrenewtheinsurance(whetheronthe\n30 same ordifferent terms)ofPor any otherindividual;\n16",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 17,
@@ -96756,8 +97276,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p18_c21",
-      "text": "HEALTH INFORMATION 19\n(g) making a claim on the insurance of P or any other\nindividual, or processing a claim made on the\ninsurance of P or any other individual;\n(h) any other purpose that may be prescribed;\n5“platform operator” has the meaning given by section 4(1) of the\nPlatform Workers Act 2024;\n“platform work agreement” has the meaning given by section 2\nof the Platform Workers Act 2024;\n“platform worker” has the meaning given by section 5(1) of the\n10Platform Workers Act 2024;\n“requestor” means a person who is approved to obtain derived\ninformation under section 25(2) or (3);\n“specified purpose”, in relation to the access or collection of\naccessible health information about any individual, means a\n15purpose mentioned in section 19(2).\nNational electronic records system\n7.—(1) For the purposes of this Act, “national electronic records\nsystem” means the computer system established by",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p18_c61",
+      "text": "HEALTH INFORMATION 19\n(g) making a claim on the insurance ofP or any other\nindividual, or processing a claim made on the\ninsurance ofP or any other individual;\n(h) any other purpose that may be prescribed;\n5“platformoperator”hasthemeaninggivenbysection4(1)ofthe\nPlatform Workers Act 2024;\n“platform work agreement” has the meaning given by section 2\nof the Platform Workers Act 2024;\n“platform worker” has the meaning given by section 5(1) of the\n10Platform Workers Act 2024;\n“requestor” means a person who is approved to obtain derived\ninformation under section 25(2) or (3);\n“specified purpose”, in relation to the access or collection of\naccessible health information about any individual, means a\n15purpose mentioned in section 19(2).\nNational electronic records system\n7.—(1) For the purposes of this Act, “national electronic records\nsystem” means the computer system established by the Governm",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 18,
@@ -96769,8 +97289,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p18_c22",
-      "text": "\nNational electronic records system\n7.—(1) For the purposes of this Act, “national electronic records\nsystem” means the computer system established by the Government\nfor the collection, storage and disclosure of health information about\n20individuals and operated by a System Operator in accordance with\nthis Part, and which comprises —\n(a) the repository of that health information; and\n(b) the electronic means that is operated, maintained and used\nfor the collection, storage and disclosure of that health\n25information.\n(2) The national electronic records system includes the computer\nservers and network equipment operated, maintained or used by a\nSystem Operator for the purposes of or in relation to the computer\nsystem mentioned in subsection (1), whether or not the computer\n30servers and network equipment are owned by the System Operator.\n17",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p18_c62",
+      "text": "ectronic records system\n7.—(1) For the purposes of this Act, “national electronic records\nsystem” means the computer system established by the Government\nfor the collection, storage and disclosure of health information about\n20individuals and operated by a System Operator in accordance with\nthis Part, and which comprises —\n(a) the repository of that health information; and\n(b) the electronic means that is operated, maintained and used\nfor the collection, storage and disclosure of that health\n25information.\n(2) The national electronic records system includes the computer\nservers and network equipment operated, maintained or used by a\nSystem Operator for the purposes of or in relation to the computer\nsystem mentioned in subsection (1), whether or not the computer\n30servers and network equipment are owned by the System Operator.\n17",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 18,
@@ -96782,8 +97302,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p19_c23",
-      "text": "20 NO. 1 OF 2026\nSystem Operator\n8.—(1) The Minister may, by order in the Gazette, designate any\nperson as a System Operator to operate, administer and maintain the\nnational electronic records system.\n5 (2) To avoid doubt, the operation, administration and maintenance\nof the national electronic records system include —\n(a) the collection of health information contributed by\ncontributors in accordance with this Part;\n(b) the making available, in accordance with this Part, of —\n10 (i) accessible health information to users; and\n(ii) derived information to requestors; and\n(c) the processing of health information for the purposes of\nand in accordance with this Act.\n(3) A System Operator must operate, administer and maintain the\n15 national electronic records system in accordance with any directions\ngiven by the Minister.\nApplication of this Part to contributors, etc., acting through\nrelevant",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p19_c63",
+      "text": "20 NO. 1 OF 2026\nSystem Operator\n8.—(1) The Minister may, by order in theGazette, designate any\nperson as a System Operator to operate, administer and maintain the\nnational electronic records system.\n5 (2) To avoid doubt, the operation, administration and maintenance\nof the national electronic records system include —\n(a) the collection of health information contributed by\ncontributors in accordance with this Part;\n(b) the making available, in accordance with this Part, of —\n10 (i) accessible health information to users; and\n(ii) derived information to requestors; and\n(c) the processing of health information for the purposes of\nand in accordance with this Act.\n(3) A System Operator must operate, administer and maintain the\n15 national electronic records system in accordance with any directions\ngiven by the Minister.\nApplication of this Part to contributors, etc., acting through\nrelevant ",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 19,
@@ -96795,8 +97315,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p19_c24",
-      "text": "tronic records system in accordance with any directions\ngiven by the Minister.\nApplication of this Part to contributors, etc., acting through\nrelevant HDI or directly\n9.—(1) This Part applies equally to both a contributor who\n20 contributes health information through a relevant HDI, and a\ncontributor who contributes health information directly.\n(2) This Part applies equally to both a user who accesses or collects\naccessible health information through a relevant HDI, and a user who\naccesses or collects accessible health information directly.\n25 (3) This Part applies equally to both a requestor who obtains\nderived information through a relevant HDI, and a requestor who\nobtains derived information directly.\nHealth information to which this Part applies\n10.—(1) This Part applies to and in relation to health information\n30 about any individual who —\n(a) is a citizen or permanent resident of S",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p19_c64",
+      "text": "ronic records system in accordance with any directions\ngiven by the Minister.\nApplication of this Part to contributors, etc., acting through\nrelevant HDI or directly\n9.—(1) This Part applies equally to both a contributor who\n20 contributes health information through a relevant HDI, and a\ncontributor who contributes health information directly.\n(2) ThisPartappliesequallytobothauserwhoaccessesorcollects\naccessiblehealthinformationthrougharelevantHDI,andauserwho\naccesses or collects accessible health information directly.\n25 (3) This Part applies equally to both a requestor who obtains\nderived information through a relevant HDI, and a requestor who\nobtains derived information directly.\nHealth information to which this Part applies\n10.—(1) This Part applies to and in relation to health information\n30 about any individual who —\n(a) is a citizen or permanent resident of Singapore;\n18",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 19,
@@ -96808,21 +97328,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p19_c25",
-      "text": "t applies\n10.—(1) This Part applies to and in relation to health information\n30 about any individual who —\n(a) is a citizen or permanent resident of Singapore;\n18",
-      "metadata": {
-        "source": "health-information-act-2026.pdf",
-        "page": 19,
-        "category": "sg-hia",
-        "jurisdiction": "SG",
-        "document_id": "sg-hia",
-        "framework": "HIA",
-        "content_type": "primary"
-      }
-    },
-    {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p20_c26",
-      "text": "HEALTH INFORMATION 21\n(b) is issued with a foreign identification number; or\n(c) belongs to any other class of individuals that may be\nprescribed.\n(2) In subsection (1)(a), “permanent resident of Singapore” has the\n5meaning given by section 2 of the Immigration Act 1959.\nConsent of individual not required for purposes of this Part\n11.—(1) Despite any other written law or rule of law, or any\nobligation under contract, the consent of an individual (P) is not\nrequired for any of the following that is done in accordance with and\n10for the purposes of this Part:\n(a) the contribution of health information about P;\n(b) the access, collection and disclosure of accessible health\ninformation about P;\n(c) the access, collection, disclosure and use of derived\n15information derived from accessible health information\nabout P.\n(2) Nothing in this Part allows a person to access, collect, disclose\nor use",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p20_c65",
+      "text": "HEALTH INFORMATION 21\n(b) is issued with a foreign identification number; or\n(c) belongs to any other class of individuals that may be\nprescribed.\n(2) In subsection (1)(a), “permanent resident of Singapore” has the\n5meaning given by section 2 of the Immigration Act 1959.\nConsent of individual not required for purposes of this Part\n11.—(1) Despite any other written law or rule of law, or any\nobligation under contract, the consent of an individual (P) is not\nrequired for any of the following that is done in accordance with and\n10for the purposes of this Part:\n(a) the contribution of health information aboutP;\n(b) the access, collection and disclosure of accessible health\ninformation aboutP;\n(c) the access, collection, disclosure and use of derived\n15information derived from accessible health information\nabout P.\n(2) Nothing in this Part allows a person to access, collect, disclose\nor use a",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 20,
@@ -96834,8 +97341,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p20_c27",
-      "text": "derived\n15information derived from accessible health information\nabout P.\n(2) Nothing in this Part allows a person to access, collect, disclose\nor use accessible health information about an individual on the basis\nthat the individual consents or has consented to the person accessing,\n20collecting, disclosing or using (as the case may be) the accessible\nhealth information.\nDivision 2 — Contribution of health information\nContribution by specified contributors\n12.—(1) A person (called a specified contributor) that is —\n25(a) an HCSA licensee specified in, or belonging to a class of\nHCSA licensees specified in, the first column of Part 1 of\nthe First Schedule;\n(b) a retail pharmacy licensee specified in, or belonging to a\nclass of retail pharmacy licensees specified in, the\n30first column of Part 1 of the First Schedule; or\n19",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p20_c66",
+      "text": "rived\n15information derived from accessible health information\nabout P.\n(2) Nothing in this Part allows a person to access, collect, disclose\nor use accessible health information about an individual on the basis\nthattheindividualconsentsorhasconsentedtothepersonaccessing,\n20collecting, disclosing or using (as the case may be) the accessible\nhealth information.\nDivision 2 — Contribution of health information\nContribution by specified contributors\n12.—(1) A person (called a specified contributor) that is —\n25(a) an HCSA licensee specified in, or belonging to a class of\nHCSA licensees specified in, the first column of Part 1 of\nthe First Schedule;\n(b) a retail pharmacy licensee specified in, or belonging to a\nclass of retail pharmacy licensees specified in, the\n30first column of Part 1 of the First Schedule; or\n19",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 20,
@@ -96847,8 +97354,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p21_c28",
-      "text": "22 NO. 1 OF 2026\n(c) a person (other than an HCSA licensee or a retail pharmacy\nlicensee) or public agency specified in, or belonging to a\nclass of persons or public agencies specified in, the\nfirst column of Part 1 of the First Schedule,\n5 must contribute health information about any individual in\naccordance with this Part.\n(2) An HCSA licensee mentioned in subsection (1)(a) must\ncontribute the types of health information specified opposite the\nHCSA licensee in the second column of Part 1 of the First Schedule\n10 about any individual who is a patient of the HCSA licensee.\n(3) A retail pharmacy licensee mentioned in subsection (1)(b) must\ncontribute the types of health information specified opposite the retail\npharmacy licensee in the second column of Part 1 of the\nFirst Schedule about any individual to whom a qualified\n15 pharmacist employed or engaged by the retail pharmacy licensee\nse",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p21_c67",
+      "text": "22 NO. 1 OF 2026\n(c) aperson(otherthananHCSAlicenseeoraretailpharmacy\nlicensee) or public agency specified in, or belonging to a\nclass of persons or public agencies specified in, the\nfirst column of Part 1 of the First Schedule,\n5 must contribute health information about any individual in\naccordance with this Part.\n(2) An HCSA licensee mentioned in subsection (1)(a) must\ncontribute the types of health information specified opposite the\nHCSA licensee in the second column of Part 1 of the First Schedule\n10 about any individual who is a patient of the HCSA licensee.\n(3) Aretailpharmacylicenseementionedinsubsection(1)(b)must\ncontributethetypesofhealthinformationspecifiedoppositetheretail\npharmacy licensee in the second column of Part 1 of the\nFirst Schedule about any individual to whom a qualified\n15 pharmacist employed or engaged by the retail pharmacy licensee\nsells or dispenses any health",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 21,
@@ -96860,8 +97367,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p21_c29",
-      "text": "d column of Part 1 of the\nFirst Schedule about any individual to whom a qualified\n15 pharmacist employed or engaged by the retail pharmacy licensee\nsells or dispenses any health product.\n(4) A person or public agency (X) mentioned in subsection (1)(c)\nmust contribute the health information specified opposite X in the\nsecond column of Part 1 of the First Schedule about any individual to\n20 whom X, or any individual employed or engaged by X or any enlisted\npersonnel of X, provides any healthcare service or community health\nservice.\nContribution by approved contributors\n13.—(1) The Minister may approve any person or public agency to\n25 contribute health information about any individual in accordance\nwith this Part.\n(2) The Minister must, as soon as is practicable after a person or\npublic agency is approved as an approved contributor, publish a\nnotification in the Gazette specifying all of t",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p21_c68",
+      "text": "irst Schedule about any individual to whom a qualified\n15 pharmacist employed or engaged by the retail pharmacy licensee\nsells or dispenses any health product.\n(4) A person or public agency (X) mentioned in subsection (1)(c)\nmust contribute the health information specified oppositeX in the\nsecondcolumnofPart1oftheFirstScheduleaboutanyindividualto\n20 whomX,oranyindividualemployedorengagedby Xoranyenlisted\npersonnel ofX, provides any healthcare service or community health\nservice.\nContribution by approved contributors\n13.—(1) TheMinistermayapproveanypersonorpublicagency to\n25 contribute health information about any individual in accordance\nwith this Part.\n(2) The Minister must, as soon as is practicable after a person or\npublic agency is approved as an approved contributor, publish a\nnotification in theGazette specifying all of the following:\n30 (a) theclassorclassesofindividualswhosehealt",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 21,
@@ -96873,8 +97380,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p21_c30",
-      "text": "on as is practicable after a person or\npublic agency is approved as an approved contributor, publish a\nnotification in the Gazette specifying all of the following:\n30 (a) the class or classes of individuals whose health information\nthe approved contributor may contribute;\n(b) subject to subsection (3), the types of health information\nthat the approved contributor may contribute;\n20",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p21_c69",
+      "text": "oved as an approved contributor, publish a\nnotification in theGazette specifying all of the following:\n30 (a) theclassorclassesofindividualswhosehealthinformation\nthe approved contributor may contribute;\n(b) subject to subsection (3), the types of health information\nthat the approved contributor may contribute;\n20",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 21,
@@ -96886,8 +97393,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p22_c31",
-      "text": "HEALTH INFORMATION 23\n(c) the conditions and restrictions (if any) that the approved\ncontributor must comply with in relation to the\ncontribution of health information.\n(3) Where a person or public agency, at the time the person or\n5public agency is approved under subsection (1), is concurrently a\nspecified contributor, the types of health information mentioned in\nsubsection (2)(b) must not include any type of health information that\nthe person or public agency is required to contribute in accordance\nwith section 12.\n10(4) An approved contributor must, in relation to the contribution of\nhealth information under this section, comply with all conditions and\nrestrictions mentioned in subsection (2)(c), if applicable.\n(5) The Minister may, by written notice at any time, revoke the\napproval of an approved contributor.\n15Obligations of contributors\n14.—(1) In addition to the conditions and res",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p22_c70",
+      "text": "HEALTH INFORMATION 23\n(c) the conditions and restrictions (if any) that the approved\ncontributor must comply with in relation to the\ncontribution of health information.\n(3) Where a person or public agency, at the time the person or\n5public agency is approved under subsection (1), is concurrently a\nspecified contributor, the types of health information mentioned in\nsubsection(2)(b)mustnotincludeanytypeofhealthinformationthat\nthe person or public agency is required to contribute in accordance\nwith section 12.\n10(4) An approved contributor must, in relation to the contribution of\nhealthinformationunderthissection,complywithall conditionsand\nrestrictions mentioned in subsection (2)(c), if applicable.\n(5) The Minister may, by written notice at any time, revoke the\napproval of an approved contributor.\n15Obligations of contributors\n14.—(1) Inadditionto theconditions andrestrictionsmentioned in\n",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 22,
@@ -96899,8 +97406,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p22_c32",
-      "text": "ritten notice at any time, revoke the\napproval of an approved contributor.\n15Obligations of contributors\n14.—(1) In addition to the conditions and restrictions mentioned in\nsection 13(2)(c) (if applicable), a contributor must comply with all\nrequirements, conditions and restrictions relating to the contribution\nof health information that may be prescribed.\n20(2) Without limiting subsection (1), the requirements, conditions\nand restrictions mentioned in that subsection include the following:\n(a) requirements relating to —\n(i) the format in which the health information is to be\ncontributed; or\n25(ii) the software (including any Application\nProgramming Interface) that a contributor or a\nrelevant HDI of a contributor is to use in or for\nany computer or computer system that interconnects\nwith the national electronic records system;\n30(b) requirements relating to the accuracy and completeness ",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p22_c71",
+      "text": "ny time, revoke the\napproval of an approved contributor.\n15Obligations of contributors\n14.—(1) Inadditionto theconditions andrestrictionsmentioned in\nsection 13(2)(c) (if applicable), a contributor must comply with all\nrequirements, conditions and restrictions relating to the contribution\nof health information that may be prescribed.\n20(2) Without limiting subsection (1), the requirements, conditions\nand restrictions mentioned in that subsection include the following:\n(a) requirements relating to —\n(i) the format in which the health information is to be\ncontributed; or\n25(ii) the software (including any Application\nProgramming Interface) that a contributor or a\nrelevant HDI of a contributor is to use in or for\nany computer or computer system that interconnects\nwith the national electronic records system;\n30(b) requirements relating to the accuracy and completeness of\nhealth information t",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 22,
@@ -96912,8 +97419,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p22_c33",
-      "text": "puter or computer system that interconnects\nwith the national electronic records system;\n30(b) requirements relating to the accuracy and completeness of\nhealth information that is or is to be contributed;\n21",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p22_c72",
+      "text": "m that interconnects\nwith the national electronic records system;\n30(b) requirements relating to the accuracy and completeness of\nhealth information that is or is to be contributed;\n21",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 22,
@@ -96925,7 +97432,7 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p23_c34",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p23_c73",
       "text": "24 NO. 1 OF 2026\n(c) the time at which or period within which the contributor is\nto contribute health information;\n(d) any computer or computer system, or any website, that the\ncontributor may use to contribute health information.\n5 (3) For the purposes of subsection (1), different requirements,\nconditions or restrictions may be prescribed in relation to different\ncontributors or classes of contributors and different types of health\ninformation.\n(4) A contributor must comply with every administrative\n10 instruction or technical requirement of a System Operator in\nrelation to the contribution of health information.\nDirections relating to contribution of health information\n15.—(1) If a specified contributor fails or neglects to contribute\nhealth information about one or more individuals in accordance with\n15 section 12(2), (3) or (4), the Minister may, by written notice, direct\nthe specifi",
       "metadata": {
         "source": "health-information-act-2026.pdf",
@@ -96938,8 +97445,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p23_c35",
-      "text": "lth information about one or more individuals in accordance with\n15 section 12(2), (3) or (4), the Minister may, by written notice, direct\nthe specified contributor to contribute the health information about\nthat individual or those individuals within the time and in the form\nand manner specified by the Minister.\n(2) If a specified contributor fails or neglects to comply with —\n20 (a) any requirement, condition or restriction mentioned in\nsection 14(1); or\n(b) any administrative instruction or technical requirement of a\nSystem Operator mentioned in section 14(4),\nthe Minister may, by written notice, direct the specified contributor to\n25 comply with the requirement, condition, restriction, administrative\ninstruction or technical requirement (as the case may be) within the\ntime and in the form and manner specified by the Minister.\n(3) If an approved contributor fails or neglects to comply",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p23_c74",
+      "text": "lth information about one or more individuals in accordance with\n15 section 12(2), (3) or (4), the Minister may, by written notice, direct\nthe specified contributor to contribute the health information about\nthat individual or those individuals within the time and in the form\nand manner specified by the Minister.\n(2) If a specified contributor fails or neglects to comply with —\n20 (a) any requirement, condition or restriction mentioned in\nsection 14(1); or\n(b) anyadministrativeinstructionortechnicalrequirementofa\nSystem Operator mentioned in section 14(4),\ntheMinistermay,bywrittennotice,directthespecifiedcontributorto\n25 comply with the requirement, condition, restriction, administrative\ninstruction or technical requirement (as the case may be) within the\ntime and in the form and manner specified by the Minister.\n(3) If an approved contributor fails or neglects to comply with —\n(a) any c",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 23,
@@ -96951,8 +97458,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p23_c36",
-      "text": " (as the case may be) within the\ntime and in the form and manner specified by the Minister.\n(3) If an approved contributor fails or neglects to comply with —\n(a) any condition or restriction mentioned in section 13(2)(c);\n30 (b) any requirement, condition or restriction mentioned in\nsection 14(1); or\n22",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p23_c75",
+      "text": " be) within the\ntime and in the form and manner specified by the Minister.\n(3) If an approved contributor fails or neglects to comply with —\n(a) any condition or restriction mentioned in section 13(2)(c);\n30 (b) any requirement, condition or restriction mentioned in\nsection 14(1); or\n22",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 23,
@@ -96964,8 +97471,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p24_c37",
-      "text": "HEALTH INFORMATION 25\n(c) any administrative instruction or technical requirement of a\nSystem Operator mentioned in section 14(4),\nthe Minister may, by written notice, direct the approved contributor to\ncomply with the requirement, condition, restriction, administrative\n5instruction or technical requirement (as the case may be) within the\ntime and in the form and manner specified by the Minister.\n(4) A person who, without reasonable excuse, fails to comply with\nthe Minister’s direction under subsection (1), (2) or (3) shall be guilty\nof an offence and shall be liable on conviction to a fine not exceeding\n10$20,000 or to imprisonment for a term not exceeding 12 months or to\nboth and, in the case of a continuing offence, to a further fine not\nexceeding $1,000 for every day or part of a day during which the\noffence continues after conviction.\nDivision 3 — Access, collection and disclosure o",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p24_c76",
+      "text": "HEALTH INFORMATION 25\n(c) anyadministrativeinstructionortechnicalrequirementofa\nSystem Operator mentioned in section 14(4),\ntheMinistermay,bywrittennotice,directtheapprovedcontributorto\ncomply with the requirement, condition, restriction, administrative\n5instruction or technical requirement (as the case may be) within the\ntime and in the form and manner specified by the Minister.\n(4) A person who, without reasonable excuse, fails to comply with\ntheMinister’sdirectionundersubsection(1),(2)or(3)shallbeguilty\nofanoffenceandshallbeliableonconvictiontoafinenotexceeding\n10$20,000ortoimprisonmentforatermnotexceeding12monthsorto\nboth and, in the case of a continuing offence, to a further fine not\nexceeding $1,000 for every day or part of a day during which the\noffence continues after conviction.\nDivision 3 — Access, collection and disclosure of\n15accessible health information\nRestriction on acce",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 24,
@@ -96977,8 +97484,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p24_c38",
-      "text": "\nexceeding $1,000 for every day or part of a day during which the\noffence continues after conviction.\nDivision 3 — Access, collection and disclosure of\n15accessible health information\nRestriction on access, collection or disclosure of accessible\nhealth information\n16.—(1) A person may access, collect or disclose accessible health\ninformation about an individual only if the access, collection or\n20disclosure —\n(a) is carried out in accordance with this Part; or\n(b) is required or permitted under any other written law.\n(2) Access, collection or disclosure of accessible health information\nabout an individual is not considered to be required or permitted\n25under any written law merely because the individual has consented or\nhas given his or her consent to it in accordance with Part 4 of the\nPersonal Data Protection Act 2012, or such consent is not required\nunder that Part.\nAccess and collect",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p24_c77",
+      "text": "ng which the\noffence continues after conviction.\nDivision 3 — Access, collection and disclosure of\n15accessible health information\nRestriction on access, collection or disclosure of accessible\nhealth information\n16.—(1) Aperson may access, collect or disclose accessible health\ninformation about an individual only if the access, collection or\n20disclosure —\n(a) is carried out in accordance with this Part; or\n(b) is required or permitted under any other written law.\n(2) Access,collectionordisclosureofaccessiblehealthinformation\nabout an individual is not considered to be required or permitted\n25underanywrittenlawmerelybecausetheindividualhasconsentedor\nhas given his or her consent to it in accordance with Part 4 of the\nPersonal Data Protection Act 2012, or such consent is not required\nunder that Part.\nAccess and collection of individual’s own accessible health\n30information\n17.—(1) Anindiv",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 24,
@@ -96990,8 +97497,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p24_c39",
-      "text": " consent to it in accordance with Part 4 of the\nPersonal Data Protection Act 2012, or such consent is not required\nunder that Part.\nAccess and collection of individual’s own accessible health\n30information\n17.—(1) An individual (P) or an authorised representative of P may\naccess and collect accessible health information about P in any\nmanner prescribed.\n23",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p24_c78",
+      "text": "n Act 2012, or such consent is not required\nunder that Part.\nAccess and collection of individual’s own accessible health\n30information\n17.—(1) Anindividual(P)oranauthorisedrepresentativeof Pmay\naccess and collect accessible health information about P in any\nmanner prescribed.\n23",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 24,
@@ -97003,8 +97510,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p25_c40",
-      "text": "26 NO. 1 OF 2026\n(2) In subsection (1), an authorised representative of P means any\nof the following persons:\n(a) if P is an individual who has not attained 21 years of age —\nP’s parent, adoptive parent, step‑parent or guardian;\n5 (b) if P lacks capacity within the meaning given by section 4 of\nthe Mental Capacity Act 2008 —\n(i) a deputy appointed or deemed to be appointed for P\nby the court under that Act with power in relation to\nP’s personal welfare;\n10 (ii) a donee under a lasting power of attorney registered\nunder that Act with power in relation to P’s personal\nwelfare; or\n(iii) where there is no deputy mentioned in\nsub‑paragraph (i) or donee mentioned in\n15 sub‑paragraph (ii), an individual who is 21 years of\nage or older and is —\n(A) P’s spouse;\n(B) a son or daughter of P;\n(C) P’s parent, adoptive parent, step‑parent or\n20 guardian;\n(D) a brother or sister of P; or\n(E) any other p",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p25_c79",
+      "text": "26 NO. 1 OF 2026\n(2) In subsection (1), an authorised representative ofP means any\nof the following persons:\n(a) ifPisanindividualwhohasnotattained21yearsofage—\nP’s parent, adoptive parent, step‑parent or guardian;\n5 (b) ifPlackscapacitywithinthemeaninggivenbysection4of\nthe Mental Capacity Act 2008 —\n(i) a deputy appointed or deemed to be appointed forP\nby the court under that Act with power in relation to\nP’s personal welfare;\n10 (ii) a donee under a lasting power of attorney registered\nunder that Act with power in relation toP’s personal\nwelfare; or\n(iii) where there is no deputy mentioned in\nsub‑paragraph (i) or donee mentioned in\n15 sub‑paragraph (ii), an individual who is 21 years of\nage or older and is —\n(A) P’s spouse;\n(B) a son or daughter ofP;\n(C) P’s parent, adoptive parent, step‑parent or\n20 guardian;\n(D) a brother or sister ofP; or\n(E) any other person who is responsible for ",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 25,
@@ -97016,8 +97523,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p25_c41",
-      "text": " P’s spouse;\n(B) a son or daughter of P;\n(C) P’s parent, adoptive parent, step‑parent or\n20 guardian;\n(D) a brother or sister of P; or\n(E) any other person who is responsible for the\ncare and wellbeing of P;\n(c) if P is an individual who is 21 years of age or older and\n25 does not lack capacity within the meaning given by\nsection 4 of the Mental Capacity Act 2008 — an individual\nwhom P has authorised to act on P’s behalf to access and\ncollect accessible health information about P.\n(3) A System Operator must comply with any directions given by\n30 the Minister in relation to the type or types of accessible health\ninformation about P that P or an authorised representative of P may\naccess and collect under subsection (1).\n24",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p25_c80",
+      "text": "aughter ofP;\n(C) P’s parent, adoptive parent, step‑parent or\n20 guardian;\n(D) a brother or sister ofP; or\n(E) any other person who is responsible for the\ncare and wellbeing ofP;\n(c) if P is an individual who is 21 years of age or older and\n25 does not lack capacity within the meaning given by\nsection4oftheMentalCapacityAct2008—anindividual\nwhom P has authorised to act onP’s behalf to access and\ncollect accessible health information aboutP.\n(3) A System Operator must comply with any directions given by\n30 the Minister in relation to the type or types of accessible health\ninformation aboutP that P or an authorised representative ofP may\naccess and collect under subsection (1).\n24",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 25,
@@ -97029,8 +97536,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p26_c42",
-      "text": "HEALTH INFORMATION 27\nAuthorised individuals of users\n18.—(1) For the purposes of this Part, “authorised individual” of a\nspecified user means any individual who —\n(a) is any of the following:\n5(i) an individual who is employed or engaged by the\nspecified user;\n(ii) an enlisted personnel of the specified user;\n(iii) an individual who provides, as a volunteer, any\nservice to the specified user or to any other person\n10acting on behalf of the specified user;\n(b) is specified, or belongs to any class of individuals specified\nopposite the specified user in the second column of Part 1\nof the Second Schedule;\n(c) is authorised by the specified user to access and collect\n15accessible health information about any individual in the\nordinary course of the individual’s duties for the specified\nuser; and\n(d) is approved by a System Operator.\n(2) For the purposes of this Part, “authorised individual”",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p26_c81",
+      "text": "HEALTH INFORMATION 27\nAuthorised individuals of users\n18.—(1) For the purposes of this Part, “authorised individual” of a\nspecified user means any individual who —\n(a) is any of the following:\n5(i) an individual who is employed or engaged by the\nspecified user;\n(ii) an enlisted personnel of the specified user;\n(iii) an individual who provides, as a volunteer, any\nservice to the specified user or to any other person\n10acting on behalf of the specified user;\n(b) isspecified,orbelongstoanyclassofindividualsspecified\nopposite the specified user in the second column of Part 1\nof the Second Schedule;\n(c) is authorised by the specified user to access and collect\n15accessible health information about any individual in the\nordinary course of the individual’s duties for the specified\nuser; and\n(d) is approved by a System Operator.\n(2) For the purposes of this Part, “authorised individual” of an\n20",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 26,
@@ -97042,8 +97549,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p26_c43",
-      "text": "f the individual’s duties for the specified\nuser; and\n(d) is approved by a System Operator.\n(2) For the purposes of this Part, “authorised individual” of an\n20approved user means an individual who —\n(a) is any of the following:\n(i) an individual who is employed or engaged by the\napproved user;\n(ii) an enlisted personnel of the approved user;\n25(iii) an individual who provides, as a volunteer, any\nservice to the approved user or to any other person\nacting on behalf of the approved user; and\n(b) is specified (by name or description), or belongs to a class\nof individuals specified, in the notification published in\n30respect of the approved user in accordance with\nsection 20(2).\n25",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p26_c82",
+      "text": "ividual’s duties for the specified\nuser; and\n(d) is approved by a System Operator.\n(2) For the purposes of this Part, “authorised individual” of an\n20approved user means an individual who —\n(a) is any of the following:\n(i) an individual who is employed or engaged by the\napproved user;\n(ii) an enlisted personnel of the approved user;\n25(iii) an individual who provides, as a volunteer, any\nservice to the approved user or to any other person\nacting on behalf of the approved user; and\n(b) is specified (by name or description), or belongs to a class\nof individuals specified, in the notification published in\n30respect of the approved user in accordance with\nsection 20(2).\n25",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 26,
@@ -97055,8 +97562,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p27_c44",
-      "text": "28 NO. 1 OF 2026\nAccess and collection of accessible health information by\nspecified users\n19.—(1) A person (called a specified user) that is —\n(a) an HCSA licensee specified in, or belonging to a class of\n5 HCSA licensees specified in, the first column of Part 1 of\nthe Second Schedule;\n(b) a retail pharmacy licensee specified in, or belonging to a\nclass of retail pharmacy licensees specified in, the\nfirst column of Part 1 of the Second Schedule; or\n10 (c) any other person or any public agency specified in, or\nbelonging to a class of persons or public agencies specified\nin, the first column of Part 1 of the Second Schedule,\nmay access and collect accessible health information about an\nindividual (P) in accordance with this Part, but only for a purpose\n15 specified in subsection (2) (called in this Part a specified purpose).\n(2) The purposes mentioned in subsection (1) are the following:\n",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p27_c83",
+      "text": "28 NO. 1 OF 2026\nAccess and collection of accessible health information by\nspecified users\n19.—(1) A person (called a specified user) that is —\n(a) an HCSA licensee specified in, or belonging to a class of\n5 HCSA licensees specified in, the first column of Part 1 of\nthe Second Schedule;\n(b) a retail pharmacy licensee specified in, or belonging to a\nclass of retail pharmacy licensees specified in, the\nfirst column of Part 1 of the Second Schedule; or\n10 (c) any other person or any public agency specified in, or\nbelongingtoaclassofpersonsorpublicagenciesspecified\nin, the first column of Part 1 of the Second Schedule,\nmay access and collect accessible health information about an\nindividual (P) in accordance with this Part, but only for a purpose\n15 specified in subsection (2) (called in this Part a specified purpose).\n(2) The purposes mentioned in subsection (1) are the following:\n(a) the p",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 27,
@@ -97068,8 +97575,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p27_c45",
-      "text": "r a purpose\n15 specified in subsection (2) (called in this Part a specified purpose).\n(2) The purposes mentioned in subsection (1) are the following:\n(a) the provision of a healthcare service to P (other than\ncarrying out any specified examination of P), but not the\nprovision of a healthcare service for an excluded purpose;\n20 (b) carrying out any specified examination of P, and any\npurpose relating to the carrying out of the specified\nexamination.\n(3) In subsection (2), “specified examination” of an individual\nmeans any medical, dental, psychiatric or psychological examination,\n25 test or assessment of the individual that is required or authorised by or\nunder, or is necessary for the purpose of complying with, any written\nlaw specified in the Third Schedule or any order made under a written\nlaw specified in that Schedule.\n(4) An authorised individual (X) of a specified user may access a",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p27_c84",
+      "text": "se\n15 specified in subsection (2) (called in this Part a specified purpose).\n(2) The purposes mentioned in subsection (1) are the following:\n(a) the provision of a healthcare service to P (other than\ncarrying out any specified examination ofP), but not the\nprovision of a healthcare service for an excluded purpose;\n20 (b) carrying out any specified examination of P, and any\npurpose relating to the carrying out of the specified\nexamination.\n(3) In subsection (2), “specified examination” of an individual\nmeansanymedical,dental,psychiatricorpsychologicalexamination,\n25 testorassessmentoftheindividualthatisrequiredorauthorisedbyor\nunder, or isnecessary for the purpose of complyingwith, any written\nlawspecifiedintheThirdScheduleoranyordermadeunderawritten\nlaw specified in that Schedule.\n(4) Anauthorisedindividual(X)ofaspecifiedusermayaccessand\n30 collectaccessiblehealthinformationabout Pif,and",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 27,
@@ -97081,8 +97588,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p27_c46",
-      "text": "the Third Schedule or any order made under a written\nlaw specified in that Schedule.\n(4) An authorised individual (X) of a specified user may access and\n30 collect accessible health information about P if, and only if, all of the\nfollowing are satisfied:\n(a) the access and collection of the information by X is\nnecessary to enable X to perform or discharge his or her\nduties for the specified user;\n26",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p27_c85",
+      "text": "rawritten\nlaw specified in that Schedule.\n(4) Anauthorisedindividual(X)ofaspecifiedusermayaccessand\n30 collectaccessiblehealthinformationabout Pif,andonlyif,allofthe\nfollowing are satisfied:\n(a) the access and collection of the information by X is\nnecessary to enableX to perform or discharge his or her\nduties for the specified user;\n26",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 27,
@@ -97094,8 +97601,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p28_c47",
-      "text": "HEALTH INFORMATION 29\n(b) X’s duties mentioned in paragraph (a) relate to the\nspecified user carrying out a specified purpose.\nAccess and collection of accessible health information by\napproved users\n520.—(1) The Minister may approve any person or public agency to\naccess and collect accessible health information about any\nindividual (P) for any of the following purposes:\n(a) the provision of any healthcare service to P by the person\nor public agency or any individual employed or engaged by\n10that person or public agency, but not the provision of any\nhealthcare service for an excluded purpose;\n(b) the provision of any community health service to P by the\nperson or public agency or any individual employed or\nengaged by that person or public agency, but not the\n15provision of any community health service for an excluded\npurpose;\n(c) any public health purpose.\n(2) The Minister must, as soon ",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p28_c86",
+      "text": "HEALTH INFORMATION 29\n(b) X’s duties mentioned in paragraph (a) relate to the\nspecified user carrying out a specified purpose.\nAccess and collection of accessible health information by\napproved users\n520.—(1) TheMinistermayapproveanypersonorpublicagency to\naccess and collect accessible health information about any\nindividual (P) for any of the following purposes:\n(a) the provision of any healthcare service toP by the person\norpublicagencyoranyindividualemployedorengagedby\n10that person or public agency, but not the provision of any\nhealthcare service for an excluded purpose;\n(b) the provision of any community health service toP by the\nperson or public agency or any individual employed or\nengaged by that person or public agency, but not the\n15provisionofanycommunityhealthserviceforanexcluded\npurpose;\n(c) any public health purpose.\n(2) The Minister must, as soon as is practicable after a p",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 28,
@@ -97107,8 +97614,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p28_c48",
-      "text": "gency, but not the\n15provision of any community health service for an excluded\npurpose;\n(c) any public health purpose.\n(2) The Minister must, as soon as is practicable after a person or\npublic agency is approved as an approved user, publish a notification\n20in the Gazette specifying all of the following:\n(a) the class or classes of individuals whose accessible health\ninformation the approved user may access and collect;\n(b) the purpose or purposes mentioned in subsection (1) for\nwhich the approved user may access and collect accessible\n25health information;\n(c) the types of accessible health information that the\napproved user may access and collect;\n(d) the authorised individuals (by name or description) or class\nor classes of authorised individuals of the approved user\n30who may access and collect those types of accessible\nhealth information;\n27",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p28_c87",
+      "text": "15provisionofanycommunityhealthserviceforanexcluded\npurpose;\n(c) any public health purpose.\n(2) The Minister must, as soon as is practicable after a person or\npublic agencyis approvedas an approveduser, publish anotification\n20in theGazette specifying all of the following:\n(a) the class or classes of individuals whose accessible health\ninformation the approved user may access and collect;\n(b) the purpose or purposes mentioned in subsection (1) for\nwhichtheapprovedusermayaccessandcollectaccessible\n25health information;\n(c) the types of accessible health information that the\napproved user may access and collect;\n(d) theauthorisedindividuals(bynameordescription)orclass\nor classes of authorised individuals of the approved user\n30who may access and collect those types of accessible\nhealth information;\n27",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 28,
@@ -97120,7 +97627,7 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p29_c49",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p29_c88",
       "text": "30 NO. 1 OF 2026\n(e) the conditions and restrictions (if any) that the approved\nuser must comply with in relation to the access, collection\nand retention of accessible health information.\n(3) An approved user must, in relation to the access and collection\n5 of accessible health information under this section —\n(a) comply with all conditions and restrictions mentioned in\nsubsection (2)(e); and\n(b) ensure that every authorised individual mentioned in\nsubsection (2)(d) complies with the conditions and\n10 restrictions mentioned in subsection (2)(e).\n(4) The Minister may, by written notice at any time, revoke the\napproval of an approved user.\nDisclosure of accessible health information accessed and\ncollected under section 19 or 20\n15 21.—(1) A specified user must not disclose accessible health\ninformation about any individual that is accessed and collected in\naccordance with section 19 except",
       "metadata": {
         "source": "health-information-act-2026.pdf",
@@ -97133,8 +97640,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p29_c50",
-      "text": "pecified user must not disclose accessible health\ninformation about any individual that is accessed and collected in\naccordance with section 19 except to any individual employed or\nengaged by the specified user (X) in accordance with subsection (3).\n(2) An authorised individual of a specified user must not disclose\n20 accessible health information about any individual that is accessed\nand collected in accordance with section 19 except to any other\nindividual employed or engaged by the specified user (also X) in\naccordance with subsection (3).\n(3) The specified user or authorised individual of the specified user\n25 may disclose the accessible health information to X if, and only if, all\nof the following are satisfied:\n(a) the disclosure of the accessible health information to X is\nnecessary to enable X to perform or discharge his or her\nduties for the specified user;\n30 (b) X’s duties men",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p29_c89",
+      "text": "pecified user must not disclose accessible health\ninformation about any individual that is accessed and collected in\naccordance with section 19 except to any individual employed or\nengaged by the specified user (X) in accordance with subsection (3).\n(2) An authorised individual of a specified user must not disclose\n20 accessible health information about any individual that is accessed\nand collected in accordance with section 19 except to any other\nindividual employed or engaged by the specified user (alsoX) in\naccordance with subsection (3).\n(3) Thespecifieduserorauthorisedindividualofthespecifieduser\n25 maydisclosetheaccessiblehealthinformationto Xif,andonlyif,all\nof the following are satisfied:\n(a) the disclosure of the accessible health information toX is\nnecessary to enableX to perform or discharge his or her\nduties for the specified user;\n30 (b) X’sdutiesmentionedinparagraph(a)relat",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 29,
@@ -97146,8 +97653,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p29_c51",
-      "text": "he accessible health information to X is\nnecessary to enable X to perform or discharge his or her\nduties for the specified user;\n30 (b) X’s duties mentioned in paragraph (a) relate to the carrying\nout of a specified purpose;\n28",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p29_c90",
+      "text": "information toX is\nnecessary to enableX to perform or discharge his or her\nduties for the specified user;\n30 (b) X’sdutiesmentionedinparagraph(a)relatetothecarrying\nout of a specified purpose;\n28",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 29,
@@ -97159,8 +97666,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p30_c52",
-      "text": "HEALTH INFORMATION 31\n(c) the accessible health information disclosed to X is no more\nthan is necessary to enable X to perform or discharge those\nduties.\n(4) An approved user must not disclose accessible health\n5information about any individual that is accessed and collected in\naccordance with section 20 except to any individual employed or\nengaged by the approved user (Y) in accordance with subsection (6).\n(5) An authorised individual of an approved user must not disclose\naccessible health information about any individual that is accessed\n10and collected in accordance with section 20 except to any other\nindividual employed or engaged by the approved user (also Y) in\naccordance with subsection (6).\n(6) The approved user or authorised individual of the approved user\nmay disclose the accessible health information to Y if, and only if, all\n15of the following are satisfied:\n(a) the disclosur",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p30_c91",
+      "text": "HEALTH INFORMATION 31\n(c) theaccessiblehealthinformationdisclosedto Xisnomore\nthanisnecessarytoenable Xtoperformordischargethose\nduties.\n(4) An approved user must not disclose accessible health\n5information about any individual that is accessed and collected in\naccordance with section 20 except to any individual employed or\nengaged by the approved user (Y) in accordance with subsection (6).\n(5) An authorised individual of an approved user must not disclose\naccessible health information about any individual that is accessed\n10and collected in accordance with section 20 except to any other\nindividual employed or engaged by the approved user (alsoY) in\naccordance with subsection (6).\n(6) Theapproveduserorauthorisedindividualoftheapproveduser\nmaydisclosetheaccessiblehealthinformationto Yif,andonlyif,all\n15of the following are satisfied:\n(a) the disclosure of the accessible health information",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 30,
@@ -97172,8 +97679,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p30_c53",
-      "text": "dual of the approved user\nmay disclose the accessible health information to Y if, and only if, all\n15of the following are satisfied:\n(a) the disclosure of the accessible health information to Y is\nnecessary to enable Y to perform or discharge his or her\nduties for the approved user;\n(b) Y’s duties mentioned in paragraph (a) relate to the carrying\n20out of a purpose specified in the notification published in\nrespect of the approved user in accordance with\nsection 20(2);\n(c) the accessible health information disclosed to Y is no more\nthan is necessary to enable Y to perform or discharge those\n25duties.\nObligations of users\n22.—(1) A user must —\n(a) in addition to the conditions and restrictions mentioned in\nsection 20(2)(e) (if applicable), comply with all\n30requirements, conditions and restrictions relating to the\naccess, collection, retention and disclosure of accessible\nhealth informati",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p30_c92",
+      "text": "aydisclosetheaccessiblehealthinformationto Yif,andonlyif,all\n15of the following are satisfied:\n(a) the disclosure of the accessible health information toY is\nnecessary to enableY to perform or discharge his or her\nduties for the approved user;\n(b) Y’sdutiesmentionedinparagraph(a)relatetothecarrying\n20out of a purpose specified in the notification published in\nrespect of the approved user in accordance with\nsection 20(2);\n(c) theaccessiblehealthinformationdisclosedto Yisnomore\nthanisnecessarytoenable Ytoperformordischargethose\n25duties.\nObligations of users\n22.—(1) A user must —\n(a) in addition to the conditions and restrictions mentioned in\nsection 20(2)(e) (if applicable), comply with all\n30requirements, conditions and restrictions relating to the\naccess, collection, retention and disclosure of accessible\nhealth information that may be prescribed;\n(b) establishand implement appropriate ",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 30,
@@ -97185,8 +97692,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p30_c54",
-      "text": "omply with all\n30requirements, conditions and restrictions relating to the\naccess, collection, retention and disclosure of accessible\nhealth information that may be prescribed;\n(b) establish and implement appropriate policies and practices\nto ensure that the authorised individuals of the user access,\n29",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p30_c93",
+      "text": "g to the\naccess, collection, retention and disclosure of accessible\nhealth information that may be prescribed;\n(b) establishand implement appropriate policies and practices\ntoensurethattheauthorisedindividualsoftheuseraccess,\n29",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 30,
@@ -97198,8 +97705,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p31_c55",
-      "text": "32 NO. 1 OF 2026\ncollect, retain and disclose accessible health information in\naccordance with this Part; and\n(c) ensure that every authorised individual of the user\ncomplies with —\n5 (i) the requirements, conditions and restrictions\nmentioned in paragraph (a); and\n(ii) the policies and practices mentioned in\nparagraph (b).\n(2) Without limiting subsection (1)(a), the requirements, conditions\n10 and restrictions mentioned in that provision include the following:\n(a) requirements relating to the software (including any\nApplication Programming Interface) that a user or a\nrelevant HDI of a user is to use in or for any computer\nor computer system that interconnects with the national\n15 electronic records system;\n(b) any computer or computer system, or any website, that a\nuser may use to access and collect accessible health\ninformation.\n(3) For the purposes of subsection (1)(a), different cond",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p31_c94",
+      "text": "32 NO. 1 OF 2026\ncollect,retainanddiscloseaccessiblehealthinformationin\naccordance with this Part; and\n(c) ensure that every authorised individual of the user\ncomplies with —\n5 (i) the requirements, conditions and restrictions\nmentioned in paragraph (a); and\n(ii) the policies and practices mentioned in\nparagraph (b).\n(2) Withoutlimitingsubsection(1)(a),therequirements,conditions\n10 and restrictions mentioned in that provision include the following:\n(a) requirements relating to the software (including any\nApplication Programming Interface) that a user or a\nrelevant HDI of a user is to use in or for any computer\nor computer system that interconnects with the national\n15 electronic records system;\n(b) any computer or computer system, or any website, that a\nuser may use to access and collect accessible health\ninformation.\n(3) For the purposes of subsection (1)(a), different conditions or\n20 ",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 31,
@@ -97211,8 +97718,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p31_c56",
-      "text": "em, or any website, that a\nuser may use to access and collect accessible health\ninformation.\n(3) For the purposes of subsection (1)(a), different conditions or\n20 restrictions may be prescribed for different users or classes of users.\n(4) For the purposes of subsection (1)(b), the policies and practices\nmentioned in that provision must include policies and practices in\nrespect of any prescribed matters relating to the access, collection,\nretention and disclosure of accessible health information.\n25 (5) A user and every authorised individual of a user must comply\nwith every administrative instruction or technical requirement of a\nSystem Operator in relation to the access, collection and disclosure of\naccessible health information.\n(6) A user must notify a System Operator, within the prescribed\n30 time, and in the form and manner prescribed (if prescribed), of —\n(a) the cessation of any in",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p31_c95",
+      "text": "bsite, that a\nuser may use to access and collect accessible health\ninformation.\n(3) For the purposes of subsection (1)(a), different conditions or\n20 restrictions may be prescribed for different users or classes of users.\n(4) For the purposes of subsection (1)(b), the policies and practices\nmentioned in that provision must include policies and practices in\nrespect of any prescribed matters relating to the access, collection,\nretention and disclosure of accessible health information.\n25 (5) A user and every authorised individual of a user must comply\nwith every administrative instruction or technical requirement of a\nSystemOperatorinrelationtotheaccess,collectionanddisclosureof\naccessible health information.\n(6) A user must notify a System Operator, within the prescribed\n30 time, and in the form and manner prescribed (if prescribed), of —\n(a) the cessation of any individual as an authoris",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 31,
@@ -97224,8 +97731,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p31_c57",
-      "text": " must notify a System Operator, within the prescribed\n30 time, and in the form and manner prescribed (if prescribed), of —\n(a) the cessation of any individual as an authorised individual\nof the user for any reason; or\n30",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p31_c96",
+      "text": "perator, within the prescribed\n30 time, and in the form and manner prescribed (if prescribed), of —\n(a) the cessation of any individual as an authorised individual\nof the user for any reason; or\n30",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 31,
@@ -97237,8 +97744,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p32_c58",
-      "text": "HEALTH INFORMATION 33\n(b) any change in the designation or role in the user’s\norganisation of any authorised individual of the user.\n(7) A user who contravenes subsection (1) or (6) shall be guilty of\nan offence and shall be liable on conviction to a fine not exceeding\n5$50,000 or to imprisonment for a term not exceeding 2 years or to\nboth.\nDirections relating to access and collection of accessible health\ninformation\n23.—(1) The Minister may, by written notice, direct a person\n10concerned to do all or any of the following:\n(a) stop the access or collection of accessible health\ninformation about any individual;\n(b) delete or destroy all copies of accessible health information\nabout any individual that are in the possession or under the\n15control of the person concerned;\n(c) take all reasonable steps —\n(i) to retrieve all copies of accessible health information\nabout any individual from an",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p32_c97",
+      "text": "HEALTH INFORMATION 33\n(b) any change in the designation or role in the user’s\norganisation of any authorised individual of the user.\n(7) A user who contravenes subsection (1) or (6) shall be guilty of\nan offence and shall be liable on conviction to a fine not exceeding\n5$50,000 or to imprisonment for a term not exceeding 2 years or to\nboth.\nDirectionsrelatingtoaccessandcollectionofaccessiblehealth\ninformation\n23.—(1) The Minister may, by written notice, direct a person\n10concerned to do all or any of the following:\n(a) stop the access or collection of accessible health\ninformation about any individual;\n(b) deleteordestroyallcopiesofaccessiblehealthinformation\naboutanyindividualthatareinthepossessionorunderthe\n15control of the person concerned;\n(c) take all reasonable steps —\n(i) toretrieveallcopiesofaccessiblehealthinformation\nabout any individual from any person to whom the\nperson conce",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 32,
@@ -97250,8 +97757,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p32_c59",
-      "text": "trol of the person concerned;\n(c) take all reasonable steps —\n(i) to retrieve all copies of accessible health information\nabout any individual from any person to whom the\nperson concerned has disclosed the accessible health\n20information; and\n(ii) to delete or destroy all copies of the accessible health\ninformation that are retrieved in accordance with\nsub‑paragraph (i).\n(2) If the Minister directs a person concerned to take any action\n25under subsection (1)(b) or (c)(ii), the Minister may additionally direct\nthe person concerned —\n(a) to delete or destroy the copies of the accessible health\ninformation in the manner specified by the Minister; or\n(b) to certify that the copies of the accessible health\n30information have been deleted or destroyed.\n(3) A person who, without reasonable excuse, fails to comply with\nthe Minister’s direction under subsection (1) or (2) shall be guilty of\nan of",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p32_c98",
+      "text": "ed;\n(c) take all reasonable steps —\n(i) toretrieveallcopiesofaccessiblehealthinformation\nabout any individual from any person to whom the\nperson concerned hasdisclosed the accessiblehealth\n20information; and\n(ii) todeleteordestroyallcopiesoftheaccessiblehealth\ninformation that are retrieved in accordance with\nsub‑paragraph (i).\n(2) If the Minister directs a person concerned to take any action\n25undersubsection(1)(b)or(c)(ii),theMinistermayadditionallydirect\nthe person concerned —\n(a) to delete or destroy the copies of the accessible health\ninformation in the manner specified by the Minister; or\n(b) to certify that the copies of the accessible health\n30information have been deleted or destroyed.\n(3) A person who, without reasonable excuse, fails to comply with\nthe Minister’s direction under subsection (1) or (2) shall be guilty of\nan offence and shall be liable on conviction to a fine not",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 32,
@@ -97263,8 +97770,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p32_c60",
-      "text": "royed.\n(3) A person who, without reasonable excuse, fails to comply with\nthe Minister’s direction under subsection (1) or (2) shall be guilty of\nan offence and shall be liable on conviction to a fine not exceeding\n31",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p32_c99",
+      "text": "ails to comply with\nthe Minister’s direction under subsection (1) or (2) shall be guilty of\nan offence and shall be liable on conviction to a fine not exceeding\n31",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 32,
@@ -97276,8 +97783,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p33_c61",
-      "text": "34 NO. 1 OF 2026\n$50,000 or to imprisonment for a term not exceeding 2 years or to\nboth and, in the case of a continuing offence, to a further fine not\nexceeding $1,000 for every day or part of a day during which the\noffence continues after conviction.\n5 (4) In this section, “person concerned” means any of the following\npersons:\n(a) an HCSA licensee, where —\n(i) the HCSA licensee’s licence has expired or lapsed,\nhas been revoked or suspended or is otherwise no\n10 longer valid under the Healthcare Services Act 2020;\nor\n(ii) the HCSA licensee voluntarily stops providing any\nlicensable healthcare service to which the licence\nrelates under section 17(1)(a) of that Act;\n15 (b) a retail pharmacy licensee whose licence is suspended or\nrevoked under section 27 of the Health Products Act 2007;\n(c) a specified user, where —\n(i) the specified user contravenes section 19(1), 21(1) or\n(3) or 22(1)(b)",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p33_c100",
+      "text": "34 NO. 1 OF 2026\n$50,000 or to imprisonment for a term not exceeding 2 years or to\nboth and, in the case of a continuing offence, to a further fine not\nexceeding $1,000 for every day or part of a day during which the\noffence continues after conviction.\n5 (4) In this section, “person concerned” means any of the following\npersons:\n(a) an HCSA licensee, where —\n(i) the HCSA licensee’s licence has expired or lapsed,\nhas been revoked or suspended or is otherwise no\n10 longervalidundertheHealthcareServicesAct2020;\nor\n(ii) the HCSA licensee voluntarily stops providing any\nlicensable healthcare service to which the licence\nrelates under section 17(1)(a) of that Act;\n15 (b) a retail pharmacy licensee whose licence is suspended or\nrevokedundersection27oftheHealthProductsAct2007;\n(c) a specified user, where —\n(i) thespecifiedusercontravenessection19(1),21(1)or\n(3) or 22(1)(b) or (c);\n20 (ii) any au",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 33,
@@ -97289,8 +97796,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p33_c62",
-      "text": "r section 27 of the Health Products Act 2007;\n(c) a specified user, where —\n(i) the specified user contravenes section 19(1), 21(1) or\n(3) or 22(1)(b) or (c);\n20 (ii) any authorised individual of the specified user\ncontravenes section 19(4) or 21(2) or (3);\n(iii) the specified user fails to comply with any\nrequirement, condition or restriction mentioned in\nsection 22(1)(a);\n25 (iv) the specified user or any authorised individual of the\nspecified user fails to comply with any\nadministrative instruction or technical requirement\nof a System Operator mentioned in section 22(5);\n(v) in a case where the specified user accesses or collects\n30 accessible health information through a relevant\nHDI, the relevant HDI fails to comply with any\nadministrative instruction or technical requirement\nof a System Operator mentioned in section 22(5);\n32",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p33_c101",
+      "text": "27oftheHealthProductsAct2007;\n(c) a specified user, where —\n(i) thespecifiedusercontravenessection19(1),21(1)or\n(3) or 22(1)(b) or (c);\n20 (ii) any authorised individual of the specified user\ncontravenes section 19(4) or 21(2) or (3);\n(iii) the specified user fails to comply with any\nrequirement, condition or restriction mentioned in\nsection 22(1)(a);\n25 (iv) the specified user or any authorised individual of the\nspecified user fails to comply with any\nadministrative instruction or technical requirement\nof a System Operator mentioned in section 22(5);\n(v) inacasewherethespecifieduseraccessesorcollects\n30 accessible health information through a relevant\nHDI, the relevant HDI fails to comply with any\nadministrative instruction or technical requirement\nof a System Operator mentioned in section 22(5);\n32",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 33,
@@ -97302,8 +97809,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p34_c63",
-      "text": "HEALTH INFORMATION 35\n(vi) the Minister has reason to believe that the specified\nuser or any authorised individual of the specified\nuser is contravening or has contravened section 38(1)\nor (3) or 40(1), and it is necessary for the specified\n5user to take any action mentioned in subsection (1) in\norder to prevent or minimise any harm or damage to\nany individual pending the outcome of any\nproceedings against the specified user or authorised\nindividual of the specified user (as the case may be)\n10for an offence arising from that contravention; or\n(vii) the specified user or any authorised individual of the\nspecified user is convicted of an offence arising from\na contravention of section 38(1) or (3) or 40(1);\n(d) an approved user, where —\n15(i) the approved user’s approval is revoked under\nsection 20(4);\n(ii) the approved user contravenes section 21(4) or (6) or\n22(1)(b) or (c);\n(iii) any a",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p34_c102",
+      "text": "HEALTH INFORMATION 35\n(vi) the Minister has reason to believe that the specified\nuser or any authorised individual of the specified\nuseriscontraveningorhascontravenedsection38(1)\nor (3) or 40(1), and it is necessary for the specified\n5usertotakeanyactionmentionedinsubsection(1)in\norder to prevent or minimise any harm or damage to\nany individual pending the outcome of any\nproceedings against the specified user or authorised\nindividual of the specified user (as the case may be)\n10for an offence arising from that contravention; or\n(vii) the specified user or any authorised individual of the\nspecifieduserisconvictedofanoffencearisingfrom\na contravention of section 38(1) or (3) or 40(1);\n(d) an approved user, where —\n15(i) the approved user’s approval is revoked under\nsection 20(4);\n(ii) theapprovedusercontravenessection21(4)or(6)or\n22(1)(b) or (c);\n(iii) any authorised individual of the appr",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 34,
@@ -97315,8 +97822,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p34_c64",
-      "text": ") the approved user’s approval is revoked under\nsection 20(4);\n(ii) the approved user contravenes section 21(4) or (6) or\n22(1)(b) or (c);\n(iii) any authorised individual of the approved user\n20contravenes section 21(5) or (6);\n(iv) the approved user fails to comply with any\nrequirement, condition or restriction mentioned in\nsection 22(1)(a);\n(v) the approved user or any authorised individual of the\n25approved user fails to comply with any\nadministrative instruction or technical requirement\nof a System Operator mentioned in section 22(5);\n(vi) in a case where the approved user accesses or\ncollects accessible health information through a\n30relevant HDI, the relevant HDI fails to comply\nwith any administrative instruction or technical\nrequirement of a System Operator mentioned in\nsection 22(5);\n33",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p34_c103",
+      "text": "proval is revoked under\nsection 20(4);\n(ii) theapprovedusercontravenessection21(4)or(6)or\n22(1)(b) or (c);\n(iii) any authorised individual of the approved user\n20contravenes section 21(5) or (6);\n(iv) the approved user fails to comply with any\nrequirement, condition or restriction mentioned in\nsection 22(1)(a);\n(v) theapproveduseroranyauthorisedindividualofthe\n25approved user fails to comply with any\nadministrative instruction or technical requirement\nof a System Operator mentioned in section 22(5);\n(vi) in a case where the approved user accesses or\ncollects accessible health information through a\n30relevant HDI, the relevant HDI fails to comply\nwith any administrative instruction or technical\nrequirement of a System Operator mentioned in\nsection 22(5);\n33",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 34,
@@ -97328,8 +97835,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p35_c65",
-      "text": "36 NO. 1 OF 2026\n(vii) the Minister has reason to believe that the approved\nuser or any authorised individual of the approved\nuser is contravening or has contravened section 38(2)\nor (3) or 40(1), and it is necessary for the approved\n5 user to take any action mentioned in subsection (1) in\norder to prevent or minimise any harm or damage to\nany individual pending the outcome of any\nproceedings against the approved user or\nauthorised individual of the approved user (as the\n10 case may be) for an offence arising from that\ncontravention; or\n(viii) the approved user or any authorised individual of the\napproved user is convicted of an offence arising from\na contravention of section 38(2) or (3) or 40(1).\n15 (5) For the purposes of subsection (4)(c)(vii) and (d)(viii), the\nMinister must accept the person’s conviction as final.\nDivision 4 — Derived information\nInterpretation of this Division\n24.",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p35_c104",
+      "text": "36 NO. 1 OF 2026\n(vii) the Minister has reason to believe that the approved\nuser or any authorised individual of the approved\nuseriscontraveningorhascontravenedsection38(2)\nor (3) or 40(1), and it is necessary for the approved\n5 usertotakeanyactionmentionedinsubsection(1)in\norder to prevent or minimise any harm or damage to\nany individual pending the outcome of any\nproceedings against the approved user or\nauthorised individual of the approved user (as the\n10 case may be) for an offence arising from that\ncontravention; or\n(viii) theapproveduseroranyauthorisedindividualofthe\napproveduserisconvictedofanoffencearisingfrom\na contravention of section 38(2) or (3) or 40(1).\n15 (5) For the purposes of subsection (4)(c)(vii) and (d)(viii), the\nMinister must accept the person’s conviction as final.\nDivision 4 — Derived information\nInterpretation of this Division\n24. In this Division —\n20 “section ",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 35,
@@ -97341,8 +97848,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p35_c66",
-      "text": "c)(vii) and (d)(viii), the\nMinister must accept the person’s conviction as final.\nDivision 4 — Derived information\nInterpretation of this Division\n24. In this Division —\n20 “section 25 approval” means an approval granted under\nsection 25(6)(a);\n“type 1 derived information” means derived information that is\nin the form of individually‑identifiable health information;\n“type 2 derived information” means derived information that is\n25 in the form of aggregated or anonymised health information.\nApplications for derived information\n25.—(1) A person who satisfies the prescribed criteria and\nrequirements or a public agency may apply to the Minister to\nobtain derived information in accordance with this section.\n30 (2) The Minister may approve an application to obtain type 1\nderived information if the application is made for a purpose that\nrelates to or promotes public health.\n34",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p35_c105",
+      "text": "ter must accept the person’s conviction as final.\nDivision 4 — Derived information\nInterpretation of this Division\n24. In this Division —\n20 “section 25 approval” means an approval granted under\nsection 25(6)(a);\n“type 1 derived information” means derived information that is\nin the form of individually‑identifiable health information;\n“type 2 derived information” means derived information that is\n25 in the form of aggregated or anonymised health information.\nApplications for derived information\n25.—(1) A person who satisfies the prescribed criteria and\nrequirements or a public agency may apply to the Minister to\nobtain derived information in accordance with this section.\n30 (2) The Minister may approve an application to obtain type 1\nderived information if the application is made for a purpose that\nrelates to or promotes public health.\n34",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 35,
@@ -97354,8 +97861,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p36_c67",
-      "text": "HEALTH INFORMATION 37\n(3) The Minister may approve an application to obtain type 2\nderived information if the Minister is satisfied, having regard to the\npurpose for which the application is made, that it is in the public\ninterest to do so.\n5(4) An application made under subsection (2) or (3) must —\n(a) be made to the Minister in the form and manner, and within\nthe time, specified by the Minister;\n(b) specify —\n(i) every purpose for which the application is made; and\n10(ii) whether the applicant intends to disclose the derived\ninformation obtained (if the application is approved)\nto any other person or class of persons; and\n(c) be accompanied by —\n(i) any information that may be prescribed; and\n15(ii) any other information that the Minister may require\nto decide on the application.\n(5) If the applicant specifies, in accordance with\nsubsection (4)(b)(ii), that the applicant intends to dis",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p36_c106",
+      "text": "HEALTH INFORMATION 37\n(3) The Minister may approve an application to obtain type 2\nderived information if the Minister is satisfied, having regard to the\npurpose for which the application is made, that it is in the public\ninterest to do so.\n5(4) An application made under subsection (2) or (3) must —\n(a) bemadetotheMinisterintheformandmanner,andwithin\nthe time, specified by the Minister;\n(b) specify —\n(i) everypurposeforwhichtheapplicationismade;and\n10(ii) whether the applicant intends to disclose the derived\ninformation obtained (if the application is approved)\nto any other person or class of persons; and\n(c) be accompanied by —\n(i) any information that may be prescribed; and\n15(ii) any other information that the Minister may require\nto decide on the application.\n(5) If the applicant specifies, in accordance with\nsubsection (4)(b)(ii), that the applicant intends to disclose the\nderived i",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 36,
@@ -97367,8 +97874,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p36_c68",
-      "text": " may require\nto decide on the application.\n(5) If the applicant specifies, in accordance with\nsubsection (4)(b)(ii), that the applicant intends to disclose the\nderived information obtained (if the application is approved) to any\n20other person or class of persons, the applicant must additionally\nspecify —\n(a) the identity or description of that person or class of\npersons; and\n(b) every purpose for which the derived information will be\n25disclosed to that person or class of persons.\n(6) Upon receiving an application under subsection (2) or (3), the\nMinister may —\n(a) approve the application and provide the type 1 derived\ninformation or type 2 derived information (as the case may\n30be) to the applicant, subject to any conditions or\nrestrictions in relation to the access, collection,\ndisclosure and use of the derived information that the\nMinister thinks fit; or\n35",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p36_c107",
+      "text": "ide on the application.\n(5) If the applicant specifies, in accordance with\nsubsection (4)(b)(ii), that the applicant intends to disclose the\nderived information obtained (if the application is approved) to any\n20other person or class of persons, the applicant must additionally\nspecify —\n(a) the identity or description of that person or class of\npersons; and\n(b) every purpose for which the derived information will be\n25disclosed to that person or class of persons.\n(6) Upon receiving an application under subsection (2) or (3), the\nMinister may —\n(a) approve the application and provide the type 1 derived\ninformationortype2derivedinformation(asthecasemay\n30be) to the applicant, subject to any conditions or\nrestrictions in relation to the access, collection,\ndisclosure and use of the derived information that the\nMinister thinks fit; or\n35",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 36,
@@ -97380,8 +97887,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p37_c69",
-      "text": "38 NO. 1 OF 2026\n(b) reject the application.\n(7) If —\n(a) the application is an application to obtain type 1 derived\ninformation under subsection (2); and\n5 (b) the Minister is of the opinion that the purpose specified in\nthe application will be satisfied by the provision of type 2\nderived information instead,\nthe Minister may provide the applicant with type 2 derived\ninformation.\n10 (8) In deciding whether to approve or reject an application to obtain\ntype 1 derived information under subsection (2), the Minister must\nhave regard, and give such weight as the Minister considers\nappropriate, to all of the following matters:\n(a) whether allowing the applicant to obtain type 1 derived\n15 information is in the public interest;\n(b) whether it is feasible and reasonable for the applicant to\nobtain the prior consent of the individual or individuals to\nwhom the type 1 derived information relate f",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p37_c108",
+      "text": "38 NO. 1 OF 2026\n(b) reject the application.\n(7) If —\n(a) the application is an application to obtain type 1 derived\ninformation under subsection (2); and\n5 (b) the Minister is of the opinion that the purpose specified in\nthe application will be satisfied by the provision of type 2\nderived information instead,\nthe Minister may provide the applicant with type 2 derived\ninformation.\n10 (8) Indecidingwhethertoapproveorrejectanapplicationtoobtain\ntype 1 derived information under subsection (2), the Minister must\nhave regard, and give such weight as the Minister considers\nappropriate, to all of the following matters:\n(a) whether allowing the applicant to obtain type 1 derived\n15 information is in the public interest;\n(b) whether it is feasible and reasonable for the applicant to\nobtain the prior consent of the individual or individuals to\nwhom the type 1 derived information relate for the acc",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 37,
@@ -97393,8 +97900,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p37_c70",
-      "text": "feasible and reasonable for the applicant to\nobtain the prior consent of the individual or individuals to\nwhom the type 1 derived information relate for the access,\ncollection, disclosure and use of the type 1 derived\n20 information;\n(c) whether the purpose for which the applicant seeks to obtain\nthe type 1 derived information can be satisfied if the\napplicant is provided with type 2 derived information\ninstead.\n25 (9) To avoid doubt, the Minister is not confined to consideration of\nthe matters mentioned in subsection (8) and may take into account\nany other matter and evidence that may be relevant.\n(10) Where the Minister approves an application under\nsubsection (2) or (3), the approval must specify all of the following:\n30 (a) the purpose for which the approval is granted;\n(b) the individuals (by name or description) or class of\nindividuals employed or engaged by the requestor who\n36",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p37_c109",
+      "text": "nd reasonable for the applicant to\nobtain the prior consent of the individual or individuals to\nwhom the type 1 derived information relate for the access,\ncollection, disclosure and use of the type 1 derived\n20 information;\n(c) whetherthepurposeforwhichtheapplicantseekstoobtain\nthe type 1 derived information can be satisfied if the\napplicant is provided with type 2 derived information\ninstead.\n25 (9) To avoid doubt, the Minister is not confined to consideration of\nthe matters mentioned in subsection (8) and may take into account\nany other matter and evidence that may be relevant.\n(10) Where the Minister approves an application under\nsubsection (2) or (3), the approval must specify all of the following:\n30 (a) the purpose for which the approval is granted;\n(b) the individuals (by name or description) or class of\nindividuals employed or engaged by the requestor who\n36",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 37,
@@ -97406,8 +97913,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p38_c71",
-      "text": "HEALTH INFORMATION 39\nare allowed to access and collect the derived information,\neach of whom must be an individual who —\n(i) is employed or engaged by the requestor; or\n(ii) provides, as a volunteer, any service to the requestor\n5or to any other person acting on behalf of the\nrequestor;\n(c) if applicable, the person (by name or description) or class\nof persons to whom the requestor may disclose the derived\ninformation and the purpose or purposes of any such\n10disclosure;\n(d) if applicable, whether the requestor may retain the derived\ninformation after the purpose specified under paragraph (c)\nhas been fulfilled or otherwise ceases to apply.\n(11) The Minister may, upon approving an application under\n15subsection (6)(a), direct the System Operator to provide the type 1\nderived information or type 2 derived information (as the case may\nbe) specified in the application to the requestor.\n(12",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p38_c110",
+      "text": "HEALTH INFORMATION 39\nare allowed to access and collect the derived information,\neach of whom must be an individual who —\n(i) is employed or engaged by the requestor; or\n(ii) provides, as a volunteer, any service to the requestor\n5or to any other person acting on behalf of the\nrequestor;\n(c) if applicable, the person (by name or description) or class\nofpersonstowhomtherequestormaydisclosethederived\ninformation and the purpose or purposes of any such\n10disclosure;\n(d) if applicable, whether the requestor may retain the derived\ninformationafterthepurposespecifiedunderparagraph(c)\nhas been fulfilled or otherwise ceases to apply.\n(11) The Minister may, upon approving an application under\n15subsection (6)(a), direct the System Operator to provide the type 1\nderived information or type 2 derived information (as the case may\nbe) specified in the application to the requestor.\n(12) The Minister m",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 38,
@@ -97419,8 +97926,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p38_c72",
-      "text": "erator to provide the type 1\nderived information or type 2 derived information (as the case may\nbe) specified in the application to the requestor.\n(12) The Minister may, by written notice, revoke an approval\ngranted under subsection (2) or (3).\n20(13) A requestor who fails to comply with any condition or\nrestriction imposed under subsection (6)(a) on the section 25\napproval granted to the requestor shall be guilty of an offence and\nshall be liable on conviction to a fine not exceeding $50,000 or to\nimprisonment for a term not exceeding 2 years or to both and, in the\n25case of a continuing offence, to a further fine not exceeding $1,000\nfor every day or part of a day during which the offence continues after\nconviction.\nAccess, collection, disclosure and use of derived information\n26. A requestor may, subject to any condition or restriction imposed\n30on the section 25 approval granted to t",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p38_c111",
+      "text": "e the type 1\nderived information or type 2 derived information (as the case may\nbe) specified in the application to the requestor.\n(12) The Minister may, by written notice, revoke an approval\ngranted under subsection (2) or (3).\n20(13) A requestor who fails to comply with any condition or\nrestriction imposed under subsection (6)(a) on the section 25\napproval granted to the requestor shall be guilty of an offence and\nshall be liable on conviction to a fine not exceeding $50,000 or to\nimprisonment for a term not exceeding 2 years or to both and, in the\n25case of a continuing offence, to a further fine not exceeding $1,000\nforeverydayorpartofadayduringwhichtheoffencecontinuesafter\nconviction.\nAccess, collection, disclosure and use of derived information\n26. Arequestormay,subjecttoanyconditionorrestrictionimposed\n30on the section 25 approval granted to the requestor, access, collect,\ndisclos",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 38,
@@ -97432,8 +97939,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p38_c73",
-      "text": "sclosure and use of derived information\n26. A requestor may, subject to any condition or restriction imposed\n30on the section 25 approval granted to the requestor, access, collect,\ndisclose and use derived information that the requestor obtained\nunder the section 25 approval for any purpose specified in that\napproval without the prior consent of any individual to whom the\nderived information relates.\n37",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p38_c112",
+      "text": "nformation\n26. Arequestormay,subjecttoanyconditionorrestrictionimposed\n30on the section 25 approval granted to the requestor, access, collect,\ndisclose and use derived information that the requestor obtained\nunder the section 25 approval for any purpose specified in that\napproval without the prior consent of any individual to whom the\nderived information relates.\n37",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 38,
@@ -97445,8 +97952,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p39_c74",
-      "text": "40 NO. 1 OF 2026\nObligations of requestors\n27.—(1) A requestor must establish and implement policies and\npractices to ensure that derived information obtained by the requestor\nunder the section 25 approval granted to the requestor is accessed,\n5 collected, disclosed and used in accordance with this Act.\n(2) For the purposes of subsection (1), the policies and practices\nmentioned in that subsection must include policies and practices in\nrespect of any matters prescribed relating to the access, collection,\ndisclosure and use of derived information.\n10 (3) In relation to any type 1 derived information obtained by a\nrequestor in accordance with section 25, the requestor —\n(a) must not, except with the prior written approval of the\nMinister, disclose to any person or class of persons other\nthan a person or class of persons specified in the section 25\n15 approval granted to the requestor (if a",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p39_c113",
+      "text": "40 NO. 1 OF 2026\nObligations of requestors\n27.—(1) A requestor must establish and implement policies and\npracticestoensurethatderivedinformationobtainedbytherequestor\nunder the section 25 approval granted to the requestor is accessed,\n5 collected, disclosed and used in accordance with this Act.\n(2) For the purposes of subsection (1), the policies and practices\nmentioned in that subsection must include policies and practices in\nrespect of any matters prescribed relating to the access, collection,\ndisclosure and use of derived information.\n10 (3) In relation to any type 1 derived information obtained by a\nrequestor in accordance with section 25, the requestor —\n(a) must not, except with the prior written approval of the\nMinister, disclose to any person or class of persons other\nthanapersonorclassofpersonsspecifiedinthesection25\n15 approval granted to the requestor (if any) —\n(i) the type 1",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 39,
@@ -97458,8 +97965,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p39_c75",
-      "text": "close to any person or class of persons other\nthan a person or class of persons specified in the section 25\n15 approval granted to the requestor (if any) —\n(i) the type 1 derived information; or\n(ii) aggregated or anonymised health information\nderived from the type 1 derived information;\n(b) must not use, for any purpose other than a purpose\n20 specified in the section 25 approval —\n(i) the type 1 derived information; or\n(ii) aggregated or anonymised health information\nderived from the type 1 derived information; and\n(c) subject to subsection (6) or unless this Act or the section 25\n25 approval otherwise specifies, must delete or destroy the\ntype 1 derived information and all copies thereof after the\npurpose specified in the section 25 approval has been\nfulfilled or otherwise ceases to apply.\n(4) Subsection (3)(a) includes the disclosure, by the requestor to\n30 another person, of aggrega",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p39_c114",
+      "text": "any person or class of persons other\nthanapersonorclassofpersonsspecifiedinthesection25\n15 approval granted to the requestor (if any) —\n(i) the type 1 derived information; or\n(ii) aggregated or anonymised health information\nderived from the type 1 derived information;\n(b) must not use, for any purpose other than a purpose\n20 specified in the section 25 approval —\n(i) the type 1 derived information; or\n(ii) aggregated or anonymised health information\nderived from the type 1 derived information; and\n(c) subjecttosubsection(6)orunlessthisActorthesection25\n25 approval otherwise specifies, must delete or destroy the\ntype 1 derived information and all copies thereof after the\npurpose specified in the section 25 approval has been\nfulfilled or otherwise ceases to apply.\n(4) Subsection (3)(a) includes the disclosure, by the requestor to\n30 another person, of aggregated or anonymised health inform",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 39,
@@ -97471,8 +97978,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p39_c76",
-      "text": "oval has been\nfulfilled or otherwise ceases to apply.\n(4) Subsection (3)(a) includes the disclosure, by the requestor to\n30 another person, of aggregated or anonymised health information\nderived from type 1 derived information where —\n38",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p39_c115",
+      "text": "rwise ceases to apply.\n(4) Subsection (3)(a) includes the disclosure, by the requestor to\n30 another person, of aggregated or anonymised health information\nderived from type 1 derived information where —\n38",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 39,
@@ -97484,8 +97991,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p40_c77",
-      "text": "HEALTH INFORMATION 41\n(a) the requestor —\n(i) discloses that aggregated or anonymised health\ninformation together with any other information; or\n(ii) knows or has reason to believe that the other person\n5has, or is likely to have access to, any other\ninformation; and\n(b) the other information mentioned in paragraph (a)(i) or (ii),\nwhen used in conjunction with the aggregated or\nanonymised health information, identifies or allows for\n10the identification of any individual.\n(5) Where a requestor obtains type 2 derived information, in\naccordance with section 25, the requestor —\n(a) except with the prior written approval of the Minister, must\nnot disclose the type 2 derived information to any person;\n15(b) must not use the type 2 derived information for any\npurpose other than a purpose specified in the section 25\napproval granted to the requestor;\n(c) must not do any act or take any step to ",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p40_c116",
+      "text": "HEALTH INFORMATION 41\n(a) the requestor —\n(i) discloses that aggregated or anonymised health\ninformation together with any other information; or\n(ii) knows or has reason to believe that the other person\n5has, or is likely to have access to, any other\ninformation; and\n(b) the other informationmentioned in paragraph (a)(i) or (ii),\nwhen used in conjunction with the aggregated or\nanonymised health information, identifies or allows for\n10the identification of any individual.\n(5) Where a requestor obtains type 2 derived information, in\naccordance with section 25, the requestor —\n(a) exceptwiththepriorwrittenapprovaloftheMinister,must\nnot disclose the type 2 derived information to any person;\n15(b) must not use the type 2 derived information for any\npurpose other than a purpose specified in the section 25\napproval granted to the requestor;\n(c) mustnotdoanyactortakeanysteptoidentifyorcausethe\ni",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 40,
@@ -97497,8 +98004,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p40_c78",
-      "text": "ation for any\npurpose other than a purpose specified in the section 25\napproval granted to the requestor;\n(c) must not do any act or take any step to identify or cause the\nidentification of any individual from the type 2 derived\n20information except —\n(i) where it is necessary to do so in connection with the\nadministration or execution of anything under this\nAct;\n(ii) where the identification of the individual is required\n25or permitted under this Act or any other written law,\nor by an order of court;\n(iii) where, in the opinion of the Minister, the\nidentification of the individual is necessary for any\npurpose related to public health; or\n30(iv) in any other circumstances that may be prescribed;\nand\n(d) subject to subsection (6) or unless this Act or the section 25\napproval otherwise specifies, must delete or destroy the\n39",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p40_c117",
+      "text": "any\npurpose other than a purpose specified in the section 25\napproval granted to the requestor;\n(c) mustnotdoanyactortakeanysteptoidentifyorcausethe\nidentification of any individual from the type 2 derived\n20information except —\n(i) where it is necessary to do so in connection with the\nadministration or execution of anything under this\nAct;\n(ii) where the identification of the individual is required\n25or permitted under this Act or any other written law,\nor by an order of court;\n(iii) where, in the opinion of the Minister, the\nidentification of the individual is necessary for any\npurpose related to public health; or\n30(iv) in any other circumstances that may be prescribed;\nand\n(d) subjecttosubsection(6)orunlessthisActorthesection25\napproval otherwise specifies, must delete or destroy the\n39",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 40,
@@ -97510,8 +98017,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p41_c79",
-      "text": "42 NO. 1 OF 2026\ntype 2 derived information and all copies thereof after the\npurpose specified in the section 25 approval has been\nfulfilled or otherwise ceases to apply.\n(6) Subsection (3)(c) or (5)(d) does not apply to the extent that the\n5 requestor is required to retain the type 1 derived information or type 2\nderived information (as the case may be) by or under, or for the\npurpose of complying with, any written law, rule of law or rule of\nprofessional conduct or ethics.\n(7) A requestor who contravenes subsection (1) shall be guilty of an\n10 offence and shall be liable on conviction to a fine not exceeding\n$50,000 or to imprisonment for a term not exceeding 2 years or to\nboth.\nDirections relating to requestors\n28.—(1) The Minister may, by written notice, direct a requestor to\n15 do all or any of the following:\n(a) subject to subsection (2), delete or destroy the derived\ninformation t",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p41_c118",
+      "text": "42 NO. 1 OF 2026\ntype 2 derived information and all copies thereof after the\npurpose specified in the section 25 approval has been\nfulfilled or otherwise ceases to apply.\n(6) Subsection (3)(c) or (5)(d) does not apply to the extent that the\n5 requestorisrequiredtoretainthetype1derivedinformationortype2\nderived information (as the case may be) by or under, or for the\npurpose of complying with, any written law, rule of law or rule of\nprofessional conduct or ethics.\n(7) Arequestorwhocontravenessubsection(1)shallbeguiltyofan\n10 offence and shall be liable on conviction to a fine not exceeding\n$50,000 or to imprisonment for a term not exceeding 2 years or to\nboth.\nDirections relating to requestors\n28.—(1) The Minister may, by written notice, direct a requestor to\n15 do all or any of the following:\n(a) subject to subsection (2), delete or destroy the derived\ninformation the requestor obtained ",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 41,
@@ -97523,8 +98030,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p41_c80",
-      "text": "by written notice, direct a requestor to\n15 do all or any of the following:\n(a) subject to subsection (2), delete or destroy the derived\ninformation the requestor obtained under the section 25\napproval granted to the requestor, and all copies of the\nderived information in the possession or under the control\n20 of the requestor;\n(b) take all reasonable steps —\n(i) to retrieve all copies of the derived information the\nrequestor obtained under the section 25 approval\nfrom any person to whom the requestor has disclosed\n25 the derived information; and\n(ii) to delete or destroy all copies of the derived\ninformation that are retrieved under\nsub‑paragraph (i).\n(2) If the Minister directs the requestor to take any action under\n30 subsection (1)(a) or (b)(ii), the Minister may additionally direct the\nrequestor —\n(a) to delete or destroy the derived information or the copy or\ncopies of the derived ",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p41_c119",
+      "text": "ect a requestor to\n15 do all or any of the following:\n(a) subject to subsection (2), delete or destroy the derived\ninformation the requestor obtained under the section 25\napproval granted to the requestor, and all copies of the\nderived information in the possession or under the control\n20 of the requestor;\n(b) take all reasonable steps —\n(i) to retrieve all copies of the derived information the\nrequestor obtained under the section 25 approval\nfromanypersontowhomtherequestorhasdisclosed\n25 the derived information; and\n(ii) to delete or destroy all copies of the derived\ninformation that are retrieved under\nsub‑paragraph (i).\n(2) If the Minister directs the requestor to take any action under\n30 subsection (1)(a) or (b)(ii), the Minister may additionally direct the\nrequestor —\n(a) to delete or destroy the derived information or the copy or\ncopies of the derived information (as the case may b",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 41,
@@ -97536,8 +98043,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p41_c81",
-      "text": "r (b)(ii), the Minister may additionally direct the\nrequestor —\n(a) to delete or destroy the derived information or the copy or\ncopies of the derived information (as the case may be) in\nthe manner specified by the Minister; or\n40",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p41_c120",
+      "text": "ditionally direct the\nrequestor —\n(a) to delete or destroy the derived information or the copy or\ncopies of the derived information (as the case may be) in\nthe manner specified by the Minister; or\n40",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 41,
@@ -97549,8 +98056,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p42_c82",
-      "text": "HEALTH INFORMATION 43\n(b) to certify that the derived information has been, or the copy\nor copies of the derived information have been (as the case\nmay be), deleted or destroyed.\n(3) A requestor who fails to comply with the Minister’s direction\n5under subsection (1) or (2) shall be guilty of an offence and shall be\nliable on conviction to a fine not exceeding $50,000 or to\nimprisonment for a term not exceeding 2 years or to both and, in\nthe case of a continuing offence, to a further fine not exceeding\n$1,000 for every day or part of a day during which the offence\n10continues after conviction.\nDivision 5 — Access restrictions\nAccess restrictions\n29.—(1) For the purposes of this Act, an access restriction is a\nmeasure that —\n15(a) prevents the access, collection and disclosure of any\naccessible health information about an individual (P) under\nthis Part (called in this Division a class 1 ac",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p42_c121",
+      "text": "HEALTH INFORMATION 43\n(b) tocertifythatthederivedinformationhasbeen,orthecopy\norcopiesofthederivedinformationhavebeen(asthecase\nmay be), deleted or destroyed.\n(3) A requestor who fails to comply with the Minister’s direction\n5under subsection (1) or (2) shall be guilty of an offence and shall be\nliable on conviction to a fine not exceeding $50,000 or to\nimprisonment for a term not exceeding 2 years or to both and, in\nthe case of a continuing offence, to a further fine not exceeding\n$1,000 for every day or part of a day during which the offence\n10continues after conviction.\nDivision 5 — Access restrictions\nAccess restrictions\n29.—(1) For the purposes of this Act, an access restriction is a\nmeasure that —\n15(a) prevents the access, collection and disclosure of any\naccessiblehealthinformationaboutanindividual(P)under\nthis Part (called in this Division a class 1 access\nrestriction); or\n(b) r",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 42,
@@ -97562,8 +98069,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p42_c83",
-      "text": "e access, collection and disclosure of any\naccessible health information about an individual (P) under\nthis Part (called in this Division a class 1 access\nrestriction); or\n(b) restricts the access, collection or disclosure of any\n20accessible health information about an individual\n(also P) under this Part in respect of one or more of the\nfollowing matters (called in this Division a class 2 access\nrestriction):\n(i) the type or types of accessible health information\n25about P that may be accessed, collected or disclosed;\n(ii) any attribute of or relating to any type of accessible\nhealth information about P that may be prescribed;\n(iii) the applicable person or applicable persons (by name\nor description) or class of applicable persons who\n30may access, collect or disclose accessible health\ninformation about P;\n41",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p42_c122",
+      "text": " and disclosure of any\naccessiblehealthinformationaboutanindividual(P)under\nthis Part (called in this Division a class 1 access\nrestriction); or\n(b) restricts the access, collection or disclosure of any\n20accessible health information about an individual\n(also P) under this Part in respect of one or more of the\nfollowing matters (called in this Division a class 2 access\nrestriction):\n(i) the type or types of accessible health information\n25aboutPthatmaybeaccessed,collectedordisclosed;\n(ii) any attribute of or relating to any type of accessible\nhealth information aboutP that may be prescribed;\n(iii) theapplicablepersonorapplicablepersons(byname\nor description) or class of applicable persons who\n30may access, collect or disclose accessible health\ninformation aboutP;\n41",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 42,
@@ -97575,8 +98082,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p43_c84",
-      "text": "44 NO. 1 OF 2026\n(iv) the purpose or purposes for which accessible health\ninformation about P may be accessed, collected or\ndisclosed;\n(v) the time or times at which, or the period or periods\n5 during which, accessible health information about P\nmay be accessed, collected or disclosed.\n(2) For the purposes of subsection (1)(b), the Minister may\nprescribe different types of class 2 access restrictions in relation to —\n(a) different classes of individuals;\n10 (b) different types of accessible health information about an\nindividual;\n(c) different attributes of or relating to any type of accessible\nhealth information about an individual;\n(d) different applicable persons or classes of applicable\n15 persons;\n(e) different purposes for which accessible health information\nabout an individual may be accessed, collected or\ndisclosed; and\n(f) different times at which or different periods during whi",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p43_c123",
+      "text": "44 NO. 1 OF 2026\n(iv) the purpose or purposes for which accessible health\ninformation aboutP may be accessed, collected or\ndisclosed;\n(v) the time or times at which, or the period or periods\n5 during which, accessible health information aboutP\nmay be accessed, collected or disclosed.\n(2) For the purposes of subsection (1)(b), the Minister may\nprescribedifferenttypesofclass2accessrestrictionsinrelationto—\n(a) different classes of individuals;\n10 (b) different types of accessible health information about an\nindividual;\n(c) different attributes of or relating to any type of accessible\nhealth information about an individual;\n(d) different applicable persons or classes of applicable\n15 persons;\n(e) different purposes for which accessible health information\nabout an individual may be accessed, collected or\ndisclosed; and\n(f) different times at which or different periods during which\n20 accessi",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 43,
@@ -97588,8 +98095,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p43_c85",
-      "text": "sible health information\nabout an individual may be accessed, collected or\ndisclosed; and\n(f) different times at which or different periods during which\n20 accessible health information about an individual may be\naccessed, collected or disclosed.\n(3) In this section, “applicable person” means —\n(a) a specified user; or\n(b) an approved user who is approved to access and collect\n25 accessible health information about any individual for a\npurpose mentioned in section 20(1)(a) or (b),\nand includes an authorised individual of any of them.\nEffect of access restrictions\n30.—(1) This section applies in relation to an access restriction in\n30 respect of accessible health information about an individual (P) that is\nin force, and applies despite anything in this Part.\n42",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p43_c124",
+      "text": "information\nabout an individual may be accessed, collected or\ndisclosed; and\n(f) different times at which or different periods during which\n20 accessible health information about an individual may be\naccessed, collected or disclosed.\n(3) In this section, “applicable person” means —\n(a) a specified user; or\n(b) an approved user who is approved to access and collect\n25 accessible health information about any individual for a\npurpose mentioned in section 20(1)(a) or (b),\nand includes an authorised individual of any of them.\nEffect of access restrictions\n30.—(1) This section applies in relation to an access restriction in\n30 respectofaccessiblehealthinformationaboutanindividual(P)thatis\nin force, and applies despite anything in this Part.\n42",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 43,
@@ -97601,8 +98108,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p44_c86",
-      "text": "HEALTH INFORMATION 45\n(2) Subject to subsections (3), (4) and (5) —\n(a) a class 1 access restriction prevents the access, collection\nand disclosure of accessible health information about P;\nand\n5(b) a class 2 access restriction allows the access, collection or\ndisclosure of accessible health information about P only to\nthe extent permitted under that access restriction.\n(3) An access restriction does not prevent or restrict the access,\ncollection or disclosure by a user in accordance with section 19, 20 or\n1021 of any type of accessible health information about P that may be\nprescribed for the purposes of this subsection.\n(4) An access restriction does not prevent or restrict the access,\ncollection or disclosure of accessible health information about P by a\nuser in accordance with section 19, 20 or 21, if the access, collection\n15or disclosure is necessary to respond to an emergency that",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p44_c125",
+      "text": "HEALTH INFORMATION 45\n(2) Subject to subsections (3), (4) and (5) —\n(a) a class 1 access restriction prevents the access, collection\nand disclosure of accessible health information aboutP;\nand\n5(b) a class 2 access restriction allows the access, collection or\ndisclosureofaccessiblehealthinformationabout Ponlyto\nthe extent permitted under that access restriction.\n(3) An access restriction does not prevent or restrict the access,\ncollectionordisclosurebyauserinaccordancewithsection19,20or\n1021 of any type of accessible health information aboutP that may be\nprescribed for the purposes of this subsection.\n(4) An access restriction does not prevent or restrict the access,\ncollectionordisclosureofaccessiblehealthinformationabout Pbya\nuser in accordance with section 19, 20 or 21, if the access, collection\n15or disclosure is necessary to respond to an emergency that threatens\nthe life or health ",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 44,
@@ -97614,8 +98121,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p44_c87",
-      "text": "tion about P by a\nuser in accordance with section 19, 20 or 21, if the access, collection\n15or disclosure is necessary to respond to an emergency that threatens\nthe life or health of P, whether or not P consents or is able, at the\nmaterial time, to consent to the access, collection or disclosure.\n(5) An access restriction does not prevent or restrict —\n(a) the provision of derived information to a requestor in\n20relation to an approval granted by the Minister under\nsection 25(2) or (3); or\n(b) the access, collection or disclosure of accessible health\ninformation about P by any person if the access, collection\nor disclosure is permitted or required under any other Act\n25or by an order of court.\n(6) The access, collection or disclosure of accessible health\ninformation about P is not considered to be permitted or required\nunder any Act merely because the individual has consented or has\ngive",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p44_c126",
+      "text": "rdance with section 19, 20 or 21, if the access, collection\n15or disclosure is necessary to respond to an emergency that threatens\nthe life or health ofP, whether or notP consents or is able, at the\nmaterial time, to consent to the access, collection or disclosure.\n(5) An access restriction does not prevent or restrict —\n(a) the provision of derived information to a requestor in\n20relation to an approval granted by the Minister under\nsection 25(2) or (3); or\n(b) the access, collection or disclosure of accessible health\ninformationabout Pbyanypersoniftheaccess,collection\nor disclosure is permitted or required under any other Act\n25or by an order of court.\n(6) The access, collection or disclosure of accessible health\ninformation about P is not considered to be permitted or required\nunder any Act merely because the individual has consented or has\ngivenhisorherconsenttoitinaccordancewithPart",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 44,
@@ -97627,8 +98134,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p44_c88",
-      "text": "essible health\ninformation about P is not considered to be permitted or required\nunder any Act merely because the individual has consented or has\ngiven his or her consent to it in accordance with Part 4 of the Personal\n30Data Protection Act 2012, or such consent is not required under that\nPart.\n(7) To avoid doubt, an access restriction does not prevent or\nrestrict —\n43",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p44_c127",
+      "text": "t considered to be permitted or required\nunder any Act merely because the individual has consented or has\ngivenhisorherconsenttoitinaccordancewithPart4ofthePersonal\n30Data Protection Act 2012, or such consent is not required under that\nPart.\n(7) To avoid doubt, an access restriction does not prevent or\nrestrict —\n43",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 44,
@@ -97640,7 +98147,7 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p45_c89",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p45_c128",
       "text": "46 NO. 1 OF 2026\n(a) the contribution of health information about P by a\ncontributor in accordance with this Part; or\n(b) the collection of that health information by a System\nOperator, in relation to the operation, administration and\n5 maintenance of the national electronic records system.\nImposition and revocation of access restrictions\n31.—(1) An individual may, in respect of accessible health\ninformation about the individual, request for —\n(a) the imposition of an access restriction; or\n10 (b) the revocation of an access restriction that is in force.\n(2) Despite subsection (1) or anything in the Mental Capacity\nAct 2008, a person mentioned in subsection (3) may, in relation to\naccessible health information about an individual (P) who lacks\ncapacity within the meaning given by that Act, request for —\n15 (a) the imposition of an access restriction in respect of\naccessible health inform",
       "metadata": {
         "source": "health-information-act-2026.pdf",
@@ -97653,8 +98160,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p45_c90",
-      "text": "cks\ncapacity within the meaning given by that Act, request for —\n15 (a) the imposition of an access restriction in respect of\naccessible health information about P; or\n(b) the revocation of an access restriction in respect of\naccessible health information about P that is in force.\n(3) The persons mentioned in subsection (2) are the following:\n20 (a) a donee of a lasting power of attorney granted by P under\nthe Mental Capacity Act 2008, under which P confers on\nthe donee authority to make decisions on P’s behalf for the\npurposes of this Part;\n(b) a deputy appointed or deemed to be appointed by the court\n25 under section 20 of the Mental Capacity Act 2008 to make\ndecisions on P’s behalf for the purposes of this Part.\n(4) A request mentioned in subsection (1) or (2) must —\n(a) be made to a System Operator in the form and manner\nprescribed; and\n30 (b) be accompanied by any document or inform",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p45_c129",
+      "text": "cks\ncapacity within the meaning given by that Act, request for —\n15 (a) the imposition of an access restriction in respect of\naccessible health information aboutP; or\n(b) the revocation of an access restriction in respect of\naccessible health information aboutP that is in force.\n(3) The persons mentioned in subsection (2) are the following:\n20 (a) a donee of a lasting power of attorney granted byP under\nthe Mental Capacity Act 2008, under whichP confers on\nthedoneeauthoritytomakedecisionson P’sbehalfforthe\npurposes of this Part;\n(b) adeputyappointedordeemedtobeappointedbythecourt\n25 undersection 20 ofthe Mental CapacityAct 2008to make\ndecisions onP’s behalf for the purposes of this Part.\n(4) A request mentioned in subsection (1) or (2) must —\n(a) be made to a System Operator in the form and manner\nprescribed; and\n30 (b) be accompanied by any document or information required\nby the System",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 45,
@@ -97666,8 +98173,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p45_c91",
-      "text": "n subsection (1) or (2) must —\n(a) be made to a System Operator in the form and manner\nprescribed; and\n30 (b) be accompanied by any document or information required\nby the System Operator.\n44",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p45_c130",
+      "text": " —\n(a) be made to a System Operator in the form and manner\nprescribed; and\n30 (b) be accompanied by any document or information required\nby the System Operator.\n44",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 45,
@@ -97679,8 +98186,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p46_c92",
-      "text": "HEALTH INFORMATION 47\n(5) Without limiting subsection (4)(b), a request to impose a class 2\naccess restriction must be accompanied by information about any\nmatter mentioned in section 29(1)(b) relating to the access restriction\nto be imposed.\n5(6) A System Operator may, in relation to a request under\nsubsection (1) or (2), require the individual or person to provide\nany additional document or information required by the System\nOperator.\n(7) Upon receiving a request mentioned in subsection (1) or (2), the\n10System Operator must impose the access restriction or revoke the\naccess restriction, as the case may be.\nAccess restrictions relating to health information about\ndeceased individuals\n32. Section 31 does not apply to or in relation to the revocation of\n15any access restriction imposed in respect of accessible health\ninformation about a deceased individual, where the access\nrestriction i",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p46_c131",
+      "text": "HEALTH INFORMATION 47\n(5) Withoutlimitingsubsection(4)(b),arequesttoimposeaclass2\naccess restriction must be accompanied by information about any\nmattermentionedinsection29(1)(b)relatingtotheaccessrestriction\nto be imposed.\n5(6) A System Operator may, in relation to a request under\nsubsection (1) or (2), require the individual or person to provide\nany additional document or information required by the System\nOperator.\n(7) Uponreceivingarequestmentionedinsubsection(1)or(2),the\n10System Operator must impose the access restriction or revoke the\naccess restriction, as the case may be.\nAccess restrictions relating to health information about\ndeceased individuals\n32. Section 31 does not apply to or in relation to the revocation of\n15any access restriction imposed in respect of accessible health\ninformation about a deceased individual, where the access\nrestriction is in force immediately before",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 46,
@@ -97692,8 +98199,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p46_c93",
-      "text": "revocation of\n15any access restriction imposed in respect of accessible health\ninformation about a deceased individual, where the access\nrestriction is in force immediately before the date of death of the\ndeceased individual.\nTransitional provision for this Division\n2033. If —\n(a) an individual (P), before the date of commencement of\nsection 31, notifies the Government to take any measure to\nprevent or restrict access to accessible health information\nabout P; and\n25(b) the measure mentioned in paragraph (a) is in force\nimmediately before that date,\na class 1 access restriction or class 2 access restriction (as the case\nmay be) in relation to accessible health information about P is\ndeemed to be imposed with effect from that date.\n45",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p46_c132",
+      "text": "striction imposed in respect of accessible health\ninformation about a deceased individual, where the access\nrestriction is in force immediately before the date of death of the\ndeceased individual.\nTransitional provision for this Division\n2033. If —\n(a) an individual (P), before the date of commencement of\nsection31,notifiestheGovernmenttotakeanymeasureto\nprevent or restrict access to accessible health information\nabout P; and\n25(b) the measure mentioned in paragraph (a) is in force\nimmediately before that date,\na class 1 access restriction or class 2 access restriction (as the case\nmay be) in relation to accessible health information about P is\ndeemed to be imposed with effect from that date.\n45",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 46,
@@ -97705,8 +98212,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p47_c94",
-      "text": "48 NO. 1 OF 2026\nDivision 6 — Action taken in response to\ncontraventions of this Part\nAction against contravening contributors, users, etc.\n34.—(1) Subject to this section and section 35, an authorised officer\n5 may in writing direct a System Operator to take any action described\nin subsection (2) against a contributor or user or an authorised\nindividual of a user (each X) if —\n(a) the authorised officer is satisfied that X is contravening or\nhas contravened any requirement under this Part, the\n10 contravention of which is not an offence under this Act;\n(b) the authorised officer —\n(i) has reason to believe that X is contravening or has\ncontravened any provision of this Act, the\ncontravention of which is an offence under this\n15 Act; and\n(ii) is satisfied that it is necessary to take the action in\norder to prevent or minimise any harm or damage to\nthe national electronic records system p",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p47_c133",
+      "text": "48 NO. 1 OF 2026\nDivision 6 — Action taken in response to\ncontraventions of this Part\nAction against contravening contributors, users, etc.\n34.—(1) Subjecttothissectionandsection35,anauthorisedofficer\n5 may in writing direct a System Operator to take any action described\nin subsection (2) against a contributor or user or an authorised\nindividual of a user (eachX) if —\n(a) the authorised officer is satisfied thatX is contravening or\nhas contravened any requirement under this Part, the\n10 contravention of which is not an offence under this Act;\n(b) the authorised officer —\n(i) has reason to believe thatX is contravening or has\ncontravened any provision of this Act, the\ncontravention of which is an offence under this\n15 Act; and\n(ii) is satisfied that it is necessary to take the action in\norder to prevent or minimise any harm or damage to\nthe national electronic records system pending the\no",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 47,
@@ -97718,8 +98225,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p47_c95",
-      "text": "i) is satisfied that it is necessary to take the action in\norder to prevent or minimise any harm or damage to\nthe national electronic records system pending the\noutcome of any proceedings against X for an offence\n20 arising from any contravention mentioned in\nsub‑paragraph (i);\n(c) X has been convicted of an offence under this Act; or\n(d) the authorised officer is satisfied that the public interest so\nrequires.\n25 (2) The actions that an authorised officer may direct a System\nOperator to take against X in respect of any of the circumstances\nmentioned in subsection (1) are as follows:\n(a) where X is a contributor — prevent X from contributing\nhealth information about any individual;\n30 (b) where X is a user —\n(i) prevent X and any authorised individual of X from\naccessing or collecting accessible health information\nabout any individual; or\n46",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p47_c134",
+      "text": "ied that it is necessary to take the action in\norder to prevent or minimise any harm or damage to\nthe national electronic records system pending the\noutcomeofanyproceedingsagainst Xfor anoffence\n20 arising from any contravention mentioned in\nsub‑paragraph (i);\n(c) X has been convicted of an offence under this Act; or\n(d) the authorised officer is satisfied that the public interest so\nrequires.\n25 (2) The actions that an authorised officer may direct a System\nOperator to take againstX in respect of any of the circumstances\nmentioned in subsection (1) are as follows:\n(a) where X is a contributor — preventX from contributing\nhealth information about any individual;\n30 (b) where X is a user —\n(i) prevent X and any authorised individual ofX from\naccessingorcollectingaccessiblehealthinformation\nabout any individual; or\n46",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 47,
@@ -97731,8 +98238,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p48_c96",
-      "text": "HEALTH INFORMATION 49\n(ii) allow X and any authorised individual of X to access\nor collect only —\n(A) the types of accessible health information\nabout any individual that are specified by the\n5authorised officer; or\n(B) accessible health information about the classes\nof individuals that are specified by the\nauthorised officer;\n(c) where X is an authorised individual of a user —\n10(i) prevent X from accessing or collecting accessible\nhealth information about any individual;\n(ii) allow X to access or collect only —\n(A) the types of accessible health information\nabout any individual that are specified by the\n15authorised officer; or\n(B) accessible health information about the classes\nof individuals that are specified by the\nauthorised officer; or\n(iii) require the user to appoint an individual approved by\n20the authorised officer to supervise X’s access and\ncollection of accessible health i",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p48_c135",
+      "text": "HEALTH INFORMATION 49\n(ii) allowX and any authorised individual ofX to access\nor collect only —\n(A) the types of accessible health information\nabout any individual that are specified by the\n5authorised officer; or\n(B) accessible health information about the classes\nof individuals that are specified by the\nauthorised officer;\n(c) where X is an authorised individual of a user —\n10(i) prevent X from accessing or collecting accessible\nhealth information about any individual;\n(ii) allow X to access or collect only —\n(A) the types of accessible health information\nabout any individual that are specified by the\n15authorised officer; or\n(B) accessible health information about the classes\nof individuals that are specified by the\nauthorised officer; or\n(iii) requiretheusertoappointanindividualapprovedby\n20the authorised officer to superviseX’s access and\ncollection of accessible health information;",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 48,
@@ -97744,8 +98251,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p48_c97",
-      "text": " or\n(iii) require the user to appoint an individual approved by\n20the authorised officer to supervise X’s access and\ncollection of accessible health information;\n(d) where X is an authorised individual of a specified user —\nrevoke the approval of X under section 18(1)(a)(iv).\n(3) For the purposes of subsection (1)(c), the authorised officer\n25must accept the person’s conviction as final.\nProcedure for action against contributors, users, etc., under\nsection 34\n35.—(1) Before giving a direction under section 34, an authorised\nofficer must, unless the authorised officer considers it not practicable\n30or desirable to do so in any particular case, give notice to the\ncontributor, user or authorised individual of a user (each X)\nconcerned —\n47",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p48_c136",
+      "text": "r\n(iii) requiretheusertoappointanindividualapprovedby\n20the authorised officer to superviseX’s access and\ncollection of accessible health information;\n(d) where X is an authorised individual of a specified user —\nrevoke the approval ofX under section 18(1)(a)(iv).\n(3) For the purposes of subsection (1)(c), the authorised officer\n25must accept the person’s conviction as final.\nProcedure for action against contributors, users, etc., under\nsection 34\n35.—(1) Before giving a direction under section 34, an authorised\nofficermust,unlesstheauthorisedofficerconsidersitnotpracticable\n30or desirable to do so in any particular case, give notice to the\ncontributor, user or authorised individual of a user (each X)\nconcerned —\n47",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 48,
@@ -97757,8 +98264,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p49_c98",
-      "text": "50 NO. 1 OF 2026\n(a) stating that the authorised officer intends to direct a System\nOperator to take action against X under section 34;\n(b) specifying the type of action mentioned in section 34(2)\nthat the authorised officer proposes to direct a System\n5 Operator to take, and each instance of contravention that is\nthe subject of the proposed action or the reason or reasons\nfor the proposed action; and\n(c) specifying the time (being not less than 14 days after the\ndate the notice is served on X) within which written\n10 representations may be made to the authorised officer with\nrespect to the proposed action.\n(2) The authorised officer may decide to issue a direction under\nsection 34 for the appropriate action to be taken —\n(a) after considering any written representation made to the\n15 authorised officer pursuant to the notice mentioned in\nsubsection (1); or\n(b) after the time specified i",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p49_c137",
+      "text": "50 NO. 1 OF 2026\n(a) statingthattheauthorisedofficerintendstodirectaSystem\nOperator to take action againstX under section 34;\n(b) specifying the type of action mentioned in section 34(2)\nthat the authorised officer proposes to direct a System\n5 Operatortotake,andeachinstanceofcontraventionthatis\nthe subject of the proposed action or the reason or reasons\nfor the proposed action; and\n(c) specifying the time (being not less than 14 days after the\ndate the notice is served on X) within which written\n10 representationsmaybemadetotheauthorisedofficerwith\nrespect to the proposed action.\n(2) The authorised officer may decide to issue a direction under\nsection 34 for the appropriate action to be taken —\n(a) after considering any written representation made to the\n15 authorised officer pursuant to the notice mentioned in\nsubsection (1); or\n(b) after the time specified in the notice under\nsubsecti",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 49,
@@ -97770,8 +98277,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p49_c99",
-      "text": "ing any written representation made to the\n15 authorised officer pursuant to the notice mentioned in\nsubsection (1); or\n(b) after the time specified in the notice under\nsubsection (1)(c), if no representation is so made or any\nwritten representation made is subsequently withdrawn.\n20 (3) However, subsection (2) does not apply where X has died, is\nadjudged bankrupt, has been dissolved or wound up or has otherwise\nceased to exist.\n(4) Where the authorised officer decides to issue a direction under\nsection 34 for the appropriate action to be taken against X, the\n25 authorised officer must serve a notice of the decision on —\n(a) X; and\n(b) a System Operator.\n(5) A decision by an authorised officer takes effect only on the date\nspecified in the notice.\n30 (6) A System Operator, on receiving a notice of an authorised\nofficer’s decision under subsection (4)(b), must take the action\nspecified in",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p49_c138",
+      "text": "ion made to the\n15 authorised officer pursuant to the notice mentioned in\nsubsection (1); or\n(b) after the time specified in the notice under\nsubsection (1)(c), if no representation is so made or any\nwritten representation made is subsequently withdrawn.\n20 (3) However, subsection (2) does not apply whereX has died, is\nadjudgedbankrupt, has beendissolved or wound up or has otherwise\nceased to exist.\n(4) Where the authorised officer decides to issue a direction under\nsection 34 for the appropriate action to be taken against X, the\n25 authorised officer must serve a notice of the decision on —\n(a) X; and\n(b) a System Operator.\n(5) Adecisionbyanauthorisedofficertakeseffectonlyonthedate\nspecified in the notice.\n30 (6) A System Operator, on receiving a notice of an authorised\nofficer’s decision under subsection (4)(b), must take the action\nspecifiedinthenoticewitheffectfromthedatethatthedecis",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 49,
@@ -97783,8 +98290,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p49_c100",
-      "text": "notice.\n30 (6) A System Operator, on receiving a notice of an authorised\nofficer’s decision under subsection (4)(b), must take the action\nspecified in the notice with effect from the date that the decision takes\neffect under subsection (5).\n48",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p49_c139",
+      "text": "iving a notice of an authorised\nofficer’s decision under subsection (4)(b), must take the action\nspecifiedinthenoticewitheffectfromthedatethatthedecisiontakes\neffect under subsection (5).\n48",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 49,
@@ -97796,7 +98303,7 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p50_c101",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p50_c140",
       "text": "HEALTH INFORMATION 51\nAppeal to Minister\n36.—(1) A contributor or user or an authorised individual of a user\nthat is aggrieved by the decision of an authorised officer to direct a\nSystem Operator to take any action against the contributor, user or\n5authorised individual of a user (as the case may be) under section 34\nmay appeal to the Minister against the decision.\n(2) An appeal under this section —\n(a) must be in writing;\n(b) must specify the grounds on which it is made; and\n10(c) must be made within the prescribed period after the\nappellant is notified of the authorised officer’s decision\nthat is appealed against.\n(3) The Minister may reject an appeal that fails to comply with\nsubsection (2).\n15(4) After consideration of an appeal, the Minister may —\n(a) reject the appeal and confirm the authorised officer’s\ndecision; or\n(b) allow the appeal and substitute or vary the authorised\noffice",
       "metadata": {
         "source": "health-information-act-2026.pdf",
@@ -97809,8 +98316,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p50_c102",
-      "text": "nister may —\n(a) reject the appeal and confirm the authorised officer’s\ndecision; or\n(b) allow the appeal and substitute or vary the authorised\nofficer’s decision.\n20(5) The Minister’s decision on an appeal is final.\n(6) Every appellant must be notified of the Minister’s decision\nunder subsection (4).\n(7) An appeal against an authorised officer’s decision does not\naffect the operation of the decision appealed against or prevent the\n25taking of action to implement the decision.\n(8) Unless otherwise directed by the Minister, the decision appealed\nagainst must be complied with until the determination of the appeal.\nMinister may designate others to hear appeals\n37.—(1) The Minister may designate any of the following persons\n30to hear and determine, in the Minister’s place, any appeal or a specific\nappeal under section 36:\n49",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p50_c141",
+      "text": "nister may —\n(a) reject the appeal and confirm the authorised officer’s\ndecision; or\n(b) allow the appeal and substitute or vary the authorised\nofficer’s decision.\n20(5) The Minister’s decision on an appeal is final.\n(6) Every appellant must be notified of the Minister’s decision\nunder subsection (4).\n(7) An appeal against an authorised officer’s decision does not\naffect the operation of the decision appealed against or prevent the\n25taking of action to implement the decision.\n(8) UnlessotherwisedirectedbytheMinister,thedecisionappealed\nagainst must be complied with until the determination of the appeal.\nMinister may designate others to hear appeals\n37.—(1) The Minister may designate any of the following persons\n30tohearanddetermine,intheMinister’splace,anyappealoraspecific\nappeal under section 36:\n49",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 50,
@@ -97822,8 +98329,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p51_c103",
-      "text": "52 NO. 1 OF 2026\n(a) the Second Minister (if any) for his or her Ministry;\n(b) any Minister of State, including a Senior Minister of State,\nfor his or her Ministry;\n(c) any Parliamentary Secretary, including a Senior\n5 Parliamentary Secretary, to his or her Ministry.\n(2) A reference to the Minister in section 36 includes a reference to\na person designated under subsection (1).\nDivision 7 — Offences under this Part\nOffences relating to improper access or collection of accessible\n10 health information by users or authorised individuals of users\n38.—(1) A specified user or an authorised individual of a specified\nuser must not access or collect accessible health information about\nany individual except for a specified purpose, or as otherwise\nrequired or permitted under this Act.\n15 (2) An approved user or an authorised individual of an approved\nuser must not —\n(a) access or collect any type ",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p51_c142",
+      "text": "52 NO. 1 OF 2026\n(a) the Second Minister (if any) for his or her Ministry;\n(b) anyMinisterofState,includingaSeniorMinisterofState,\nfor his or her Ministry;\n(c) any Parliamentary Secretary, including a Senior\n5 Parliamentary Secretary, to his or her Ministry.\n(2) Areferenceto theMinisterin section36 includesareferenceto\na person designated under subsection (1).\nDivision 7 — Offences under this Part\nOffencesrelatingtoimproperaccessorcollectionofaccessible\n10 health information by users or authorised individuals of users\n38.—(1) A specified user or an authorised individual of a specified\nuser must not access or collect accessible health information about\nany individual except for a specified purpose, or as otherwise\nrequired or permitted under this Act.\n15 (2) An approved user or an authorised individual of an approved\nuser must not —\n(a) access or collect any type of accessible health info",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 51,
@@ -97835,8 +98342,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p51_c104",
-      "text": "quired or permitted under this Act.\n15 (2) An approved user or an authorised individual of an approved\nuser must not —\n(a) access or collect any type of accessible health information\nthat is not specified in the notification published in respect\nof that approved user under section 20(2); or\n20 (b) access or collect accessible health information about any\nindividual except for a purpose specified in that\nnotification, or as otherwise required or permitted under\nthis Act.\n(3) A user or an authorised individual of a user (X) must not access\n25 or collect accessible health information about any individual if —\n(a) either of the following applies:\n(i) a class 1 access restriction is in force in respect of\naccessible health information about that individual;\n(ii) a class 2 access restriction is in force in respect of\n30 accessible health information about that individual,\nand X’s access or col",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p51_c143",
+      "text": " this Act.\n15 (2) An approved user or an authorised individual of an approved\nuser must not —\n(a) access or collect any type of accessible health information\nthat is not specified in the notification published in respect\nof that approved user under section 20(2); or\n20 (b) access or collect accessible health information about any\nindividual except for a purpose specified in that\nnotification, or as otherwise required or permitted under\nthis Act.\n(3) A user or an authorised individual of a user (X) must not access\n25 or collect accessible health information about any individual if —\n(a) either of the following applies:\n(i) a class 1 access restriction is in force in respect of\naccessible health information about that individual;\n(ii) a class 2 access restriction is in force in respect of\n30 accessible health information about that individual,\nand X’s access or collection of that accessibl",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 51,
@@ -97848,8 +98355,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p51_c105",
-      "text": " individual;\n(ii) a class 2 access restriction is in force in respect of\n30 accessible health information about that individual,\nand X’s access or collection of that accessible health\n50",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p51_c144",
+      "text": " 2 access restriction is in force in respect of\n30 accessible health information about that individual,\nand X’s access or collection of that accessible health\n50",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 51,
@@ -97861,8 +98368,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p52_c106",
-      "text": "HEALTH INFORMATION 53\ninformation is not in accordance with that access\nrestriction; and\n(b) X’s access or collection of accessible health information\nabout that individual is not otherwise permitted under\n5section 30(3), (4) or (5).\n(4) Except in a case where subsection (5) applies, a person who\ncontravenes subsection (1), (2) or (3) shall be guilty of an offence and\nshall be liable on conviction —\n(a) to a fine not exceeding $50,000 or to imprisonment for a\n10term not exceeding 2 years or to both, unless paragraph (b)\napplies; or\n(b) if the person has a prior qualifying conviction — to a fine\nnot exceeding $100,000 or to imprisonment for a term not\nexceeding 4 years or to both.\n15(5) A person who contravenes subsection (1), (2) or (3) by\naccessing or collecting accessible health information about any\nindividual for an excluded purpose shall be guilty of an offence and\nshall be liable o",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p52_c145",
+      "text": "HEALTH INFORMATION 53\ninformation is not in accordance with that access\nrestriction; and\n(b) X’s access or collection of accessible health information\nabout that individual is not otherwise permitted under\n5section 30(3), (4) or (5).\n(4) Except in a case where subsection (5) applies, a person who\ncontravenessubsection(1),(2)or(3)shallbeguiltyofanoffenceand\nshall be liable on conviction —\n(a) to a fine not exceeding $50,000 or to imprisonment for a\n10termnotexceeding2yearsortoboth,unlessparagraph(b)\napplies; or\n(b) if the person has a prior qualifying conviction — to a fine\nnot exceeding $100,000 or to imprisonment for a term not\nexceeding 4 years or to both.\n15(5) A person who contravenes subsection (1), (2) or (3) by\naccessing or collecting accessible health information about any\nindividual for an excluded purpose shall be guilty of an offence and\nshall be liable on conviction —\n(a) to ",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 52,
@@ -97874,8 +98381,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p52_c107",
-      "text": "accessing or collecting accessible health information about any\nindividual for an excluded purpose shall be guilty of an offence and\nshall be liable on conviction —\n(a) to a fine not exceeding $100,000 or to imprisonment for a\n20term not exceeding 4 years or to both, unless paragraph (b)\napplies; and\n(b) if the person has a prior qualifying conviction — to a fine\nnot exceeding $200,000 or to imprisonment for a term not\nexceeding 7 years or to both.\n25(6) In subsections (4) and (5), “qualifying conviction” means a\nconviction for an offence under subsection (4) or (5).\n(7) It is not a defence in any proceedings for an offence under\nsubsection (4) or (5) that the accused accessed or collected accessible\nhealth information about an individual on the basis that the individual\n30has consented or has given his or her consent in accordance with\nPart 4 of the Personal Data Protection Act 2012 or ",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p52_c146",
+      "text": "g accessible health information about any\nindividual for an excluded purpose shall be guilty of an offence and\nshall be liable on conviction —\n(a) to a fine not exceeding $100,000 or to imprisonment for a\n20termnotexceeding4yearsortoboth,unlessparagraph(b)\napplies; and\n(b) if the person has a prior qualifying conviction — to a fine\nnot exceeding $200,000 or to imprisonment for a term not\nexceeding 7 years or to both.\n25(6) In subsections (4) and (5), “qualifying conviction” means a\nconviction for an offence under subsection (4) or (5).\n(7) It is not a defence in any proceedings for an offence under\nsubsection(4)or(5)thattheaccusedaccessedorcollectedaccessible\nhealthinformationaboutanindividualonthebasisthattheindividual\n30has consented or has given his or her consent in accordance with\nPart4ofthePersonalDataProtectionAct2012orsuchconsentisnot\nrequired under that Part.\n(8) It is not a def",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 52,
@@ -97887,8 +98394,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p52_c108",
-      "text": "n the basis that the individual\n30has consented or has given his or her consent in accordance with\nPart 4 of the Personal Data Protection Act 2012 or such consent is not\nrequired under that Part.\n(8) It is not a defence in any proceedings for an offence under\nsubsection (4) or (5) in relation to a contravention of subsection (1)\n51",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p52_c147",
+      "text": "as given his or her consent in accordance with\nPart4ofthePersonalDataProtectionAct2012orsuchconsentisnot\nrequired under that Part.\n(8) It is not a defence in any proceedings for an offence under\nsubsection (4) or (5) in relation to a contravention of subsection (1)\n51",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 52,
@@ -97900,8 +98407,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p53_c109",
-      "text": "54 NO. 1 OF 2026\nthat the accused accessed or collected accessible health information\nabout an individual for more than one purpose, and any of those\npurposes is a specified purpose.\n(9) It is not a defence in any proceedings for an offence under\n5 subsection (4) or (5) in relation to a contravention of subsection (2)\nthat the accused accessed or collected accessible health information\nabout an individual for more than one purpose, and any of those\npurposes is a purpose mentioned in subsection (2)(b).\nOffences relating to access or collection of accessible health\n10 information by unauthorised persons\n39.—(1) A person who is not a user or an authorised individual of a\nuser must not access or collect accessible health information about\nany individual for any purpose, unless the access or collection is\nrequired or permitted under this Act or any other written law, or by an\n15 order of cour",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p53_c148",
+      "text": "54 NO. 1 OF 2026\nthat the accused accessed or collected accessible health information\nabout an individual for more than one purpose, and any of those\npurposes is a specified purpose.\n(9) It is not a defence in any proceedings for an offence under\n5 subsection (4) or (5) in relation to a contravention of subsection (2)\nthat the accused accessed or collected accessible health information\nabout an individual for more than one purpose, and any of those\npurposes is a purpose mentioned in subsection (2)(b).\nOffences relating to access or collection of accessible health\n10 information by unauthorised persons\n39.—(1) Apersonwhoisnotauseroranauthorisedindividualofa\nuser must not access or collect accessible health information about\nany individual for any purpose, unless the access or collection is\nrequiredorpermittedunderthisActoranyotherwrittenlaw,orbyan\n15 order of court.\n(2) A person who contr",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 53,
@@ -97913,8 +98420,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p53_c110",
-      "text": "ndividual for any purpose, unless the access or collection is\nrequired or permitted under this Act or any other written law, or by an\n15 order of court.\n(2) A person who contravenes subsection (1) shall be guilty of an\noffence and shall be liable on conviction to a fine not exceeding\n$100,000 or to imprisonment for a term not exceeding 4 years or to\nboth.\n20 (3) It is not a defence in any proceedings for an offence under\nsubsection (1) that the accused accessed or collected accessible health\ninformation about an individual on the basis that the individual has\nconsented or has given his or her consent in accordance with Part 4 of\nthe Personal Data Protection Act 2012 or such consent is not required\n25 under that Part.\nOffences relating to unauthorised disclosure of accessible\nhealth information\n40.—(1) A user or an authorised individual of a user must not\ndisclose accessible health inform",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p53_c149",
+      "text": "r any purpose, unless the access or collection is\nrequiredorpermittedunderthisActoranyotherwrittenlaw,orbyan\n15 order of court.\n(2) A person who contravenes subsection (1) shall be guilty of an\noffence and shall be liable on conviction to a fine not exceeding\n$100,000 or to imprisonment for a term not exceeding 4 years or to\nboth.\n20 (3) It is not a defence in any proceedings for an offence under\nsubsection(1)thattheaccusedaccessedorcollectedaccessiblehealth\ninformation about an individual on the basis that the individual has\nconsentedorhasgivenhisorherconsentinaccordancewithPart4of\nthePersonalDataProtectionAct2012orsuchconsentisnotrequired\n25 under that Part.\nOffences relating to unauthorised disclosure of accessible\nhealth information\n40.—(1) A user or an authorised individual of a user must not\ndisclose accessible health information about any individual, or any\n30 document that reprod",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 53,
@@ -97926,8 +98433,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p53_c111",
-      "text": "authorised disclosure of accessible\nhealth information\n40.—(1) A user or an authorised individual of a user must not\ndisclose accessible health information about any individual, or any\n30 document that reproduces (fully or substantially) accessible health\ninformation about any individual, to any other person, unless the\ndisclosure —\n(a) is necessary for the administration or execution of anything\nunder this Act;\n52",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p53_c150",
+      "text": "—(1) A user or an authorised individual of a user must not\ndisclose accessible health information about any individual, or any\n30 document that reproduces (fully or substantially) accessible health\ninformation about any individual, to any other person, unless the\ndisclosure —\n(a) isnecessaryfortheadministrationorexecutionofanything\nunder this Act;\n52",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 53,
@@ -97939,8 +98446,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p54_c112",
-      "text": "HEALTH INFORMATION 55\n(b) is required or permitted under this Act or any other written\nlaw, or by an order of court; or\n(c) is to any person or class of persons to whom, in the\nMinister’s opinion, it is in the public interest to disclose the\n5accessible health information.\n(2) A person who is not a user or an authorised individual of a user\nmust not disclose accessible health information about any individual,\nor any document reproducing (fully or substantially) accessible\nhealth information about any individual, unless the disclosure is\n10required or permitted under this Act or any other written law, or by an\norder of court.\n(3) A person who contravenes subsection (1) shall be guilty of an\noffence and shall be liable —\n(a) on the first conviction — to a fine not exceeding $50,000\n15or to imprisonment for a term not exceeding 2 years or to\nboth; and\n(b) on a second or subsequent convictio",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p54_c151",
+      "text": "HEALTH INFORMATION 55\n(b) isrequiredorpermittedunderthisActoranyotherwritten\nlaw, or by an order of court; or\n(c) is to any person or class of persons to whom, in the\nMinister’sopinion,itisinthepublicinteresttodisclosethe\n5accessible health information.\n(2) A person who is not a user or an authorised individual of a user\nmustnotdiscloseaccessiblehealthinformationaboutanyindividual,\nor any document reproducing (fully or substantially) accessible\nhealth information about any individual, unless the disclosure is\n10requiredorpermittedunderthisActoranyotherwrittenlaw,orbyan\norder of court.\n(3) A person who contravenes subsection (1) shall be guilty of an\noffence and shall be liable —\n(a) on the first conviction — to a fine not exceeding $50,000\n15or to imprisonment for a term not exceeding 2 years or to\nboth; and\n(b) on a second or subsequent conviction — to a fine not\nexceeding $100,000 or t",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 54,
@@ -97952,8 +98459,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p54_c113",
-      "text": "iction — to a fine not exceeding $50,000\n15or to imprisonment for a term not exceeding 2 years or to\nboth; and\n(b) on a second or subsequent conviction — to a fine not\nexceeding $100,000 or to imprisonment for a term not\nexceeding 4 years or to both.\n20(4) A person who contravenes subsection (2) shall be guilty of an\noffence and shall be liable on conviction to a fine not exceeding\n$100,000 or to imprisonment for a term not exceeding 4 years or to\nboth.\n(5) A person does not contravene subsection (1) or (2) only because\n25any information about an individual that is disclosed by the person, or\nis stated or contained in any document disclosed by the person, is\nidentical or substantially similar to accessible health information\nabout that individual.\n(6) It is a defence in any proceedings for an offence under\n30subsection (3) or (4) for the accused to prove, on a balance of\nprobabilities, t",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p54_c152",
+      "text": "15or to imprisonment for a term not exceeding 2 years or to\nboth; and\n(b) on a second or subsequent conviction — to a fine not\nexceeding $100,000 or to imprisonment for a term not\nexceeding 4 years or to both.\n20(4) A person who contravenes subsection (2) shall be guilty of an\noffence and shall be liable on conviction to a fine not exceeding\n$100,000 or to imprisonment for a term not exceeding 4 years or to\nboth.\n(5) Apersondoesnotcontravenesubsection(1)or(2)onlybecause\n25anyinformationaboutanindividualthatisdisclosedbytheperson,or\nis stated or contained in any document disclosed by the person, is\nidentical or substantially similar to accessible health information\nabout that individual.\n(6) It is a defence in any proceedings for an offence under\n30subsection (3) or (4) for the accused to prove, on a balance of\nprobabilities, that the accused did not know, and had no reason to\nbelieve, th",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 54,
@@ -97965,8 +98472,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p54_c114",
-      "text": "vidual.\n(6) It is a defence in any proceedings for an offence under\n30subsection (3) or (4) for the accused to prove, on a balance of\nprobabilities, that the accused did not know, and had no reason to\nbelieve, that the accused had disclosed accessible health information\nabout an individual or a document reproducing (fully or substantially)\naccessible health information about an individual, as the case may be.\n53",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p54_c153",
+      "text": "under\n30subsection (3) or (4) for the accused to prove, on a balance of\nprobabilities, that the accused did not know, and had no reason to\nbelieve, that the accused had disclosed accessible health information\naboutanindividualoradocumentreproducing(fullyorsubstantially)\naccessiblehealthinformationaboutanindividual,asthecasemaybe.\n53",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 54,
@@ -97978,8 +98485,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p55_c115",
-      "text": "56 NO. 1 OF 2026\n(7) It is not a defence in any proceedings for an offence under\nsubsection (3) or (4) that the accused disclosed accessible health\ninformation about an individual on the basis that the individual has\nconsented or has given his or her consent in accordance with Part 4 of\n5 the Personal Data Protection Act 2012 or such consent is not required\nunder that Part.\nOffences relating to derived information — requestors\n41.—(1) A requestor or an authorised individual of the requestor\nwho, without reasonable excuse —\n10 (a) discloses any type 1 derived information obtained by the\nrequestor in accordance with section 25, in contravention\nof section 27(3)(a);\n(b) uses any type 1 derived information in contravention of\nsection 27(3)(b); or\n15 (c) fails to delete or destroy any type 1 derived information or\ncopies thereof in contravention of section 27(3)(c),\nshall be guilty of an offe",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p55_c154",
+      "text": "56 NO. 1 OF 2026\n(7) It is not a defence in any proceedings for an offence under\nsubsection (3) or (4) that the accused disclosed accessible health\ninformation about an individual on the basis that the individual has\nconsentedorhasgivenhisorherconsentinaccordancewithPart4of\n5 thePersonalDataProtectionAct2012orsuchconsentisnotrequired\nunder that Part.\nOffences relating to derived information — requestors\n41.—(1) A requestor or an authorised individual of the requestor\nwho, without reasonable excuse —\n10 (a) discloses any type 1 derived information obtained by the\nrequestor in accordance with section 25, in contravention\nof section 27(3)(a);\n(b) uses any type 1 derived information in contravention of\nsection 27(3)(b); or\n15 (c) fails to delete or destroy any type 1 derived information or\ncopies thereof in contravention of section 27(3)(c),\nshall be guilty of an offence.\n(2) A requestor or ",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 55,
@@ -97991,8 +98498,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p55_c116",
-      "text": "or\n15 (c) fails to delete or destroy any type 1 derived information or\ncopies thereof in contravention of section 27(3)(c),\nshall be guilty of an offence.\n(2) A requestor or an authorised individual of the requestor who,\nwithout reasonable excuse —\n20 (a) discloses any type 2 derived information obtained by the\nrequestor in accordance with section 25, in contravention\nof section 27(5)(a);\n(b) uses any type 2 derived information in contravention of\nsection 27(5)(b);\n25 (c) does any act or takes any step to identify or cause the\nidentification of any individual from any type 2 derived\ninformation in contravention of section 27(5)(c); or\n(d) fails to delete or destroy any type 2 derived information or\ncopies thereof in contravention of section 27(5)(d),\n30 shall be guilty of an offence.\n(3) A person convicted of an offence under subsection (1) or (2)\nshall be liable on conviction —\n54",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p55_c155",
+      "text": "e or destroy any type 1 derived information or\ncopies thereof in contravention of section 27(3)(c),\nshall be guilty of an offence.\n(2) A requestor or an authorised individual of the requestor who,\nwithout reasonable excuse —\n20 (a) discloses any type 2 derived information obtained by the\nrequestor in accordance with section 25, in contravention\nof section 27(5)(a);\n(b) uses any type 2 derived information in contravention of\nsection 27(5)(b);\n25 (c) does any act or takes any step to identify or cause the\nidentification of any individual from any type 2 derived\ninformation in contravention of section 27(5)(c); or\n(d) fails to delete or destroy any type 2 derived information or\ncopies thereof in contravention of section 27(5)(d),\n30 shall be guilty of an offence.\n(3) A person convicted of an offence under subsection (1) or (2)\nshall be liable on conviction —\n54",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 55,
@@ -98004,8 +98511,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p56_c117",
-      "text": "HEALTH INFORMATION 57\n(a) to a fine not exceeding $50,000 or to imprisonment for a\nterm not exceeding 2 years or to both, unless paragraph (b)\napplies; and\n(b) if the person has a prior qualifying conviction — to a fine\n5not exceeding $100,000 or to imprisonment for a term not\nexceeding 4 years or to both.\n(4) In this section —\n“authorised individual” of a requestor means an individual who\nis, or belongs to a class of individuals, specified in the\n10approval granted by the Minister to the requestor in\naccordance with section 25(10)(b);\n“qualifying conviction” means a conviction for an offence under\nsubsection (1) or (2);\n“type 1 derived information” and “type 2 derived information”\n15have the meanings given by section 24.\nOffences relating to derived information — other persons\n42.—(1) A person who —\n(a) is not a requestor; and\n(b) without reasonable excuse, accesses, collects, discloses",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p56_c156",
+      "text": "HEALTH INFORMATION 57\n(a) to a fine not exceeding $50,000 or to imprisonment for a\ntermnotexceeding2yearsortoboth,unlessparagraph(b)\napplies; and\n(b) if the person has a prior qualifying conviction — to a fine\n5not exceeding $100,000 or to imprisonment for a term not\nexceeding 4 years or to both.\n(4) In this section —\n“authorised individual” of a requestor means an individual who\nis, or belongs to a class of individuals, specified in the\n10approval granted by the Minister to the requestor in\naccordance with section 25(10)(b);\n“qualifyingconviction”meansaconvictionforanoffenceunder\nsubsection (1) or (2);\n“type 1 derived information” and “type 2 derived information”\n15have the meanings given by section 24.\nOffences relating to derived information — other persons\n42.—(1) A person who —\n(a) is not a requestor; and\n(b) without reasonable excuse, accesses, collects, discloses or\n20uses any inf",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 56,
@@ -98017,8 +98524,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p56_c118",
-      "text": "to derived information — other persons\n42.—(1) A person who —\n(a) is not a requestor; and\n(b) without reasonable excuse, accesses, collects, discloses or\n20uses any information that the person knows or has reason\nto believe is derived information,\nshall be guilty of an offence.\n(2) A person who —\n(a) is not a requestor;\n25(b) without reasonable excuse, does any act or takes any step\nto identify or cause the identification of any individual\nfrom aggregated or anonymised health information; and\n(c) knows or has reason to believe that the aggregated or\nanonymised health information mentioned in paragraph (b)\n30is type 2 derived information within the meaning given by\nsection 24,\nshall be guilty of an offence.\n55",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p56_c157",
+      "text": "tion — other persons\n42.—(1) A person who —\n(a) is not a requestor; and\n(b) without reasonable excuse, accesses, collects, discloses or\n20uses any information that the person knows or has reason\nto believe is derived information,\nshall be guilty of an offence.\n(2) A person who —\n(a) is not a requestor;\n25(b) without reasonable excuse, does any act or takes any step\nto identify or cause the identification of any individual\nfrom aggregated or anonymised health information; and\n(c) knows or has reason to believe that the aggregated or\nanonymisedhealthinformationmentionedinparagraph(b)\n30is type 2 derived information within the meaning given by\nsection 24,\nshall be guilty of an offence.\n55",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 56,
@@ -98030,8 +98537,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p57_c119",
-      "text": "58 NO. 1 OF 2026\n(3) A person convicted of an offence under subsection (1) or (2)\nshall be liable on conviction to a fine not exceeding $100,000 or to\nimprisonment for a term not exceeding 4 years or to both.\nDivision 8 — Miscellaneous\n5 Directions relating to access, collection, possession and control\nof accessible health information by unauthorised persons\n43.—(1) This section applies to a person (X) that is not a user, or an\nauthorised individual of a user within the meaning of section 18(1)\nor (2).\n10 (2) If —\n(a) the Minister has reason to believe that X is contravening or\nhas contravened section 39(1), and it is necessary for X to\ntake any action mentioned in paragraph (c) or (d) in order\nto prevent or minimise any harm or damage to any\n15 individual pending the outcome of any proceedings against\nX for an offence arising from that contravention; or\n(b) X is convicted of an offence ",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p57_c158",
+      "text": "58 NO. 1 OF 2026\n(3) A person convicted of an offence under subsection (1) or (2)\nshall be liable on conviction to a fine not exceeding $100,000 or to\nimprisonment for a term not exceeding 4 years or to both.\nDivision 8 — Miscellaneous\n5 Directionsrelatingtoaccess,collection,possessionandcontrol\nof accessible health information by unauthorised persons\n43.—(1) Thissectionappliestoaperson(X)thatisnotauser,oran\nauthorised individual of a user within the meaning of section 18(1)\nor (2).\n10 (2) If —\n(a) theMinisterhasreasontobelievethat Xiscontraveningor\nhas contravened section 39(1), and it is necessary forX to\ntake any action mentioned in paragraph (c) or (d) in order\nto prevent or minimise any harm or damage to any\n15 individualpendingtheoutcomeofanyproceedingsagainst\nX for an offence arising from that contravention; or\n(b) Xisconvictedofanoffencearisingfromacontraventionof\nsection 39(1),\n",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 57,
@@ -98043,8 +98550,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p57_c120",
-      "text": "ny\n15 individual pending the outcome of any proceedings against\nX for an offence arising from that contravention; or\n(b) X is convicted of an offence arising from a contravention of\nsection 39(1),\nthe Minister may, by written notice, direct X —\n20 (c) to stop accessing or collecting accessible health\ninformation about any individual; and\n(d) to delete or destroy all copies of any such accessible health\ninformation that is in the possession or under the control\nof X.\n25 (3) If the Minister has reason to believe that —\n(a) accessible health information about any individual is in the\npossession or under the control of X; and\n56",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p57_c159",
+      "text": "omeofanyproceedingsagainst\nX for an offence arising from that contravention; or\n(b) Xisconvictedofanoffencearisingfromacontraventionof\nsection 39(1),\nthe Minister may, by written notice, directX —\n20 (c) to stop accessing or collecting accessible health\ninformation about any individual; and\n(d) todeleteordestroyallcopiesofanysuchaccessiblehealth\ninformation that is in the possession or under the control\nof X.\n25 (3) If the Minister has reason to believe that —\n(a) accessiblehealthinformationaboutanyindividualisinthe\npossession or under the control ofX; and\n56",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 57,
@@ -98056,8 +98563,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p58_c121",
-      "text": "HEALTH INFORMATION 59\n(b) X’s possession or control of that accessible health\ninformation is not required or permitted under this Act\nor any other written law, or by an order of court,\nthe Minister may, by written notice, direct X to delete or destroy all\n5copies of that accessible health information that is in the possession or\nunder the control of X.\n(4) If the Minister directs X to take any action under\nsubsection (2)(d) or (3), the Minister may additionally direct X —\n(a) to delete or destroy the copies of the accessible health\n10information in the manner specified by the Minister; or\n(b) to certify to the Minister that the copies of the accessible\nhealth information have been deleted or destroyed.\n(5) A person who, without reasonable excuse, fails to comply with\nthe Minister’s direction under subsection (2), (3) or (4) shall be guilty\n15of an offence and shall be liable on convictio",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p58_c160",
+      "text": "HEALTH INFORMATION 59\n(b) X’s possession or control of that accessible health\ninformation is not required or permitted under this Act\nor any other written law, or by an order of court,\nthe Minister may, by written notice, directX to delete or destroy all\n5copiesofthataccessiblehealthinformationthatisinthepossessionor\nunder the control ofX.\n(4) If the Minister directs X to take any action under\nsubsection (2)(d) or (3), the Minister may additionally directX —\n(a) to delete or destroy the copies of the accessible health\n10information in the manner specified by the Minister; or\n(b) to certify to the Minister that the copies of the accessible\nhealth information have been deleted or destroyed.\n(5) A person who, without reasonable excuse, fails to comply with\ntheMinister’sdirectionundersubsection(2),(3)or(4)shallbeguilty\n15ofanoffenceandshallbeliableonconvictiontoafinenotexceeding\n$50,000 or t",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 58,
@@ -98069,8 +98576,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p58_c122",
-      "text": "xcuse, fails to comply with\nthe Minister’s direction under subsection (2), (3) or (4) shall be guilty\n15of an offence and shall be liable on conviction to a fine not exceeding\n$50,000 or to imprisonment for a term not exceeding 2 years or to\nboth and, in the case of a continuing offence, to a further fine not\nexceeding $1,000 for each day or part of a day during which the\noffence continues after conviction.\n20(6) For the purposes of this section, the possession or control of\naccessible health information about an individual is not considered to\nbe required or permitted under any written law merely because the\nindividual has consented or has given his or her consent in accordance\nwith Part 4 of the Personal Data Protection Act 2012, or such consent\n25is not required under that Part.\nTransitional provisions for this Part\n44.—(1) If —\n(a) a person is party to any contract or agreement with ",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p58_c161",
+      "text": "o comply with\ntheMinister’sdirectionundersubsection(2),(3)or(4)shallbeguilty\n15ofanoffenceandshallbeliableonconvictiontoafinenotexceeding\n$50,000 or to imprisonment for a term not exceeding 2 years or to\nboth and, in the case of a continuing offence, to a further fine not\nexceeding $1,000 for each day or part of a day during which the\noffence continues after conviction.\n20(6) For the purposes of this section, the possession or control of\naccessiblehealthinformationaboutanindividualisnotconsideredto\nbe required or permitted under any written law merely because the\nindividualhasconsentedorhasgivenhisorherconsentinaccordance\nwithPart4ofthePersonalDataProtectionAct2012,orsuchconsent\n25is not required under that Part.\nTransitional provisions for this Part\n44.—(1) If —\n(a) a person is party to any contract or agreement with the\nGovernment under which the person contributes or agrees\n30tocontri",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 58,
@@ -98082,8 +98589,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p58_c123",
-      "text": "consent\n25is not required under that Part.\nTransitional provisions for this Part\n44.—(1) If —\n(a) a person is party to any contract or agreement with the\nGovernment under which the person contributes or agrees\n30to contribute health information about any individual to the\nnational electronic records system;\n(b) the contract or agreement mentioned in paragraph (a) is in\nforce immediately before the date of commencement of\nsection 13; and\n57",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p58_c162",
+      "text": " this Part\n44.—(1) If —\n(a) a person is party to any contract or agreement with the\nGovernment under which the person contributes or agrees\n30tocontributehealthinformationaboutanyindividualtothe\nnational electronic records system;\n(b) the contract or agreement mentioned in paragraph (a) is in\nforce immediately before the date of commencement of\nsection 13; and\n57",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 58,
@@ -98095,8 +98602,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p59_c124",
-      "text": "60 NO. 1 OF 2026\n(c) the person is not a person mentioned in section 12(1),\nthen the following applies:\n(d) the person is deemed to be an approved contributor\napproved under section 13(1) with effect from that date;\n5 (e) all conditions and restrictions (if any) specified in the\ncontract or agreement mentioned in paragraph (a) are\ndeemed to be conditions and restrictions mentioned in\nsection 13(2)(c) that the person must comply with;\n(f) the Minister must publish a notification in the Gazette in\n10 respect of the person specifying the matters in\nsection 13(2).\n(2) If —\n(a) a person is party to any contract or agreement with the\nGovernment under which the person is allowed to access\n15 and collect health information about one or more\nindividuals that is made available on the national\nelectronic records system;\n(b) the contract or agreement mentioned in paragraph (a) is in\nforce immediatel",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p59_c163",
+      "text": "60 NO. 1 OF 2026\n(c) the person is not a person mentioned in section 12(1),\nthen the following applies:\n(d) the person is deemed to be an approved contributor\napproved under section 13(1) with effect from that date;\n5 (e) all conditions and restrictions (if any) specified in the\ncontract or agreement mentioned in paragraph (a) are\ndeemed to be conditions and restrictions mentioned in\nsection 13(2)(c) that the person must comply with;\n(f) the Minister must publish a notification in theGazette in\n10 respect of the person specifying the matters in\nsection 13(2).\n(2) If —\n(a) a person is party to any contract or agreement with the\nGovernment under which the person is allowed to access\n15 and collect health information about one or more\nindividuals that is made available on the national\nelectronic records system;\n(b) the contract or agreement mentioned in paragraph (a) is in\nforce immediately",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 59,
@@ -98108,8 +98615,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p59_c125",
-      "text": "uals that is made available on the national\nelectronic records system;\n(b) the contract or agreement mentioned in paragraph (a) is in\nforce immediately before the date of commencement of\n20 section 20; and\n(c) the person is not a person mentioned in section 19(1),\nthen the following applies:\n(d) the person is deemed to be an approved user approved\nunder section 20(1) with effect from that date;\n25 (e) all conditions and restrictions (if any) specified in the\ncontract or agreement mentioned in paragraph (a) are\ndeemed to be conditions and restrictions mentioned in\nsection 20(2)(e) that the person must comply with;\n(f) the Minister must publish a notification in the Gazette in\n30 respect of the person specifying the matters in\nsection 20(2).\n58",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p59_c164",
+      "text": "als that is made available on the national\nelectronic records system;\n(b) the contract or agreement mentioned in paragraph (a) is in\nforce immediately before the date of commencement of\n20 section 20; and\n(c) the person is not a person mentioned in section 19(1),\nthen the following applies:\n(d) the person is deemed to be an approved user approved\nunder section 20(1) with effect from that date;\n25 (e) all conditions and restrictions (if any) specified in the\ncontract or agreement mentioned in paragraph (a) are\ndeemed to be conditions and restrictions mentioned in\nsection 20(2)(e) that the person must comply with;\n(f) the Minister must publish a notification in theGazette in\n30 respect of the person specifying the matters in\nsection 20(2).\n58",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 59,
@@ -98121,8 +98628,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p60_c126",
-      "text": "HEALTH INFORMATION 61\n(3) A person that —\n(a) is a party to any contract or agreement with the\nGovernment under which the person is allowed to access\nand collect health information about one or more\n5individuals that is made available on the national\nelectronic records system; and\n(b) before the date of commencement of sections 19 and 20\n(called in this subsection the relevant date), accesses and\ncollects health information about any individual so made\n10available,\nmay, subject to the provisions of this Act, retain and use that health\ninformation on or after the relevant date for the purposes for which\nthe health information was accessed and collected under the contract\nor agreement mentioned in paragraph (a).\n15PART 3\nSHARING OF RELEV ANT INFORMA TION FOR\nSPECIFIED USE CASES\nInterpretation of this Part\n45. In this Part —\n20“data request” means a request by a recipient to a discloser,\npu",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p60_c165",
+      "text": "HEALTH INFORMATION 61\n(3) A person that —\n(a) is a party to any contract or agreement with the\nGovernment under which the person is allowed to access\nand collect health information about one or more\n5individuals that is made available on the national\nelectronic records system; and\n(b) before the date of commencement of sections 19 and 20\n(called in this subsection the relevant date), accesses and\ncollects health information about any individual so made\n10available,\nmay, subject to the provisions of this Act, retain and use that health\ninformation on or after the relevant date for the purposes for which\nthe health information was accessed and collected under the contract\nor agreement mentioned in paragraph (a).\n15PART 3\nSHARING OF RELEVANT INFORMATION FOR\nSPECIFIED USE CASES\nInterpretation of this Part\n45. In this Part —\n20“data request” means a request by a recipient to a discloser,\npurs",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 60,
@@ -98134,8 +98641,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p60_c127",
-      "text": "INFORMA TION FOR\nSPECIFIED USE CASES\nInterpretation of this Part\n45. In this Part —\n20“data request” means a request by a recipient to a discloser,\npursuant to a data sharing agreement, for the disclosure of\nrelevant information about one or more individuals in the\npossession or under the control of the discloser;\n“data sharing agreement” means an agreement between a\n25discloser and a recipient that satisfies the requirements\nmentioned in section 52;\n“discloser” means a person or public agency who discloses or\nintends to disclose relevant information in relation to a use\ncase;\n30“personnel” —\n(a) in relation to a discloser or recipient, means an\nindividual who —\n59",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p60_c166",
+      "text": "NFORMATION FOR\nSPECIFIED USE CASES\nInterpretation of this Part\n45. In this Part —\n20“data request” means a request by a recipient to a discloser,\npursuant to a data sharing agreement, for the disclosure of\nrelevant information about one or more individuals in the\npossession or under the control of the discloser;\n“data sharing agreement” means an agreement between a\n25discloser and a recipient that satisfies the requirements\nmentioned in section 52;\n“discloser” means a person or public agency who discloses or\nintends to disclose relevant information in relation to a use\ncase;\n30“personnel” —\n(a) in relation to a discloser or recipient, means an\nindividual who —\n59",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 60,
@@ -98147,8 +98654,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p61_c128",
-      "text": "62 NO. 1 OF 2026\n(i) is employed or engaged by the discloser or\nrecipient, as the case may be; or\n(ii) provides, as a volunteer, any service —\n(A) to the discloser or recipient, as the case\n5 may be; or\n(B) to any other person on behalf of the\ndiscloser or recipient, as the case may be;\nor\n(b) in relation to a health data intermediary of a discloser\n10 or recipient, means an individual who is employed or\nengaged by the health data intermediary;\n“recipient” means a person or public agency who collects or\nuses, or intends to collect or use relevant information in\nrelation to a use case.\n15 Meaning of “relevant information”\n46.—(1) In this Part, “relevant information” about an individual (P)\nmeans —\n(a) any type of administrative information or clinical\ninformation about P; or\n20 (b) any other type of individually‑identifiable information\nrelating to —\n(i) P; or\n(ii) any individual who prov",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p61_c167",
+      "text": "62 NO. 1 OF 2026\n(i) is employed or engaged by the discloser or\nrecipient, as the case may be; or\n(ii) provides, as a volunteer, any service —\n(A) to the discloser or recipient, as the case\n5 may be; or\n(B) to any other person on behalf of the\ndiscloserorrecipient,asthecasemaybe;\nor\n(b) inrelationtoahealthdataintermediaryofadiscloser\n10 orrecipient,meansanindividualwhoisemployedor\nengaged by the health data intermediary;\n“recipient” means a person or public agency who collects or\nuses, or intends to collect or use relevant information in\nrelation to a use case.\n15 Meaning of “relevant information”\n46.—(1) InthisPart,“relevantinformation”aboutanindividual(P)\nmeans —\n(a) any type of administrative information or clinical\ninformation aboutP; or\n20 (b) any other type of individually‑identifiable information\nrelating to —\n(i) P; or\n(ii) any individual who provides care to P, or is\nresponsible",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 61,
@@ -98160,8 +98667,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p61_c129",
-      "text": "r clinical\ninformation about P; or\n20 (b) any other type of individually‑identifiable information\nrelating to —\n(i) P; or\n(ii) any individual who provides care to P, or is\nresponsible for P’s care and welfare,\n25 as may be prescribed for a use case.\nIllustration\nThe name and contact information of an individual who is the caregiver for P\nare examples of relevant information about P.\n(2) For the purposes of subsection (1), different types of relevant\n30 information may be prescribed for different use cases.\n60",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p61_c168",
+      "text": "r\n20 (b) any other type of individually‑identifiable information\nrelating to —\n(i) P; or\n(ii) any individual who provides care to P, or is\nresponsible forP’s care and welfare,\n25 as may be prescribed for a use case.\nIllustration\nThenameandcontactinformationofanindividualwhoisthecaregiverfor P\nare examples of relevant information aboutP.\n(2) For the purposes of subsection (1), different types of relevant\n30 information may be prescribed for different use cases.\n60",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 61,
@@ -98173,8 +98680,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p62_c130",
-      "text": "HEALTH INFORMATION 63\nMeaning of “use case”\n47. In this Part, “use case” means a use case specified in the\nthird column of Part 1 of the Fourth Schedule in relation to which —\n(a) a discloser discloses relevant information about an\n5individual to a recipient; and\n(b) the recipient —\n(i) collects that relevant information from the discloser;\nand\n(ii) uses that relevant information,\n10for a purpose that comes within the scope of that use case.\nApplication of this Part\n48.—(1) This Part does not apply to the disclosure, collection and\nuse of accessible health information about any individual.\n(2) This Part does not prevent or restrict the disclosure, collection\n15or use of relevant information about any individual in accordance\nwith any other provision of this Act or any other written law or rule of\nlaw or by an order of court.\n(3) A person is not to be taken to be a discloser or recipient ",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p62_c169",
+      "text": "HEALTH INFORMATION 63\nMeaning of “use case”\n47. In this Part, “use case” means a use case specified in the\nthird column of Part 1 of the Fourth Schedule in relation to which —\n(a) a discloser discloses relevant information about an\n5individual to a recipient; and\n(b) the recipient —\n(i) collects that relevant information from the discloser;\nand\n(ii) uses that relevant information,\n10for a purpose that comes within the scope of that use case.\nApplication of this Part\n48.—(1) This Part does not apply to the disclosure, collection and\nuse of accessible health information about any individual.\n(2) This Part does not prevent or restrict the disclosure, collection\n15or use of relevant information about any individual in accordance\nwithanyotherprovisionofthisActoranyotherwrittenlaworruleof\nlaw or by an order of court.\n(3) A person is not to be taken to be a discloser or recipient on the\nbasis t",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 62,
@@ -98186,8 +98693,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p62_c131",
-      "text": "provision of this Act or any other written law or rule of\nlaw or by an order of court.\n(3) A person is not to be taken to be a discloser or recipient on the\nbasis that the person is a contributor or user under this Act or a\n20requestor within the meaning given by section 6.\n(4) To avoid doubt, nothing in this Part imposes an obligation on a\ndiscloser to collect relevant information about any individual for the\npurpose of enabling the discloser to disclose the relevant information\nto any recipient under this Part.\n25Application of this Part to disclosers, etc., acting through\nhealth data intermediaries or directly\n49.—(1) This Part applies equally to both a discloser who discloses\nrelevant information about any individual through a health data\nintermediary, and a discloser who discloses relevant information\n30directly.\n(2) This Part applies equally to both a recipient who collects or uses",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p62_c170",
+      "text": "visionofthisActoranyotherwrittenlaworruleof\nlaw or by an order of court.\n(3) A person is not to be taken to be a discloser or recipient on the\nbasis that the person is a contributor or user under this Act or a\n20requestor within the meaning given by section 6.\n(4) To avoid doubt, nothing in this Part imposes an obligation on a\ndiscloser to collect relevant information about any individual for the\npurposeofenablingthedisclosertodisclosetherelevantinformation\nto any recipient under this Part.\n25Application of this Part to disclosers, etc., acting through\nhealth data intermediaries or directly\n49.—(1) ThisPartappliesequallytobothadiscloserwhodiscloses\nrelevant information about any individual through a health data\nintermediary, and a discloser who discloses relevant information\n30directly.\n(2) ThisPartappliesequallytobotharecipientwhocollectsoruses\nrelevant information about any individual ",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 62,
@@ -98199,8 +98706,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p62_c132",
-      "text": "ta\nintermediary, and a discloser who discloses relevant information\n30directly.\n(2) This Part applies equally to both a recipient who collects or uses\nrelevant information about any individual through a health data\n61",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p62_c171",
+      "text": " who discloses relevant information\n30directly.\n(2) ThisPartappliesequallytobotharecipientwhocollectsoruses\nrelevant information about any individual through a health data\n61",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 62,
@@ -98212,8 +98719,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p63_c133",
-      "text": "64 NO. 1 OF 2026\nintermediary, and a recipient who collects or uses relevant\ninformation directly.\nIndividual’s consent not required under this Part\n50.—(1) Despite any other written law or rule of law or any\n5 obligation of confidentiality imposed by contract, the consent of an\nindividual (P) is not required for the disclosure by a discloser of\nrelevant information about P to a recipient in accordance with this\nPart.\n(2) Despite any other written law or rule of law or any obligation of\n10 confidentiality imposed by contract, P’s consent is not required for —\n(a) a recipient’s collection of relevant information about P\ndisclosed by a discloser to the recipient in accordance with\nthis Part; and\n(b) the recipient’s use of the relevant information mentioned in\n15 paragraph (a) in accordance with this Part.\nSharing of relevant information under this Part\n51.—(1) A discloser (A) must not, in ",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p63_c172",
+      "text": "64 NO. 1 OF 2026\nintermediary, and a recipient who collects or uses relevant\ninformation directly.\nIndividual’s consent not required under this Part\n50.—(1) Despite any other written law or rule of law or any\n5 obligation of confidentiality imposed by contract, the consent of an\nindividual (P) is not required for the disclosure by a discloser of\nrelevant information aboutP to a recipient in accordance with this\nPart.\n(2) Despiteanyotherwrittenlaworruleoflaworanyobligationof\n10 confidentialityimposedbycontract, P’sconsentisnotrequiredfor—\n(a) a recipient’s collection of relevant information aboutP\ndisclosedbyadisclosertotherecipientinaccordancewith\nthis Part; and\n(b) therecipient’suseoftherelevantinformationmentionedin\n15 paragraph (a) in accordance with this Part.\nSharing of relevant information under this Part\n51.—(1) Adiscloser(A)mustnot,inrelationtoausecase,disclose\nrelevant informati",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 63,
@@ -98225,8 +98732,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p63_c134",
-      "text": "tion mentioned in\n15 paragraph (a) in accordance with this Part.\nSharing of relevant information under this Part\n51.—(1) A discloser (A) must not, in relation to a use case, disclose\nrelevant information about any individual to a recipient (B)\nunless A —\n20 (a) is a person that is specified (by name or description), or\nbelongs to a class of persons that is specified, in the\nfirst column of Part 1 of the Fourth Schedule opposite B\nand that use case; and\n(b) complies with the requirements under this Part.\n25 (2) B must not, in relation to a use case —\n(a) collect relevant information about any individual from A;\nor\n(b) use the relevant information mentioned in paragraph (a),\nunless B —\n30 (c) is a person that is specified (by name or description), or\nbelongs to a class of persons that is specified, in the\n62",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p63_c173",
+      "text": "cordance with this Part.\nSharing of relevant information under this Part\n51.—(1) Adiscloser(A)mustnot,inrelationtoausecase,disclose\nrelevant information about any individual to a recipient (B)\nunless A —\n20 (a) is a person that is specified (by name or description), or\nbelongs to a class of persons that is specified, in the\nfirst column of Part 1 of the Fourth Schedule oppositeB\nand that use case; and\n(b) complies with the requirements under this Part.\n25 (2) B must not, in relation to a use case —\n(a) collect relevant information about any individual fromA;\nor\n(b) use the relevant information mentioned in paragraph (a),\nunless B —\n30 (c) is a person that is specified (by name or description), or\nbelongs to a class of persons that is specified, in the\n62",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 63,
@@ -98238,8 +98745,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p64_c135",
-      "text": "HEALTH INFORMATION 65\nsecond column of Part 1 of the Fourth Schedule opposite A\nand that use case; and\n(d) complies with the requirements under this Part.\nData sharing agreements\n552.—(1) This section applies if —\n(a) a person or public agency (A) intends to disclose relevant\ninformation about any individual to another person or\npublic agency (B) in relation to a use case; and\n(b) B intends to collect and use the relevant information\n10disclosed by A in relation to that use case.\n(2) A must not disclose relevant information about any individual to\nB unless A and B have entered into an agreement that satisfies the\nrequirements in this section.\n(3) The agreement mentioned in subsection (2) must be in writing\n15and must specify all of the following:\n(a) the particulars of A and B, including any particulars that\nmay be prescribed;\n(b) that the agreement is in respect of the disclosure, colle",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p64_c174",
+      "text": "HEALTH INFORMATION 65\nsecondcolumnofPart1oftheFourthScheduleopposite A\nand that use case; and\n(d) complies with the requirements under this Part.\nData sharing agreements\n552.—(1) This section applies if —\n(a) a person or public agency (A) intends to disclose relevant\ninformation about any individual to another person or\npublic agency (B) in relation to a use case; and\n(b) B intends to collect and use the relevant information\n10disclosed byA in relation to that use case.\n(2) Amustnotdiscloserelevantinformationaboutanyindividualto\nB unless A and B have entered into an agreement that satisfies the\nrequirements in this section.\n(3) The agreement mentioned in subsection (2) must be in writing\n15and must specify all of the following:\n(a) the particulars ofA and B, including any particulars that\nmay be prescribed;\n(b) thattheagreementisinrespectofthedisclosure,collection\nand use of relevant inf",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 64,
@@ -98251,8 +98758,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p64_c136",
-      "text": "owing:\n(a) the particulars of A and B, including any particulars that\nmay be prescribed;\n(b) that the agreement is in respect of the disclosure, collection\nand use of relevant information about any individual in\n20relation to the use case mentioned in subsection (1) in\naccordance with this Part;\n(c) subject to subsection (4), every type of relevant\ninformation about any individual that may be disclosed,\ncollected and used under the agreement;\n25(d) the personnel of A or a health data intermediary of A (if\nany) who is authorised to disclose relevant information\nabout any individual to B under the agreement;\n(e) the personnel of B or a health data intermediary of B (if\nany) who is authorised to collect or use relevant\n30information about any individual disclosed by A under\nthe agreement;\n(f) any other matter that may be prescribed.\n63",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p64_c175",
+      "text": "iculars ofA and B, including any particulars that\nmay be prescribed;\n(b) thattheagreementisinrespectofthedisclosure,collection\nand use of relevant information about any individual in\n20relation to the use case mentioned in subsection (1) in\naccordance with this Part;\n(c) subject to subsection (4), every type of relevant\ninformation about any individual that may be disclosed,\ncollected and used under the agreement;\n25(d) the personnel ofA or a health data intermediary ofA (if\nany) who is authorised to disclose relevant information\nabout any individual toB under the agreement;\n(e) the personnel ofB or a health data intermediary ofB (if\nany) who is authorised to collect or use relevant\n30information about any individual disclosed by A under\nthe agreement;\n(f) any other matter that may be prescribed.\n63",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 64,
@@ -98264,8 +98771,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p65_c137",
-      "text": "66 NO. 1 OF 2026\n(4) The type or types of relevant information about any individual\nspecified in the data sharing agreement in accordance with\nsubsection (3)(c) must be no more than the minimum necessary to\nimplement or facilitate the use case mentioned in subsection (1).\n5 (5) An agreement that does not satisfy the requirements in\nsubsections (3) and (4) is not a data sharing agreement for the\npurposes of this Part.\n(6) For the purposes of subsection (3)(d) and (e), every personnel of\nA or B, or of a health data intermediary of A or B, must be an\n10 individual —\n(a) who is specified by name or description in the agreement;\nor\n(b) who belongs to a class of individuals specified in the\nagreement.\n15 Discloser’s obligations\n53.—(1) A discloser (A) must not, in relation to a use case, disclose\nrelevant information about any individual (P) to a recipient (B) unless\nall of the following apply",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p65_c176",
+      "text": "66 NO. 1 OF 2026\n(4) The type or types of relevant information about any individual\nspecified in the data sharing agreement in accordance with\nsubsection (3)(c) must be no more than the minimum necessary to\nimplement or facilitate the use case mentioned in subsection (1).\n5 (5) An agreement that does not satisfy the requirements in\nsubsections (3) and (4) is not a data sharing agreement for the\npurposes of this Part.\n(6) Forthepurposesofsubsection(3)(d)and(e),everypersonnelof\nA or B, or of a health data intermediary ofA or B, must be an\n10 individual —\n(a) who is specified by name or description in the agreement;\nor\n(b) who belongs to a class of individuals specified in the\nagreement.\n15 Discloser’s obligations\n53.—(1) Adiscloser(A)mustnot,inrelationtoausecase,disclose\nrelevantinformationaboutanyindividual(P)toarecipient(B)unless\nall of the following apply:\n(a) B makes a data request toA",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 65,
@@ -98277,8 +98784,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p65_c138",
-      "text": "r (A) must not, in relation to a use case, disclose\nrelevant information about any individual (P) to a recipient (B) unless\nall of the following apply:\n(a) B makes a data request to A pursuant to a data sharing\n20 agreement (called in this section DSA) between A and B\nthat relates to that use case;\n(b) the purpose for which B makes the data request comes\nwithin the scope of that use case;\n(c) at the time A discloses the relevant information to B in\n25 response to B’s data request, the DSA is in force.\n(2) A must ensure, before disclosing relevant information about P to\nB in response to B’s data request, that every type of relevant\ninformation to be disclosed to B is a type that is specified in the DSA\nin accordance with section 52(3)(c).\n30 (3) A must, in relation to the disclosure of relevant information\nabout P to B in response to B’s data request —\n64",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p65_c177",
+      "text": "inrelationtoausecase,disclose\nrelevantinformationaboutanyindividual(P)toarecipient(B)unless\nall of the following apply:\n(a) B makes a data request toA pursuant to a data sharing\n20 agreement (called in this section DSA) betweenA and B\nthat relates to that use case;\n(b) the purpose for whichB makes the data request comes\nwithin the scope of that use case;\n(c) at the timeA discloses the relevant information toB in\n25 response toB’s data request, the DSA is in force.\n(2) Amustensure,beforedisclosingrelevantinformationabout Pto\nB in response to B’s data request, that every type of relevant\ninformationtobe disclosed toBisatypethatisspecifiedin theDSA\nin accordance with section 52(3)(c).\n30 (3) A must, in relation to the disclosure of relevant information\nabout P to B in response toB’s data request —\n64",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 65,
@@ -98290,8 +98797,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p66_c139",
-      "text": "HEALTH INFORMATION 67\n(a) ensure that the relevant information is disclosed only by a\npersonnel of A or a health data intermediary of A who is\nspecified in the DSA in accordance with section 52(3)(d);\n(b) ensure that the relevant information is disclosed only to a\n5personnel of B or a health data intermediary of B who is\nspecified in the DSA in accordance with section 52(3)(e);\n(c) make reasonable efforts to ensure that the relevant\ninformation that is disclosed —\n(i) is no more than the minimum that is necessary to\n10implement or facilitate the use case specified in B’s\ndata request; and\n(ii) is accurate and complete; and\n(d) make reasonable efforts to ensure that the relevant\ninformation is disclosed in a manner consistent with the\n15DSA.\n(4) In addition to subsections (1), (2) and (3), A must comply with\nany conditions or restrictions relating to the disclosure of relevant\ninformation",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p66_c178",
+      "text": "HEALTH INFORMATION 67\n(a) ensure that the relevant information is disclosed only by a\npersonnel ofA or a health data intermediary ofA who is\nspecified in the DSA in accordance with section 52(3)(d);\n(b) ensure that the relevant information is disclosed only to a\n5personnel ofB or a health data intermediary ofB who is\nspecified in the DSA in accordance with section 52(3)(e);\n(c) make reasonable efforts to ensure that the relevant\ninformation that is disclosed —\n(i) is no more than the minimum that is necessary to\n10implement or facilitate the use case specified inB’s\ndata request; and\n(ii) is accurate and complete; and\n(d) make reasonable efforts to ensure that the relevant\ninformation is disclosed in a manner consistent with the\n15DSA.\n(4) In addition to subsections (1), (2) and (3),A must comply with\nany conditions or restrictions relating to the disclosure of relevant\ninformation that ",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 66,
@@ -98303,8 +98810,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p66_c140",
-      "text": "\n(4) In addition to subsections (1), (2) and (3), A must comply with\nany conditions or restrictions relating to the disclosure of relevant\ninformation that may be prescribed.\n(5) For the purposes of subsection (4), different conditions or\n20restrictions may be prescribed for —\n(a) different disclosers or classes of disclosers;\n(b) different use cases; and\n(c) different types of relevant information about any\nindividual.\n25Recipient’s obligations\n54.—(1) A recipient (B) must not, in relation to a use case, make a\ndata request to a discloser (A) for the disclosure of relevant\ninformation about any individual in accordance with this Part\nunless all of the following apply:\n30(a) B’s data request is pursuant to a data sharing agreement\nbetween A and B that relates to that use case;\n65",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p66_c179",
+      "text": "In addition to subsections (1), (2) and (3),A must comply with\nany conditions or restrictions relating to the disclosure of relevant\ninformation that may be prescribed.\n(5) For the purposes of subsection (4), different conditions or\n20restrictions may be prescribed for —\n(a) different disclosers or classes of disclosers;\n(b) different use cases; and\n(c) different types of relevant information about any\nindividual.\n25Recipient’s obligations\n54.—(1) A recipient (B) must not, in relation to a use case, make a\ndata request to a discloser (A) for the disclosure of relevant\ninformation about any individual in accordance with this Part\nunless all of the following apply:\n30(a) B’s data request is pursuant to a data sharing agreement\nbetween A and B that relates to that use case;\n65",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 66,
@@ -98316,8 +98823,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p67_c141",
-      "text": "68 NO. 1 OF 2026\n(b) the purpose for which B makes the data request comes\nwithin the scope of that use case;\n(c) B, having regard to all the circumstances of the use case,\ngenuinely requires the relevant information for the purpose\n5 mentioned in paragraph (b).\n(2) Despite any other written law or rule of law or any obligation of\nconfidentiality imposed by contract, B may, in relation to a data\nrequest to A, disclose to A any information about any individual to\nwhom the data request relates if the disclosure of that information is\n10 necessary —\n(a) to identify the individual; or\n(b) to substantiate, or explain or elaborate on the purpose or\nscope of, B’s data request.\n(3) The information about the individual that B discloses to A under\n15 subsection (2) must not be more than the minimum that is relevant to,\nand is necessary for, the purposes of subsection (2)(a) or (b), as the\ncase may ",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p67_c180",
+      "text": "68 NO. 1 OF 2026\n(b) the purpose for whichB makes the data request comes\nwithin the scope of that use case;\n(c) B, having regard to all the circumstances of the use case,\ngenuinelyrequirestherelevantinformationforthepurpose\n5 mentioned in paragraph (b).\n(2) Despiteanyotherwrittenlaworruleoflaworanyobligationof\nconfidentiality imposed by contract, B may, in relation to a data\nrequest toA, disclose toA any information about any individual to\nwhom the data request relates if the disclosure of that information is\n10 necessary —\n(a) to identify the individual; or\n(b) to substantiate, or explain or elaborate on the purpose or\nscope of,B’s data request.\n(3) Theinformationabouttheindividualthat Bdisclosesto Aunder\n15 subsection(2)mustnotbemorethantheminimumthatisrelevantto,\nand is necessary for, the purposes of subsection (2)(a) or (b), as the\ncase may be.\n(4) To avoid doubt, a data request may ",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 67,
@@ -98329,8 +98836,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p67_c142",
-      "text": "subsection (2) must not be more than the minimum that is relevant to,\nand is necessary for, the purposes of subsection (2)(a) or (b), as the\ncase may be.\n(4) To avoid doubt, a data request may contain a request for the\ndisclosure of relevant information about one or more individuals and\n20 on one or more occasions.\n(5) In addition to subsections (1) and (2), B must comply with any\nconditions or restrictions relating to the making of a data request that\nmay be prescribed.\n(6) For the purposes of subsection (5), different conditions or\n25 restrictions may be prescribed for —\n(a) different recipients or classes of recipients;\n(b) different use cases; and\n(c) different types of relevant information about any\nindividual.\n30 Collection of relevant information\n55.—(1) A recipient (B) that collects, in relation to a use case,\nrelevant information about any individual that is disclosed by a\n66",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p67_c181",
+      "text": "heminimumthatisrelevantto,\nand is necessary for, the purposes of subsection (2)(a) or (b), as the\ncase may be.\n(4) To avoid doubt, a data request may contain a request for the\ndisclosure of relevant information about one or more individuals and\n20 on one or more occasions.\n(5) In addition to subsections (1) and (2),B must comply with any\nconditions or restrictions relating to the making of a data request that\nmay be prescribed.\n(6) For the purposes of subsection (5), different conditions or\n25 restrictions may be prescribed for —\n(a) different recipients or classes of recipients;\n(b) different use cases; and\n(c) different types of relevant information about any\nindividual.\n30 Collection of relevant information\n55.—(1) A recipient (B) that collects, in relation to a use case,\nrelevant information about any individual that is disclosed by a\n66",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 67,
@@ -98342,8 +98849,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p68_c143",
-      "text": "HEALTH INFORMATION 69\ndiscloser (A) pursuant to a data sharing agreement between A and B\nmust —\n(a) ensure that the relevant information is collected only by a\npersonnel of B or a health data intermediary of B who is\n5specified in the data sharing agreement between A and B in\naccordance with section 52(3)(e);\n(b) make reasonable efforts to ensure that the relevant\ninformation is collected in a manner consistent with that\ndata sharing agreement; and\n10(c) comply with any condition or restriction in relation to the\ncollection of relevant information under this Part that may\nbe prescribed.\n(2) For the purposes of subsection (1)(c), different conditions or\nrestrictions may be prescribed for —\n15(a) different recipients or classes of recipients;\n(b) different use cases; and\n(c) different types of relevant information about any\nindividual.\nUse of relevant information\n2056.—(1) This section app",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p68_c182",
+      "text": "HEALTH INFORMATION 69\ndiscloser (A) pursuant to a data sharing agreement betweenA and B\nmust —\n(a) ensure that the relevant information is collected only by a\npersonnel ofB or a health data intermediary ofB who is\n5specifiedinthedatasharingagreementbetween AandBin\naccordance with section 52(3)(e);\n(b) make reasonable efforts to ensure that the relevant\ninformation is collected in a manner consistent with that\ndata sharing agreement; and\n10(c) comply with any condition or restriction in relation to the\ncollection of relevant information under this Part that may\nbe prescribed.\n(2) For the purposes of subsection (1)(c), different conditions or\nrestrictions may be prescribed for —\n15(a) different recipients or classes of recipients;\n(b) different use cases; and\n(c) different types of relevant information about any\nindividual.\nUse of relevant information\n2056.—(1) This section applies in rela",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 68,
@@ -98355,8 +98862,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p68_c144",
-      "text": "\n(b) different use cases; and\n(c) different types of relevant information about any\nindividual.\nUse of relevant information\n2056.—(1) This section applies in relation to the use of relevant\ninformation about any individual (P) that a recipient (B) collects from\na discloser (A) pursuant to a data sharing agreement between A and B.\n(2) The following persons must not use relevant information about\nP except to implement or facilitate a use case specified in the data\n25sharing agreement between A and B:\n(a) B;\n(b) a health data intermediary of B;\n(c) a personnel of B;\n(d) a personnel of a health data intermediary of B.\n30(3) A health data intermediary of B, or any personnel of any health\ndata intermediary of B, may process relevant information about P for\n67",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p68_c183",
+      "text": "nt use cases; and\n(c) different types of relevant information about any\nindividual.\nUse of relevant information\n2056.—(1) This section applies in relation to the use of relevant\ninformationaboutanyindividual(P)thatarecipient(B)collectsfrom\nadiscloser(A)pursuanttoadatasharingagreementbetween AandB.\n(2) The following persons must not use relevant information about\nP except to implement or facilitate a use case specified in the data\n25sharing agreement betweenA and B:\n(a) B;\n(b) a health data intermediary ofB;\n(c) a personnel ofB;\n(d) a personnel of a health data intermediary ofB.\n30(3) A health data intermediary ofB, or any personnel of any health\ndataintermediaryof B,mayprocessrelevantinformationabout Pfor\n67",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 68,
@@ -98368,8 +98875,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p69_c145",
-      "text": "70 NO. 1 OF 2026\nthe purpose of enabling or facilitating B’s use of that relevant\ninformation for the use case mentioned in subsection (2).\n(4) B must ensure that relevant information about P is made\navailable to any personnel of B or a health data intermediary of B only\n5 to the extent that is necessary to enable the personnel or health data\nintermediary (as the case may be) to carry out any function or perform\nany duty relating to the implementation or facilitation of the use case\nmentioned in subsection (2).\n(5) B must comply with any condition or restriction in relation to\n10 the use of relevant information under this Part that may be prescribed.\n(6) For the purposes of subsection (5), different conditions or\nrestrictions may be prescribed for —\n(a) different recipients or classes of recipients;\n(b) different use cases; and\n15 (c) different types of relevant information about an indi",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p69_c184",
+      "text": "70 NO. 1 OF 2026\nthe purpose of enabling or facilitating B’s use of that relevant\ninformation for the use case mentioned in subsection (2).\n(4) B must ensure that relevant information about P is made\navailabletoanypersonnelof Borahealthdataintermediaryof Bonly\n5 to the extent that is necessary to enable the personnel or health data\nintermediary(asthecasemaybe)tocarryoutanyfunctionorperform\nany duty relating to the implementationor facilitation of the usecase\nmentioned in subsection (2).\n(5) B must comply with any condition or restriction in relation to\n10 theuseofrelevantinformationunderthisPartthatmaybeprescribed.\n(6) For the purposes of subsection (5), different conditions or\nrestrictions may be prescribed for —\n(a) different recipients or classes of recipients;\n(b) different use cases; and\n15 (c) differenttypesofrelevantinformationaboutanindividual.\nSubsequent disclosure of relevant i",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 69,
@@ -98381,8 +98888,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p69_c146",
-      "text": "bed for —\n(a) different recipients or classes of recipients;\n(b) different use cases; and\n15 (c) different types of relevant information about an individual.\nSubsequent disclosure of relevant information by recipient\n57.—(1) A recipient (B) who collects, in relation to a use case,\nrelevant information about any individual that is disclosed by a\ndiscloser (A) pursuant to a data sharing agreement between A and B\n20 must not disclose that relevant information to any other person\nunless —\n(a) the disclosure of the relevant information is required or\npermitted by or under this Act or any other written law, or\nby an order of court; or\n25 (b) the relevant information is disclosed to any person and in\nany circumstances that may be prescribed.\n(2) For the purposes of subsection (1)(a), the disclosure of relevant\ninformation about an individual is not considered to be required or\npermitted under a",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p69_c185",
+      "text": "r classes of recipients;\n(b) different use cases; and\n15 (c) differenttypesofrelevantinformationaboutanindividual.\nSubsequent disclosure of relevant information by recipient\n57.—(1) A recipient (B) who collects, in relation to a use case,\nrelevant information about any individual that is disclosed by a\ndiscloser (A) pursuant to a data sharing agreement betweenA and B\n20 must not disclose that relevant information to any other person\nunless —\n(a) the disclosure of the relevant information is required or\npermitted by or under this Act or any other written law, or\nby an order of court; or\n25 (b) the relevant information is disclosed to any person and in\nany circumstances that may be prescribed.\n(2) For the purposes of subsection (1)(a), the disclosure of relevant\ninformation about an individual is not considered to be required or\npermitted under any written law merely because the individual",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 69,
@@ -98394,8 +98901,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p69_c147",
-      "text": "or the purposes of subsection (1)(a), the disclosure of relevant\ninformation about an individual is not considered to be required or\npermitted under any written law merely because the individual has\n30 consented or has given his or her consent in accordance with Part 4 of\nthe Personal Data Protection Act 2012, or such consent is not required\nunder that Part.\n68",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p69_c186",
+      "text": "sclosure of relevant\ninformation about an individual is not considered to be required or\npermitted under any written law merely because the individual has\n30 consentedorhasgivenhisorherconsentinaccordancewithPart4of\nthePersonalDataProtectionAct2012,orsuchconsentisnotrequired\nunder that Part.\n68",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 69,
@@ -98407,8 +98914,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p70_c148",
-      "text": "HEALTH INFORMATION 71\n(3) To avoid doubt, subsection (1) does not affect the processing of\nrelevant information mentioned in that subsection by a health data\nintermediary of B or any personnel of a health data intermediary of B\nin accordance with section 56(3).\n5Notification of data sharing agreements\n58.—(1) The Minister may by regulations require —\n(a) a discloser to provide to the Minister —\n(i) a copy of any data sharing agreement between the\ndiscloser and any recipient; or\n10(ii) any document or information about any data sharing\nagreement between the discloser and any recipient\nthat may be prescribed; or\n(b) a recipient to provide to the Minister —\n(i) a copy of any data sharing agreement between the\n15recipient and any discloser; or\n(ii) any document or information about any data sharing\nagreement between the recipient and any discloser\nthat may be prescribed.\n(2) For the purposes",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p70_c187",
+      "text": "HEALTH INFORMATION 71\n(3) To avoid doubt, subsection (1) does not affect the processing of\nrelevant information mentioned in that subsection by a health data\nintermediaryof Boranypersonnelofahealthdataintermediaryof B\nin accordance with section 56(3).\n5Notification of data sharing agreements\n58.—(1) The Minister may by regulations require —\n(a) a discloser to provide to the Minister —\n(i) a copy of any data sharing agreement between the\ndiscloser and any recipient; or\n10(ii) any document or information about any data sharing\nagreement between the discloser and any recipient\nthat may be prescribed; or\n(b) a recipient to provide to the Minister —\n(i) a copy of any data sharing agreement between the\n15recipient and any discloser; or\n(ii) any document or information about any data sharing\nagreement between the recipient and any discloser\nthat may be prescribed.\n(2) For the purposes of subsec",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 70,
@@ -98420,8 +98927,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p70_c149",
-      "text": "(ii) any document or information about any data sharing\nagreement between the recipient and any discloser\nthat may be prescribed.\n(2) For the purposes of subsection (1)(a)(ii) and (b)(ii), the\n20document or information about any data sharing agreement\nbetween a discloser and a recipient mentioned in those provisions\nmay relate to any of the following:\n(a) the identity and particulars of the discloser or recipient;\n(b) the type or types of relevant health information about any\n25individual that have been disclosed, collected and used\nunder the data sharing agreement;\n(c) the use cases for which the type or types of relevant health\ninformation mentioned in paragraph (b) have been\ndisclosed, collected and used;\n30(d) the identity and particulars of —\n(i) any personnel of the discloser or a health data\nintermediary of the discloser who is authorised to\n69",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p70_c188",
+      "text": "ocument or information about any data sharing\nagreement between the recipient and any discloser\nthat may be prescribed.\n(2) For the purposes of subsection (1)(a)(ii) and (b)(ii), the\n20document or information about any data sharing agreement\nbetween a discloser and a recipient mentioned in those provisions\nmay relate to any of the following:\n(a) the identity and particulars of the discloser or recipient;\n(b) the type or types of relevant health information about any\n25individual that have been disclosed, collected and used\nunder the data sharing agreement;\n(c) the use cases for which the type or types of relevant health\ninformation mentioned in paragraph (b) have been\ndisclosed, collected and used;\n30(d) the identity and particulars of —\n(i) any personnel of the discloser or a health data\nintermediary of the discloser who is authorised to\n69",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 70,
@@ -98433,8 +98940,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p71_c150",
-      "text": "72 NO. 1 OF 2026\ndisclose relevant health information under the data\nsharing agreement; or\n(ii) any personnel of the recipient or a health data\nintermediary of the recipient who is authorised to\n5 collect or use relevant health information disclosed\nunder the data sharing agreement.\n(3) The discloser or recipient must provide the copy of the data\nsharing agreement or the document or information mentioned in\nsubsection (1)(a) or (b), as the case may be —\n10 (a) within the prescribed time; and\n(b) in the form or manner prescribed, if prescribed.\n(4) A person who contravenes subsection (3) shall be guilty of an\noffence and shall be liable on conviction to a fine not exceeding\n$20,000 or to imprisonment for a term not exceeding 12 months or to\n15 both.\nDirections for purposes of this Part\n59.—(1) Subsections (2) and (3) apply if the Minister has reason to\nbelieve that —\n(a) relevant informat",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p71_c189",
+      "text": "72 NO. 1 OF 2026\ndisclose relevant health information under the data\nsharing agreement; or\n(ii) any personnel of the recipient or a health data\nintermediary of the recipient who is authorised to\n5 collect or use relevant health information disclosed\nunder the data sharing agreement.\n(3) The discloser or recipient must provide the copy of the data\nsharing agreement or the document or information mentioned in\nsubsection (1)(a) or (b), as the case may be —\n10 (a) within the prescribed time; and\n(b) in the form or manner prescribed, if prescribed.\n(4) A person who contravenes subsection (3) shall be guilty of an\noffence and shall be liable on conviction to a fine not exceeding\n$20,000ortoimprisonmentforatermnotexceeding12monthsorto\n15 both.\nDirections for purposes of this Part\n59.—(1) Subsections(2)and(3)applyiftheMinisterhasreasonto\nbelieve that —\n(a) relevant information about any individu",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 71,
@@ -98446,8 +98953,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p71_c151",
-      "text": "15 both.\nDirections for purposes of this Part\n59.—(1) Subsections (2) and (3) apply if the Minister has reason to\nbelieve that —\n(a) relevant information about any individual —\n20 (i) has been or has purportedly been disclosed by a\ndiscloser (A); or\n(ii) has been or has purportedly been collected or used by\na recipient (B),\npursuant to a data sharing agreement between A and B\n25 (called in this section the DSA); and\n(b) the disclosure, collection or use (as the case may be) of that\nrelevant information is not in accordance with the DSA or\nthe provisions of this Part.\n(2) The Minister may, by written notice, direct A or B to take any\n30 one or more of the following actions:\n70",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p71_c190",
+      "text": "ections for purposes of this Part\n59.—(1) Subsections(2)and(3)applyiftheMinisterhasreasonto\nbelieve that —\n(a) relevant information about any individual —\n20 (i) has been or has purportedly been disclosed by a\ndiscloser (A); or\n(ii) hasbeenorhaspurportedlybeencollectedorusedby\na recipient (B),\npursuant to a data sharing agreement betweenA and B\n25 (called in this section the DSA); and\n(b) thedisclosure,collectionoruse(asthecasemaybe)ofthat\nrelevant information is not in accordance with the DSA or\nthe provisions of this Part.\n(2) The Minister may, by written notice, directA or B to take any\n30 one or more of the following actions:\n70",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 71,
@@ -98459,8 +98966,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p72_c152",
-      "text": "HEALTH INFORMATION 73\n(a) in the case of A —\n(i) review and assess whether the disclosure or\npurported disclosure of relevant information about\nany individual is in accordance with the DSA and the\n5provisions of this Part; or\n(ii) identify any error, failure, inadequacy or\nshortcoming relating to the disclosure or purported\ndisclosure of relevant information about any\nindividual pursuant to the DSA, and take\n10reasonable steps to remedy the error, failure,\ninadequacy or shortcoming and prevent its\nrecurrence;\n(b) in the case of B —\n(i) review and assess whether the collection or use or\n15purported collection or use of relevant information\nabout any individual is in accordance with the DSA\nand the provisions of this Part; or\n(ii) identify any error, failure, inadequacy or\nshortcoming in relation to the collection or use or\n20purported collection or use (as the case may be) of\nrelevant inf",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p72_c191",
+      "text": "HEALTH INFORMATION 73\n(a) in the case ofA —\n(i) review and assess whether the disclosure or\npurported disclosure of relevant information about\nanyindividualisinaccordancewiththeDSAandthe\n5provisions of this Part; or\n(ii) identify any error, failure, inadequacy or\nshortcoming relating to the disclosure or purported\ndisclosure of relevant information about any\nindividual pursuant to the DSA, and take\n10reasonable steps to remedy the error, failure,\ninadequacy or shortcoming and prevent its\nrecurrence;\n(b) in the case ofB —\n(i) review and assess whether the collection or use or\n15purported collection or use of relevant information\nabout any individual is in accordance with the DSA\nand the provisions of this Part; or\n(ii) identify any error, failure, inadequacy or\nshortcoming in relation to the collection or use or\n20purported collection or use (as the case may be) of\nrelevant information ab",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 72,
@@ -98472,8 +98979,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p72_c153",
-      "text": "y error, failure, inadequacy or\nshortcoming in relation to the collection or use or\n20purported collection or use (as the case may be) of\nrelevant information about any individual pursuant\nto the DSA, and take reasonable steps to remedy the\nerror, failure, inadequacy or shortcoming and\nprevent its recurrence;\n25(c) provide to the Minister any document or information that\nthe Minister may reasonably require relating to —\n(i) the review and assessment conducted in accordance\nwith paragraph (a)(i) or (b)(i), including information\nrelating to the disclosure, collection or use (as the\n30case may be) of relevant information about any\nindividual pursuant to the DSA prior to the review\nand assessment;\n(ii) any error, failure, inadequacy or shortcoming\nidentified in accordance with paragraph (a)(ii) or\n35(b)(ii); or\n71",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p72_c192",
+      "text": "ilure, inadequacy or\nshortcoming in relation to the collection or use or\n20purported collection or use (as the case may be) of\nrelevant information about any individual pursuant\nto the DSA, and take reasonable steps to remedy the\nerror, failure, inadequacy or shortcoming and\nprevent its recurrence;\n25(c) provide to the Minister any document or information that\nthe Minister may reasonably require relating to —\n(i) the review and assessment conducted in accordance\nwithparagraph(a)(i)or(b)(i),includinginformation\nrelating to the disclosure, collection or use (as the\n30case may be) of relevant information about any\nindividual pursuant to the DSA prior to the review\nand assessment;\n(ii) any error, failure, inadequacy or shortcoming\nidentified in accordance with paragraph (a)(ii) or\n35(b)(ii); or\n71",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 72,
@@ -98485,8 +98992,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p73_c154",
-      "text": "74 NO. 1 OF 2026\n(iii) the steps taken to remedy any error, failure,\ninadequacy or shortcoming identified in\naccordance with paragraph (a)(ii) or (b)(ii);\n(d) take any other action in relation to any matter mentioned in\n5 paragraph (a) or (b) that the Minister may reasonably\nrequire.\n(3) In addition —\n(a) where the Minister —\n(i) directs A to take any action mentioned in\n10 subsection (2)(a)(i) or (ii); and\n(ii) is of the opinion that B’s assistance is required or\ndesirable to enable the proper and effective carrying\nout of that action by A,\nthe Minister may, by written notice, direct B to take all\n15 reasonable steps to assist A; and\n(b) where the Minister —\n(i) directs B to take any action mentioned in\nsubsection (2)(b)(i) or (ii); and\n(ii) is of the opinion that A’s assistance is required or\n20 desirable to ensure the proper and effective carrying\nout of that action by B,\nthe Minister",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p73_c193",
+      "text": "74 NO. 1 OF 2026\n(iii) the steps taken to remedy any error, failure,\ninadequacy or shortcoming identified in\naccordance with paragraph (a)(ii) or (b)(ii);\n(d) takeanyotheractioninrelationtoanymattermentionedin\n5 paragraph (a) or (b) that the Minister may reasonably\nrequire.\n(3) In addition —\n(a) where the Minister —\n(i) directs A to take any action mentioned in\n10 subsection (2)(a)(i) or (ii); and\n(ii) is of the opinion thatB’s assistance is required or\ndesirable to enable the proper and effective carrying\nout of that action byA,\nthe Minister may, by written notice, directB to take all\n15 reasonable steps to assistA; and\n(b) where the Minister —\n(i) directs B to take any action mentioned in\nsubsection (2)(b)(i) or (ii); and\n(ii) is of the opinion thatA’s assistance is required or\n20 desirable to ensure the proper and effective carrying\nout of that action byB,\nthe Minister may, by written",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 73,
@@ -98498,8 +99005,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p73_c155",
-      "text": "i) is of the opinion that A’s assistance is required or\n20 desirable to ensure the proper and effective carrying\nout of that action by B,\nthe Minister may, by written notice, direct A to take all\nreasonable steps to assist B.\n(4) If —\n25 (a) both of the following apply:\n(i) the Minister has reason to believe that A has\ncontravened section 52(2) or 53(1), (2) or (3), or\nany condition or restriction imposed under\nsection 53(4);\n30 (ii) it is necessary for A to take any action mentioned in\nparagraph (c) or (d) in order to prevent or minimise\nany harm or damage to any individual pending the\n72",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p73_c194",
+      "text": "pinion thatA’s assistance is required or\n20 desirable to ensure the proper and effective carrying\nout of that action byB,\nthe Minister may, by written notice, directA to take all\nreasonable steps to assistB.\n(4) If —\n25 (a) both of the following apply:\n(i) the Minister has reason to believe that A has\ncontravened section 52(2) or 53(1), (2) or (3), or\nany condition or restriction imposed under\nsection 53(4);\n30 (ii) it is necessary forA to take any action mentioned in\nparagraph (c) or (d) in order to prevent or minimise\nany harm or damage to any individual pending the\n72",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 73,
@@ -98511,8 +99018,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p74_c156",
-      "text": "HEALTH INFORMATION 75\noutcome of any proceedings against A for an offence\narising from that contravention; or\n(b) A is convicted of an offence under section 60(1),\nthe Minister may, by written notice, direct A —\n5(c) to stop disclosing relevant information about any\nindividual to any recipient under this Part; or\n(d) to take any other specified action which the Minister\nreasonably considers to be necessary to bring the\ncontravention to an end and prevent the recurrence of the\n10contravention.\n(5) If —\n(a) both of the following apply:\n(i) the Minister has reason to believe that B has\ncontravened section 52(2), 54(1) or (3), 55(1),\n1556(2) or (4) or 57(1), or any condition or\nrestriction imposed under section 54(5) or 56(5);\n(ii) it is necessary for B to take any action mentioned in\nparagraph (c), (d) or (e) in order to prevent or\nminimise any harm or damage to any individual\n20pending the",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p74_c195",
+      "text": "HEALTH INFORMATION 75\noutcomeofanyproceedingsagainst Afor anoffence\narising from that contravention; or\n(b) A is convicted of an offence under section 60(1),\nthe Minister may, by written notice, directA —\n5(c) to stop disclosing relevant information about any\nindividual to any recipient under this Part; or\n(d) to take any other specified action which the Minister\nreasonably considers to be necessary to bring the\ncontravention to an end and prevent the recurrence of the\n10contravention.\n(5) If —\n(a) both of the following apply:\n(i) the Minister has reason to believe that B has\ncontravened section 52(2), 54(1) or (3), 55(1),\n1556(2) or (4) or 57(1), or any condition or\nrestriction imposed under section 54(5) or 56(5);\n(ii) it is necessary forB to take any action mentioned in\nparagraph (c), (d) or (e) in order to prevent or\nminimise any harm or damage to any individual\n20pending the outcome",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 74,
@@ -98524,8 +99031,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p74_c157",
-      "text": "ary for B to take any action mentioned in\nparagraph (c), (d) or (e) in order to prevent or\nminimise any harm or damage to any individual\n20pending the outcome of any proceedings against B\nfor an offence arising from that contravention; or\n(b) B is convicted of an offence under section 60(2),\nthe Minister may, by written notice, direct B —\n(c) to do either or both of the following:\n25(i) stop collecting relevant information about any\nindividual from any discloser under this Part;\n(ii) stop using relevant information about any individual\ncollected from any discloser under this Part that is in\nthe possession or under the control of B;\n30(d) to delete or destroy relevant information about any\nindividual collected from any discloser under this Part;\n73",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p74_c196",
+      "text": "B to take any action mentioned in\nparagraph (c), (d) or (e) in order to prevent or\nminimise any harm or damage to any individual\n20pending the outcome of any proceedings againstB\nfor an offence arising from that contravention; or\n(b) B is convicted of an offence under section 60(2),\nthe Minister may, by written notice, directB —\n(c) to do either or both of the following:\n25(i) stop collecting relevant information about any\nindividual from any discloser under this Part;\n(ii) stop using relevant information about any individual\ncollected fromany discloser underthis Part that is in\nthe possession or under the control ofB;\n30(d) to delete or destroy relevant information about any\nindividual collected from any discloser under this Part;\n73",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 74,
@@ -98537,8 +99044,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p75_c158",
-      "text": "76 NO. 1 OF 2026\n(e) to take all reasonable steps —\n(i) to retrieve all copies of the relevant information\nabout any individual from any person to whom B has\ndisclosed the relevant information; and\n5 (ii) to delete or destroy all copies of the relevant\ninformation that are retrieved under\nsub‑paragraph (i); or\n(f) to take any other specified action which the Minister\nreasonably considers to be necessary to bring the\n10 contravention to an end and prevent the recurrence of the\ncontravention.\n(6) A person who, without reasonable excuse, refuses or fails to\ncomply with a direction under subsection (2), (3), (4) or (5) shall be\nguilty of an offence and shall be liable on conviction to a fine not\n15 exceeding $50,000 or to imprisonment for a term not exceeding\n2 years or to both and, in the case of a continuing offence, to a further\nfine not exceeding $1,000 for every day or part of a day dur",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p75_c197",
+      "text": "76 NO. 1 OF 2026\n(e) to take all reasonable steps —\n(i) to retrieve all copies of the relevant information\naboutanyindividualfromanypersontowhom Bhas\ndisclosed the relevant information; and\n5 (ii) to delete or destroy all copies of the relevant\ninformation that are retrieved under\nsub‑paragraph (i); or\n(f) to take any other specified action which the Minister\nreasonably considers to be necessary to bring the\n10 contravention to an end and prevent the recurrence of the\ncontravention.\n(6) A person who, without reasonable excuse, refuses or fails to\ncomply with a direction under subsection (2), (3), (4) or (5) shall be\nguilty of an offence and shall be liable on conviction to a fine not\n15 exceeding $50,000 or to imprisonment for a term not exceeding\n2yearsortobothand,inthecaseofacontinuingoffence,toafurther\nfinenotexceeding$1,000foreverydayorpartofadayduringwhich\nthe offence continues afte",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 75,
@@ -98550,8 +99057,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p75_c159",
-      "text": "m not exceeding\n2 years or to both and, in the case of a continuing offence, to a further\nfine not exceeding $1,000 for every day or part of a day during which\nthe offence continues after conviction.\nOffences under this Part\n20 60.—(1) A person who, without reasonable excuse, contravenes —\n(a) section 52(2) or 53(1), (2) or (3); or\n(b) any condition or restriction imposed under section 53(4),\nshall be guilty of an offence.\n(2) A person who, without reasonable excuse, contravenes —\n25 (a) section 52(2), 54(1) or (3), 55(1), 56(2) or (4) or 57(1); or\n(b) any condition or restriction imposed under section 54(5) or\n56(5),\nshall be guilty of an offence.\n(3) A person who is convicted of an offence under subsection (1) or\n30 (2) shall be liable on conviction —\n74",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p75_c198",
+      "text": "ceeding\n2yearsortobothand,inthecaseofacontinuingoffence,toafurther\nfinenotexceeding$1,000foreverydayorpartofadayduringwhich\nthe offence continues after conviction.\nOffences under this Part\n20 60.—(1) Apersonwho,withoutreasonableexcuse,contravenes—\n(a) section 52(2) or 53(1), (2) or (3); or\n(b) any condition or restriction imposed under section 53(4),\nshall be guilty of an offence.\n(2) A person who, without reasonable excuse, contravenes —\n25 (a) section 52(2), 54(1) or (3), 55(1), 56(2) or (4) or 57(1); or\n(b) anyconditionorrestrictionimposedundersection54(5)or\n56(5),\nshall be guilty of an offence.\n(3) Apersonwhoisconvictedofanoffenceundersubsection(1)or\n30 (2) shall be liable on conviction —\n74",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 75,
@@ -98563,8 +99070,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p76_c160",
-      "text": "HEALTH INFORMATION 77\n(a) to a fine not exceeding $50,000 or to imprisonment for a\nterm not exceeding 2 years or to both, unless paragraph (b)\napplies; and\n(b) if the person has a prior qualifying conviction — to a fine\n5not exceeding $100,000 or to imprisonment for a term not\nexceeding 4 years or to both.\n(4) In subsection (3), “qualifying conviction” means a conviction\nfor an offence under subsection (1) or (2).\nPART 4\n10SECURITY OF HEALTH INFORMA TION AND\nRELEV ANT INFORMA TION\nDivision 1 — General\nInterpretation of this Part\n61.—(1) In this Part —\n15“cybersecurity” means the state in which a computer or\ncomputer system is protected from unauthorised access or\nattack, and because of that state —\n(a) the computer or computer system continues to be\navailable and operational;\n20(b) the integrity of the computer or computer system is\nmaintained; and\n(c) the integrity and confidentiality o",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p76_c199",
+      "text": "HEALTH INFORMATION 77\n(a) to a fine not exceeding $50,000 or to imprisonment for a\ntermnotexceeding2yearsortoboth,unlessparagraph(b)\napplies; and\n(b) if the person has a prior qualifying conviction — to a fine\n5not exceeding $100,000 or to imprisonment for a term not\nexceeding 4 years or to both.\n(4) In subsection (3), “qualifying conviction” means a conviction\nfor an offence under subsection (1) or (2).\nPART 4\n10SECURITY OF HEALTH INFORMATION AND\nRELEVANT INFORMATION\nDivision 1 — General\nInterpretation of this Part\n61.—(1) In this Part —\n15“cybersecurity” means the state in which a computer or\ncomputer system is protected from unauthorised access or\nattack, and because of that state —\n(a) the computer or computer system continues to be\navailable and operational;\n20(b) the integrity of the computer or computer system is\nmaintained; and\n(c) theintegrityandconfidentialityofinformationstore",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 76,
@@ -98576,8 +99083,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p76_c161",
-      "text": "ues to be\navailable and operational;\n20(b) the integrity of the computer or computer system is\nmaintained; and\n(c) the integrity and confidentiality of information stored\nin, processed by or transmitted through the computer\nor computer system is maintained;\n25“cybersecurity incident” means an act or activity carried out\nwithout lawful authority on or through a computer or\ncomputer system that jeopardises or adversely affects its\ncybersecurity or the cybersecurity of another computer or\ncomputer system;\n30“discloser” and “recipient” have the meanings given by\nsection 45;\n75",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p76_c200",
+      "text": "ilable and operational;\n20(b) the integrity of the computer or computer system is\nmaintained; and\n(c) theintegrityandconfidentialityofinformationstored\nin, processed by or transmitted through the computer\nor computer system is maintained;\n25“cybersecurity incident” means an act or activity carried out\nwithout lawful authority on or through a computer or\ncomputer system that jeopardises or adversely affects its\ncybersecurity or the cybersecurity of another computer or\ncomputer system;\n30“discloser” and “recipient” have the meanings given by\nsection 45;\n75",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 76,
@@ -98589,8 +99096,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p77_c162",
-      "text": "78 NO. 1 OF 2026\n“relevant person” means a person mentioned in section 64(1);\n“requestor” has the meaning given by section 6.\n(2) For the purposes of this Part, a computer or computer system is\ntaken to process health information or relevant information even\n5 though the computer or computer system also processes any\ninformation other than health information or relevant information,\nas the case may be.\nMeaning of “data breach”\n62. For the purposes of this Part, “data breach”, in relation to health\n10 information or relevant information, means —\n(a) the unauthorised access, collection, use, disclosure,\ncopying, modification, disposal or destruction of that\ninformation; or\n(b) the loss of any storage medium or device on which that\n15 information is stored in circumstances where the\nunauthorised access, collection, use, disclosure, copying,\nmodification, disposal or destruction of that info",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p77_c201",
+      "text": "78 NO. 1 OF 2026\n“relevant person” means a person mentioned in section 64(1);\n“requestor” has the meaning given by section 6.\n(2) For the purposes of this Part, a computer or computer system is\ntaken to process health information or relevant information even\n5 though the computer or computer system also processes any\ninformation other than health information or relevant information,\nas the case may be.\nMeaning of “data breach”\n62. ForthepurposesofthisPart,“databreach”,inrelationtohealth\n10 information or relevant information, means —\n(a) the unauthorised access, collection, use, disclosure,\ncopying, modification, disposal or destruction of that\ninformation; or\n(b) the loss of any storage medium or device on which that\n15 information is stored in circumstances where the\nunauthorised access, collection, use, disclosure, copying,\nmodification, disposal or destruction of that information is\n",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 77,
@@ -98602,8 +99109,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p77_c163",
-      "text": "ion is stored in circumstances where the\nunauthorised access, collection, use, disclosure, copying,\nmodification, disposal or destruction of that information is\nlikely to occur.\nRelevant computers or computer systems\n20 63.—(1) For the purposes of this Part, “relevant computer or\ncomputer system” —\n(a) means —\n(i) a computer or computer system that is\ninterconnected with the national electronic records\n25 system;\n(ii) a computer or computer system that processes health\ninformation or relevant information, whether or not it\nis interconnected with the national electronic records\nsystem or a computer or computer system mentioned\n30 in sub‑paragraph (i); or\n76",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p77_c202",
+      "text": "ed in circumstances where the\nunauthorised access, collection, use, disclosure, copying,\nmodification, disposal or destruction of that information is\nlikely to occur.\nRelevant computers or computer systems\n20 63.—(1) For the purposes of this Part, “relevant computer or\ncomputer system” —\n(a) means —\n(i) a computer or computer system that is\ninterconnected with the national electronic records\n25 system;\n(ii) acomputerorcomputersystemthatprocesseshealth\ninformationorrelevantinformation,whetherornotit\nisinterconnectedwiththenationalelectronicrecords\nsystemoracomputerorcomputersystemmentioned\n30 in sub‑paragraph (i); or\n76",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 77,
@@ -98615,8 +99122,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p78_c164",
-      "text": "HEALTH INFORMATION 79\n(iii) a computer or computer system that —\n(A) processes information other than health\ninformation or relevant information; and\n(B) is interconnected with a computer or computer\n5system mentioned in sub‑paragraph (i); but\n(b) does not include —\n(i) the national electronic records system; or\n(ii) any computer or computer system mentioned in\nparagraph (a) that may be prescribed.\n10(2) A relevant computer system of a person includes the computer\nservers and network equipment operated or used by the person for the\npurposes of or in relation to the relevant computer system, whether or\nnot the computer servers and network equipment are owned by that\nperson.\n15Application of this Part\n64.—(1) Except as otherwise provided, this Part applies to the\nfollowing persons (called in this Part a relevant person):\n(a) a contributor;\n(b) a user;\n20(c) a requestor;\n(d) a System Operat",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p78_c203",
+      "text": "HEALTH INFORMATION 79\n(iii) a computer or computer system that —\n(A) processes information other than health\ninformation or relevant information; and\n(B) is interconnected with a computer or computer\n5system mentioned in sub‑paragraph (i); but\n(b) does not include —\n(i) the national electronic records system; or\n(ii) any computer or computer system mentioned in\nparagraph (a) that may be prescribed.\n10(2) A relevant computer system of a person includes the computer\nserversandnetworkequipmentoperatedorusedbythepersonforthe\npurposesoforinrelationtotherelevantcomputersystem,whetheror\nnot the computer servers and network equipment are owned by that\nperson.\n15Application of this Part\n64.—(1) Except as otherwise provided, this Part applies to the\nfollowing persons (called in this Part a relevant person):\n(a) a contributor;\n(b) a user;\n20(c) a requestor;\n(d) a System Operator;\n(e) a discloser;\n(",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 78,
@@ -98628,8 +99135,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p78_c165",
-      "text": "s Part applies to the\nfollowing persons (called in this Part a relevant person):\n(a) a contributor;\n(b) a user;\n20(c) a requestor;\n(d) a System Operator;\n(e) a discloser;\n(f) a recipient.\n(2) This Part does not apply to the Government or any public\n25authority.\n(3) This Part applies equally to and in relation to health information\nprocessed by a relevant HDI on behalf of and for the purposes of a\ncontributor or user, and health information processed by a contributor\nor user directly.\n30(4) Unless otherwise expressly provided, this Part does not\naffect —\n77",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p78_c204",
+      "text": "following persons (called in this Part a relevant person):\n(a) a contributor;\n(b) a user;\n20(c) a requestor;\n(d) a System Operator;\n(e) a discloser;\n(f) a recipient.\n(2) This Part does not apply to the Government or any public\n25authority.\n(3) ThisPartappliesequallytoandinrelationtohealthinformation\nprocessed by a relevant HDI on behalf of and for the purposes of a\ncontributororuser,andhealthinformationprocessedbyacontributor\nor user directly.\n30(4) Unless otherwise expressly provided, this Part does not\naffect —\n77",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 78,
@@ -98641,8 +99148,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p79_c166",
-      "text": "80 NO. 1 OF 2026\n(a) the operation of any other written law that applies to or in\nrelation to the cybersecurity of any computer or computer\nsystem; or\n(b) the obligations of any person under any written law\n5 mentioned in paragraph (a).\nDesignated individual of relevant person\n65.—(1) A relevant person must designate one or more individuals\nto be responsible for ensuring that the relevant person complies with\nthis Part and Part 5.\n10 (2) An individual designated under subsection (1) may delegate to\nanother individual the responsibility conferred by that designation.\n(3) The designation of an individual by a relevant person under\nsubsection (1) does not relieve the relevant person of any of the\nrelevant person’s obligations under this Part or Part 5.\n15 Division 2 — Data security requirements\nData security and handling of health information and relevant\ninformation\n66.—(1) A relevant pers",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p79_c205",
+      "text": "80 NO. 1 OF 2026\n(a) the operation of any other written law that applies to or in\nrelation to the cybersecurity of any computer or computer\nsystem; or\n(b) the obligations of any person under any written law\n5 mentioned in paragraph (a).\nDesignated individual of relevant person\n65.—(1) A relevant person must designate one or more individuals\nto be responsible for ensuring that the relevant person complies with\nthis Part and Part 5.\n10 (2) An individual designated under subsection (1) may delegate to\nanother individual the responsibility conferred by that designation.\n(3) The designation of an individual by a relevant person under\nsubsection (1) does not relieve the relevant person of any of the\nrelevant person’s obligations under this Part or Part 5.\n15 Division 2 — Data security requirements\nDatasecurityandhandlingofhealthinformationandrelevant\ninformation\n66.—(1) A relevant person must ",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 79,
@@ -98654,8 +99161,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p79_c167",
-      "text": "r Part 5.\n15 Division 2 — Data security requirements\nData security and handling of health information and relevant\ninformation\n66.—(1) A relevant person must —\n(a) implement reasonable controls to ensure the secure\n20 processing of health information or relevant information,\nas the case may be;\n(b) implement reasonable safeguards to protect against the\nunauthorised access, collection, use, disclosure, copying,\nmodification, disposal, destruction or loss of health\n25 information or relevant information, as the case may be;\nand\n(c) ensure that every personnel who accesses or handles health\ninformation or relevant information (as the case may be) is\naware of his or her role and responsibility in ensuring\n30 that —\n(i) the confidentiality and integrity of the information is\nprotected; and\n78",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p79_c206",
+      "text": "r Part 5.\n15 Division 2 — Data security requirements\nDatasecurityandhandlingofhealthinformationandrelevant\ninformation\n66.—(1) A relevant person must —\n(a) implement reasonable controls to ensure the secure\n20 processing of health information or relevant information,\nas the case may be;\n(b) implement reasonable safeguards to protect against the\nunauthorised access, collection, use, disclosure, copying,\nmodification, disposal, destruction or loss of health\n25 information or relevant information, as the case may be;\nand\n(c) ensurethateverypersonnelwhoaccessesorhandleshealth\ninformationorrelevantinformation(asthecasemaybe)is\naware of his or her role and responsibility in ensuring\n30 that —\n(i) the confidentialityandintegrityofthe informationis\nprotected; and\n78",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 79,
@@ -98667,7 +99174,7 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p80_c168",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p80_c207",
       "text": "HEALTH INFORMATION 81\n(ii) the information is available for use by the relevant\nperson (including individuals employed or engaged\nby the relevant person who are authorised to access\nor handle the information) in the ordinary course of\n5the relevant person’s activities.\n(2) For the purposes of subsection (1)(a), the controls to ensure the\nsecure processing of health information or relevant information\ninclude controls or requirements relating to the classification of the\ninformation, having regard to —\n10(a) the nature of the information; and\n(b) the likely consequences that follow from the disclosure of\nthe information.\n(3) A relevant person must, in relation to any health information or\nrelevant information that is in the form of or part of an extract or a\n15compilation of de‑identified or aggregated information, additionally\nensure that —\n(a) the confidentiality and integrity of the ex",
       "metadata": {
         "source": "health-information-act-2026.pdf",
@@ -98680,7 +99187,7 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p80_c169",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p80_c208",
       "text": "f an extract or a\n15compilation of de‑identified or aggregated information, additionally\nensure that —\n(a) the confidentiality and integrity of the extract or\ncompilation is maintained at all times; and\n(b) the extract or compilation is available for use in the\n20ordinary course of the relevant person’s activities.\n(4) If health information is processed by a relevant HDI (A) of a\ncontributor or user (B) —\n(a) A must —\n(i) implement reasonable controls to ensure the secure\n25processing of health information;\n(ii) implement reasonable safeguards to protect against\nthe unauthorised access, collection, use, disclosure,\ncopying, modification, disposal, destruction or loss\nof health information; and\n30(iii) ensure that every personnel who accesses or handles\nhealth information is aware of his or her role and\nresponsibility in ensuring that —\n79",
       "metadata": {
         "source": "health-information-act-2026.pdf",
@@ -98693,8 +99200,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p81_c170",
-      "text": "82 NO. 1 OF 2026\n(A) the confidentiality and integrity of the health\ninformation is protected; and\n(B) the health information is available for use by B\n(including individuals employed or engaged by\n5 B who are authorised to access or handle the\nhealth information) in the ordinary course of\nB’s activities; and\n(b) B must ensure that A complies with all the requirements\nunder paragraph (a).\n10 (5) A relevant person or a relevant HDI of a contributor or user\nmust comply with any requirements that may be prescribed in relation\nto —\n(a) the processing of health information or relevant\ninformation (as the case may be), including the controls\n15 mentioned in subsection (1)(a) or (4)(a)(i) that must be\nimplemented, if any; and\n(b) the protection of health information or relevant\ninformation (as the case may be) against unauthorised\naccess, collection, use, disclosure, copying, modification,\n20 d",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p81_c209",
+      "text": "82 NO. 1 OF 2026\n(A) the confidentiality and integrity of the health\ninformation is protected; and\n(B) the healthinformationis availablefor useby B\n(includingindividualsemployedorengagedby\n5 B who are authorised to access or handle the\nhealth information) in the ordinary course of\nB’s activities; and\n(b) B must ensure thatA complies with all the requirements\nunder paragraph (a).\n10 (5) A relevant person or a relevant HDI of a contributor or user\nmustcomplywithanyrequirementsthatmaybeprescribedinrelation\nto —\n(a) the processing of health information or relevant\ninformation (as the case may be), including the controls\n15 mentioned in subsection (1)(a) or (4)(a)(i) that must be\nimplemented, if any; and\n(b) the protection of health information or relevant\ninformation (as the case may be) against unauthorised\naccess, collection, use, disclosure, copying, modification,\n20 disposal, destruction",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 81,
@@ -98706,8 +99213,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p81_c171",
-      "text": " health information or relevant\ninformation (as the case may be) against unauthorised\naccess, collection, use, disclosure, copying, modification,\n20 disposal, destruction or loss.\n(6) A person who contravenes subsection (1), (3), (4) or (5) shall be\nguilty of an offence and shall be liable on conviction —\n(a) in the case of an individual, to a fine not exceeding\n$200,000 or to imprisonment for a term not exceeding\n25 2 years or to both; or\n(b) in any other case, to a fine not exceeding $1 million.\nRetention, disposal and destruction of health information and\nrelevant information\n67.—(1) A relevant person must —\n30 (a) cease to retain any health information or relevant\ninformation, or remove the means by which health\ninformation or relevant information can be associated\n80",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p81_c210",
+      "text": "or relevant\ninformation (as the case may be) against unauthorised\naccess, collection, use, disclosure, copying, modification,\n20 disposal, destruction or loss.\n(6) Apersonwhocontravenessubsection(1),(3),(4)or(5)shallbe\nguilty of an offence and shall be liable on conviction —\n(a) in the case of an individual, to a fine not exceeding\n$200,000 or to imprisonment for a term not exceeding\n25 2 years or to both; or\n(b) in any other case, to a fine not exceeding $1 million.\nRetention, disposal and destruction of health information and\nrelevant information\n67.—(1) A relevant person must —\n30 (a) cease to retain any health information or relevant\ninformation, or remove the means by which health\ninformation or relevant information can be associated\n80",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 81,
@@ -98719,8 +99226,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p82_c172",
-      "text": "HEALTH INFORMATION 83\nwith any particular individual, as soon as it is reasonable to\nassume that —\n(i) the purpose for which the information was collected\nis no longer being served by retention of the\n5information; and\n(ii) retention is no longer necessary for legal or business\npurposes; and\n(b) take reasonable care, in relation to the disposal or\ndestruction of any health information or relevant\n10information, to prevent unauthorised access, disclosure\nor reproduction of the information.\n(2) A relevant HDI of a contributor or user must —\n(a) cease to retain any health information collected or\nprocessed on behalf of and for the purposes of the\n15contributor or user (as the case may be), or remove the\nmeans by which the health information can be associated\nwith any particular individual, as soon as it is reasonable to\nassume that —\n(i) the purpose for which the health information was\n20co",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p82_c211",
+      "text": "HEALTH INFORMATION 83\nwithanyparticularindividual,assoonasitisreasonableto\nassume that —\n(i) the purpose for which the information was collected\nis no longer being served by retention of the\n5information; and\n(ii) retention is no longer necessary for legal or business\npurposes; and\n(b) take reasonable care, in relation to the disposal or\ndestruction of any health information or relevant\n10information, to prevent unauthorised access, disclosure\nor reproduction of the information.\n(2) A relevant HDI of a contributor or user must —\n(a) cease to retain any health information collected or\nprocessed on behalf of and for the purposes of the\n15contributor or user (as the case may be), or remove the\nmeans by which the health information can be associated\nwithanyparticularindividual,assoonasitisreasonableto\nassume that —\n(i) the purpose for which the health information was\n20collected or processed",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 82,
@@ -98732,8 +99239,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p82_c173",
-      "text": "n be associated\nwith any particular individual, as soon as it is reasonable to\nassume that —\n(i) the purpose for which the health information was\n20collected or processed is no longer being served by\nretention of the health information; and\n(ii) retention is no longer necessary for legal or business\npurposes; and\n(b) take reasonable care, in relation to the disposal or\n25destruction of any health information, to prevent\nunauthorised access, disclosure or reproduction of the\nhealth information.\n(3) A person who contravenes subsection (1) or (2) shall be guilty\nof an offence and shall be liable on conviction —\n30(a) in the case of an individual, to a fine not exceeding\n$200,000 or to imprisonment for a term not exceeding\n2 years or to both; or\n(b) in any other case, to a fine not exceeding $1 million.\n81",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p82_c212",
+      "text": "iated\nwithanyparticularindividual,assoonasitisreasonableto\nassume that —\n(i) the purpose for which the health information was\n20collected or processed is no longer being served by\nretention of the health information; and\n(ii) retention is no longer necessary for legal or business\npurposes; and\n(b) take reasonable care, in relation to the disposal or\n25destruction of any health information, to prevent\nunauthorised access, disclosure or reproduction of the\nhealth information.\n(3) A person who contravenes subsection (1) or (2) shall be guilty\nof an offence and shall be liable on conviction —\n30(a) in the case of an individual, to a fine not exceeding\n$200,000 or to imprisonment for a term not exceeding\n2 years or to both; or\n(b) in any other case, to a fine not exceeding $1 million.\n81",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 82,
@@ -98745,8 +99252,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p83_c174",
-      "text": "84 NO. 1 OF 2026\nDivision 3 — Cybersecurity requirements\nCybersecurity of relevant computer or computer system\n68.—(1) A relevant person must implement reasonable safeguards,\nin relation to any relevant computer or computer system used by the\n5 relevant person to process health information or relevant\ninformation —\n(a) to protect the confidentiality and integrity of the\ninformation;\n(b) to ensure the availability of the information for use in the\n10 ordinary course of the relevant person’s activities; and\n(c) to protect the relevant computer or computer system\nagainst unauthorised access, interference or tampering.\n(2) If health information is processed by a relevant HDI of a\ncontributor or user —\n15 (a) the relevant HDI must implement reasonable safeguards —\n(i) to protect the confidentiality and integrity of the\nhealth information processed by the relevant HDI;\n(ii) to ensure the avail",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p83_c213",
+      "text": "84 NO. 1 OF 2026\nDivision 3 — Cybersecurity requirements\nCybersecurity of relevant computer or computer system\n68.—(1) Arelevantperson mustimplementreasonable safeguards,\nin relation to any relevant computer or computer system used by the\n5 relevant person to process health information or relevant\ninformation —\n(a) to protect the confidentiality and integrity of the\ninformation;\n(b) to ensure the availability of the information for use in the\n10 ordinary course of the relevant person’s activities; and\n(c) to protect the relevant computer or computer system\nagainst unauthorised access, interference or tampering.\n(2) If health information is processed by a relevant HDI of a\ncontributor or user —\n15 (a) therelevantHDImustimplementreasonablesafeguards—\n(i) to protect the confidentiality and integrity of the\nhealth information processed by the relevant HDI;\n(ii) to ensure the availability of ",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 83,
@@ -98758,8 +99265,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p83_c175",
-      "text": "onable safeguards —\n(i) to protect the confidentiality and integrity of the\nhealth information processed by the relevant HDI;\n(ii) to ensure the availability of the health information\nfor use in the ordinary course of the activities of the\n20 contributor or user, as the case may be; and\n(iii) to protect any relevant computer or computer system\nused by the relevant HDI to process the health\ninformation against unauthorised access,\ninterference and tampering; and\n25 (b) the contributor or user (as the case may be) must ensure\nthat the relevant HDI implements the safeguards\nmentioned in paragraph (a).\n(3) For the purposes of subsection (1), a relevant person must\ncomply with any requirements that may be prescribed in respect of\n30 the safeguards mentioned in that subsection.\n(4) For the purposes of subsection (2)(a), a relevant HDI of a\ncontributor or user must comply with any requirements ",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p83_c214",
+      "text": "eguards—\n(i) to protect the confidentiality and integrity of the\nhealth information processed by the relevant HDI;\n(ii) to ensure the availability of the health information\nfor use in the ordinary course of the activities of the\n20 contributor or user, as the case may be; and\n(iii) toprotectanyrelevantcomputerorcomputersystem\nused by the relevant HDI to process the health\ninformation against unauthorised access,\ninterference and tampering; and\n25 (b) the contributor or user (as the case may be) must ensure\nthat the relevant HDI implements the safeguards\nmentioned in paragraph (a).\n(3) For the purposes of subsection (1), a relevant person must\ncomply with any requirements that may be prescribed in respect of\n30 the safeguards mentioned in that subsection.\n(4) For the purposes of subsection (2)(a), a relevant HDI of a\ncontributor or user must comply with any requirements that may be\nprescr",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 83,
@@ -98771,8 +99278,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p83_c176",
-      "text": "ds mentioned in that subsection.\n(4) For the purposes of subsection (2)(a), a relevant HDI of a\ncontributor or user must comply with any requirements that may be\nprescribed in respect of the safeguards mentioned in that provision.\n82",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p83_c215",
+      "text": "at subsection.\n(4) For the purposes of subsection (2)(a), a relevant HDI of a\ncontributor or user must comply with any requirements that may be\nprescribed in respect of the safeguards mentioned in that provision.\n82",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 83,
@@ -98784,8 +99291,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p84_c177",
-      "text": "HEALTH INFORMATION 85\n(5) A person who contravenes subsection (1), (2), (3) or (4) shall be\nguilty of an offence and shall be liable on conviction —\n(a) in the case of an individual, to a fine not exceeding\n$200,000 or to imprisonment for a term not exceeding\n52 years or to both; or\n(b) in any other case, to a fine not exceeding $1 million.\nDivision 4 — Miscellaneous\nPolicies and practices for ensuring data security and\ncybersecurity\n1069.—(1) A relevant person must establish and implement\nappropriate policies and practices in respect of the matters\nmentioned in sections 66(1), (3) and (4)(b), 67(1) and 68(1) and\n(2)(b).\n(2) Without limiting subsection (1), a relevant person must ensure\n15that the policies and practices mentioned in that subsection provide\nfor any matter prescribed relating to those policies and practices.\n(3) For the purposes of subsection (2), the Minister may prescrib",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p84_c216",
+      "text": "HEALTH INFORMATION 85\n(5) Apersonwhocontravenessubsection(1),(2),(3)or(4)shallbe\nguilty of an offence and shall be liable on conviction —\n(a) in the case of an individual, to a fine not exceeding\n$200,000 or to imprisonment for a term not exceeding\n52 years or to both; or\n(b) in any other case, to a fine not exceeding $1 million.\nDivision 4 — Miscellaneous\nPolicies and practices for ensuring data security and\ncybersecurity\n1069.—(1) A relevant person must establish and implement\nappropriate policies and practices in respect of the matters\nmentioned in sections 66(1), (3) and (4)(b), 67(1) and 68(1) and\n(2)(b).\n(2) Without limiting subsection (1), a relevant person must ensure\n15that the policies and practices mentioned in that subsection provide\nfor any matter prescribed relating to those policies and practices.\n(3) For the purposes of subsection (2), the Minister may prescribe\ndifferent",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 84,
@@ -98797,8 +99304,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p84_c178",
-      "text": "bsection provide\nfor any matter prescribed relating to those policies and practices.\n(3) For the purposes of subsection (2), the Minister may prescribe\ndifferent matters relating to the policies and practices mentioned in\nsubsection (1) in relation to different relevant persons or classes of\n20relevant persons.\n(4) A relevant person must implement processes to ensure that\nevery personnel of the relevant person adhere to the policies and\npractices mentioned in subsection (1).\n(5) Additionally, a contributor or user must implement processes to\n25ensure that any relevant HDI of the contributor or user and every\npersonnel of that relevant HDI adhere to the policies and practices\nmentioned in subsection (1).\n(6) A relevant person must, at the prescribed frequency, review and\nevaluate the policies and practices mentioned in subsection (1) to\n30ensure that the policies and practices are effecti",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p84_c217",
+      "text": "ovide\nfor any matter prescribed relating to those policies and practices.\n(3) For the purposes of subsection (2), the Minister may prescribe\ndifferent matters relating to the policies and practices mentioned in\nsubsection (1) in relation to different relevant persons or classes of\n20relevant persons.\n(4) A relevant person must implement processes to ensure that\nevery personnel of the relevant person adhere to the policies and\npractices mentioned in subsection (1).\n(5) Additionally,acontributororusermustimplementprocessesto\n25ensure that any relevant HDI of the contributor or user and every\npersonnel of that relevant HDI adhere to the policies and practices\nmentioned in subsection (1).\n(6) Arelevantpersonmust,attheprescribedfrequency,reviewand\nevaluate the policies and practices mentioned in subsection (1) to\n30ensure that the policies and practices are effective.\n(7) Forthepurposesofsubs",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 84,
@@ -98810,8 +99317,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p84_c179",
-      "text": "escribed frequency, review and\nevaluate the policies and practices mentioned in subsection (1) to\n30ensure that the policies and practices are effective.\n(7) For the purposes of subsection (6), different frequencies may be\nprescribed for different relevant persons or classes of relevant\npersons.\n83",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p84_c218",
+      "text": "nd\nevaluate the policies and practices mentioned in subsection (1) to\n30ensure that the policies and practices are effective.\n(7) Forthepurposesofsubsection(6),differentfrequenciesmaybe\nprescribed for different relevant persons or classes of relevant\npersons.\n83",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 84,
@@ -98823,8 +99330,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p85_c180",
-      "text": "86 NO. 1 OF 2026\n(8) A person who contravenes subsection (1), (4), (5) or (6) shall be\nguilty of an offence and shall be liable on conviction —\n(a) in the case of an individual, to a fine not exceeding\n$200,000 or to imprisonment for a term not exceeding\n5 2 years or to both; or\n(b) in any other case, to a fine not exceeding $1 million.\n(9) In this section, “personnel” —\n(a) in relation to a relevant person, means an individual\nwho —\n10 (i) is employed or engaged by the relevant person; or\n(ii) provides, as a volunteer, any service to the relevant\nperson or to any other person acting on behalf of the\nrelevant person; or\n(b) in relation to a relevant HDI of a contributor or user, means\n15 an individual who is employed or engaged by the relevant\nHDI.\nIncident management framework\n70.—(1) A relevant person must establish and implement an\nincident management framework that provides for —\n20 ",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p85_c219",
+      "text": "86 NO. 1 OF 2026\n(8) Apersonwhocontravenessubsection(1),(4),(5)or(6)shallbe\nguilty of an offence and shall be liable on conviction —\n(a) in the case of an individual, to a fine not exceeding\n$200,000 or to imprisonment for a term not exceeding\n5 2 years or to both; or\n(b) in any other case, to a fine not exceeding $1 million.\n(9) In this section, “personnel” —\n(a) in relation to a relevant person, means an individual\nwho —\n10 (i) is employed or engaged by the relevant person; or\n(ii) provides, as a volunteer, any service to the relevant\nperson or to any other person acting on behalf of the\nrelevant person; or\n(b) inrelationtoarelevantHDIofacontributororuser,means\n15 an individual who is employed or engaged by the relevant\nHDI.\nIncident management framework\n70.—(1) A relevant person must establish and implement an\nincident management framework that provides for —\n20 (a) mechanisms and pro",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 85,
@@ -98836,8 +99343,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p85_c181",
-      "text": "ant\nHDI.\nIncident management framework\n70.—(1) A relevant person must establish and implement an\nincident management framework that provides for —\n20 (a) mechanisms and processes to detect and respond to any\ncybersecurity incident or data breach; and\n(b) processes to identify and resolve the cause or causes of any\ncybersecurity incident or data breach, and prevent the\nrecurrence of the cybersecurity incident or data breach or\n25 the occurrence of a similar cybersecurity incident or data\nbreach.\n(2) Without limiting subsection (1), a relevant person must ensure\nthat the incident management framework mentioned in that\nsubsection provides for any prescribed matter relating to the\n30 mechanisms and processes mentioned in subsection (1)(a) or the\nprocesses in subsection (1)(b).\n84",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p85_c220",
+      "text": "gement framework\n70.—(1) A relevant person must establish and implement an\nincident management framework that provides for —\n20 (a) mechanisms and processes to detect and respond to any\ncybersecurity incident or data breach; and\n(b) processestoidentifyandresolvethecauseorcausesofany\ncybersecurity incident or data breach, and prevent the\nrecurrence of the cybersecurity incident or data breach or\n25 the occurrence of a similar cybersecurity incident or data\nbreach.\n(2) Without limiting subsection (1), a relevant person must ensure\nthat the incident management framework mentioned in that\nsubsection provides for any prescribed matter relating to the\n30 mechanisms and processes mentioned in subsection (1)(a) or the\nprocesses in subsection (1)(b).\n84",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 85,
@@ -98849,8 +99356,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p86_c182",
-      "text": "HEALTH INFORMATION 87\n(3) For the purposes of subsection (2), the Minister may prescribe\ndifferent matters relating to the mechanisms and processes mentioned\nin subsection (1)(a) or the processes in subsection (1)(b) for different\nrelevant persons.\n5(4) A person who contravenes subsection (1) or (2) shall be guilty\nof an offence and shall be liable on conviction to a fine not exceeding\n$100,000 or to imprisonment for a term not exceeding 12 months or\nto both.\nDirections relating to relevant persons\n1071.—(1) If the Minister has reason to believe that a relevant person\nhas contravened section 65(1), 66(1), (3) or (4)(b), 67(1), 68(1) or\n(2)(b), 69(1), (4), (5) or (6) or 70(1) or any requirement mentioned in\nsection 66(5), the Minister may, by written notice, require the relevant\nperson to take any action specified in the notice which the Minister\n15reasonably considers to be necessary to ",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p86_c221",
+      "text": "HEALTH INFORMATION 87\n(3) For the purposes of subsection (2), the Minister may prescribe\ndifferentmattersrelatingtothemechanismsandprocessesmentioned\ninsubsection(1)(a)ortheprocessesinsubsection(1)(b)fordifferent\nrelevant persons.\n5(4) A person who contravenes subsection (1) or (2) shall be guilty\nofanoffenceandshallbeliableonconvictiontoafinenotexceeding\n$100,000 or to imprisonment for a term not exceeding 12 months or\nto both.\nDirections relating to relevant persons\n1071.—(1) IftheMinisterhasreasonto believethatarelevantperson\nhas contravened section 65(1), 66(1), (3) or (4)(b), 67(1), 68(1) or\n(2)(b),69(1),(4),(5)or(6)or70(1)oranyrequirementmentionedin\nsection66(5),theMinistermay,bywrittennotice,requiretherelevant\nperson to take any action specified in the notice which the Minister\n15reasonably considers to be necessary to bring the contravention to an\nend and prevent the recurrence o",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 86,
@@ -98862,8 +99369,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p86_c183",
-      "text": "y written notice, require the relevant\nperson to take any action specified in the notice which the Minister\n15reasonably considers to be necessary to bring the contravention to an\nend and prevent the recurrence of the contravention.\n(2) If the Minister has reason to believe that a relevant HDI of a\ncontributor or user has contravened section 66(4)(a), 67(2) or\n68(2)(a) or any requirement mentioned in section 66(5) in relation\n20to the processing of health information on behalf of and for the\npurposes of the contributor or user (as the case may be), the Minister\nmay, by written notice, require the relevant HDI or the contributor or\nuser (as the case may be) to take any action specified in the notice\nwhich the Minister reasonably considers to be necessary to bring the\n25contravention to an end and prevent the recurrence of the\ncontravention.\n(3) A person who, without reasonable excuse, ref",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p86_c222",
+      "text": "on specified in the notice which the Minister\n15reasonably considers to be necessary to bring the contravention to an\nend and prevent the recurrence of the contravention.\n(2) If the Minister has reason to believe that a relevant HDI of a\ncontributor or user has contravened section 66(4)(a), 67(2) or\n68(2)(a) or any requirement mentioned in section 66(5) in relation\n20to the processing of health information on behalf of and for the\npurposes of the contributor or user (as the case may be), the Minister\nmay, by written notice, require the relevant HDI or the contributor or\nuser (as the case may be) to take any action specified in the notice\nwhich the Minister reasonably considers to be necessary to bring the\n25contravention to an end and prevent the recurrence of the\ncontravention.\n(3) A person who, without reasonable excuse, refuses or fails to\ncomply with a direction under subsection (1) ",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 86,
@@ -98875,8 +99382,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p86_c184",
-      "text": " be necessary to bring the\n25contravention to an end and prevent the recurrence of the\ncontravention.\n(3) A person who, without reasonable excuse, refuses or fails to\ncomply with a direction under subsection (1) or (2) shall be guilty of\nan offence and shall be liable on conviction to a fine not exceeding\n30$50,000 or to imprisonment for a term not exceeding 12 months or to\nboth and, in the case of a continuing offence, to a further fine not\nexceeding $1,000 for every day or part of a day during which the\noffence continues after conviction.\n85",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p86_c223",
+      "text": "nt the recurrence of the\ncontravention.\n(3) A person who, without reasonable excuse, refuses or fails to\ncomply with a direction under subsection (1) or (2) shall be guilty of\nan offence and shall be liable on conviction to a fine not exceeding\n30$50,000ortoimprisonmentforatermnotexceeding12monthsorto\nboth and, in the case of a continuing offence, to a further fine not\nexceeding $1,000 for every day or part of a day during which the\noffence continues after conviction.\n85",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 86,
@@ -98888,8 +99395,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p87_c185",
-      "text": "88 NO. 1 OF 2026\nPART 5\nNOTIFICA TION OF CYBERSECURITY INCIDENTS\nAND DA TA BREACHES\nDivision 1 — General\n5 Interpretation of this Part\n72. In this Part —\n“cybersecurity incident” has the meaning given by\nsection 61(1);\n“data breach” has the meaning given by section 62;\n10 “notifiable data breach” has the meaning given by section 77(1);\n“relevant computer or computer system” has the meaning given\nby section 63(1);\n“relevant person” means a person mentioned in section 64(1).\nApplication of this Part\n15 73. This Part applies to —\n(a) in relation to any cybersecurity incident or data breach that\naffects —\n(i) the national electronic records system; or\n(ii) any relevant computer or computer system used by\n20 the relevant person to process health information or\nrelevant information; and\n(b) in relation to any data breach that affects health\ninformation or relevant information in the possession",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p87_c224",
+      "text": "88 NO. 1 OF 2026\nPART 5\nNOTIFICATION OF CYBERSECURITY INCIDENTS\nAND DATA BREACHES\nDivision 1 — General\n5 Interpretation of this Part\n72. In this Part —\n“cybersecurity incident” has the meaning given by\nsection 61(1);\n“data breach” has the meaning given by section 62;\n10 “notifiabledatabreach”hasthemeaninggivenbysection77(1);\n“relevant computer or computer system” has the meaning given\nby section 63(1);\n“relevant person” means a person mentioned in section 64(1).\nApplication of this Part\n15 73. This Part applies to —\n(a) inrelationtoanycybersecurityincidentordatabreachthat\naffects —\n(i) the national electronic records system; or\n(ii) any relevant computer or computer system used by\n20 the relevant person to process health information or\nrelevant information; and\n(b) in relation to any data breach that affects health\ninformation or relevant information in the possession or\nunder the contro",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 87,
@@ -98901,8 +99408,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p87_c186",
-      "text": " information or\nrelevant information; and\n(b) in relation to any data breach that affects health\ninformation or relevant information in the possession or\nunder the control of the relevant person.\n25 Division 2 — Notification of cybersecurity incidents\nDuty to conduct assessment of cybersecurity incident\n74.—(1) Where a relevant person has reason to believe that a\ncybersecurity incident in respect of the national electronic records\nsystem or any relevant computer or computer system used by the\n30 relevant person to process health information or relevant information\n86",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p87_c225",
+      "text": "vant information; and\n(b) in relation to any data breach that affects health\ninformation or relevant information in the possession or\nunder the control of the relevant person.\n25 Division 2 — Notification of cybersecurity incidents\nDuty to conduct assessment of cybersecurity incident\n74.—(1) Where a relevant person has reason to believe that a\ncybersecurity incident in respect of the national electronic records\nsystem or any relevant computer or computer system used by the\n30 relevantpersontoprocesshealthinformationorrelevantinformation\n86",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 87,
@@ -98914,8 +99421,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p88_c187",
-      "text": "HEALTH INFORMATION 89\nhas occurred, the relevant person must conduct, in a reasonable and\nexpeditious manner, an assessment of whether the cybersecurity\nincident is a notifiable cybersecurity incident.\n(2) Where a relevant HDI of a contributor or user has reason to\n5believe that a cybersecurity incident has occurred in respect of any\nrelevant computer or computer system used by the relevant HDI to\nprocess health information on behalf of and for the purposes of the\ncontributor or user (as the case may be) under this Act —\n(a) the relevant HDI must, without undue delay, notify the\n10contributor or user, as the case may be; and\n(b) the contributor or user (as the case may be) must, upon\nnotification by the relevant HDI, conduct an assessment of\nwhether the cybersecurity incident is a notifiable\ncybersecurity incident.\n15(3) The relevant person must carry out the assessment mentioned in\nsubs",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p88_c226",
+      "text": "HEALTH INFORMATION 89\nhas occurred, the relevant person must conduct, in a reasonable and\nexpeditious manner, an assessment of whether the cybersecurity\nincident is a notifiable cybersecurity incident.\n(2) Where a relevant HDI of a contributor or user has reason to\n5believe that a cybersecurity incident has occurred in respect of any\nrelevant computer or computer system used by the relevant HDI to\nprocess health information on behalf of and for the purposes of the\ncontributor or user (as the case may be) under this Act —\n(a) the relevant HDI must, without undue delay, notify the\n10contributor or user, as the case may be; and\n(b) the contributor or user (as the case may be) must, upon\nnotificationbytherelevantHDI,conductanassessmentof\nwhether the cybersecurity incident is a notifiable\ncybersecurity incident.\n15(3) Therelevantpersonmustcarryouttheassessmentmentionedin\nsubsection (1) or (2)",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 88,
@@ -98927,8 +99434,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p88_c188",
-      "text": "f\nwhether the cybersecurity incident is a notifiable\ncybersecurity incident.\n15(3) The relevant person must carry out the assessment mentioned in\nsubsection (1) or (2)(b) in accordance with the prescribed\nrequirements (if any).\nDuty to notify occurrence of notifiable cybersecurity incident\n75.—(1) Where a relevant person assesses, in accordance with\n20section 74, that a cybersecurity incident is a notifiable cybersecurity\nincident, the relevant person must notify the Minister as soon as is\npracticable, but in any case no later than the expiry of the period\nprescribed after the day the relevant person makes that assessment.\n(2) For the purposes of subsection (1), different periods may be\n25prescribed for different notifiable cybersecurity incidents.\n(3) The notification under subsection (1) must contain, to the best\nof the knowledge and belief of the relevant person at the time the\nreleva",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p88_c227",
+      "text": "r the cybersecurity incident is a notifiable\ncybersecurity incident.\n15(3) Therelevantpersonmustcarryouttheassessmentmentionedin\nsubsection (1) or (2)(b) in accordance with the prescribed\nrequirements (if any).\nDuty to notify occurrence of notifiable cybersecurity incident\n75.—(1) Where a relevant person assesses, in accordance with\n20section 74, that a cybersecurity incident is a notifiable cybersecurity\nincident, the relevant person must notify the Minister as soon as is\npracticable, but in any case no later than the expiry of the period\nprescribed after the day the relevant person makes that assessment.\n(2) For the purposes of subsection (1), different periods may be\n25prescribed for different notifiable cybersecurity incidents.\n(3) The notification under subsection (1) must contain, to the best\nof the knowledge and belief of the relevant person at the time the\nrelevant person notifie",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 88,
@@ -98940,8 +99447,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p88_c189",
-      "text": "cidents.\n(3) The notification under subsection (1) must contain, to the best\nof the knowledge and belief of the relevant person at the time the\nrelevant person notifies the Minister, all the information that is\nprescribed for this purpose.\n30(4) The notification under subsection (1) must be made in the form\nand submitted in the manner required by the Minister.\n(5) A relevant person is not, by reason only of notifying the\nMinister under subsection (1), to be regarded as being in breach of —\n87",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p88_c228",
+      "text": "notification under subsection (1) must contain, to the best\nof the knowledge and belief of the relevant person at the time the\nrelevant person notifies the Minister, all the information that is\nprescribed for this purpose.\n30(4) The notification under subsection (1) must be made in the form\nand submitted in the manner required by the Minister.\n(5) A relevant person is not, by reason only of notifying the\nMinisterundersubsection(1),toberegardedasbeinginbreachof—\n87",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 88,
@@ -98953,8 +99460,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p89_c190",
-      "text": "90 NO. 1 OF 2026\n(a) any duty or obligation under any written law, rule of law or\ncontract as to secrecy or other restriction on the disclosure\nof information; or\n(b) any rule of professional conduct or ethics applicable to the\n5 relevant person.\n(6) Subsection (1) applies concurrently with any obligation of the\nrelevant person —\n(a) under this Part to notify the Minister of the occurrence of a\nnotifiable data breach arising from or relating to a\n10 cybersecurity incident; or\n(b) under any other written law to notify any other person\n(including the Government or any public authority) of the\noccurrence of a cybersecurity incident, or to provide any\ninformation relating to a cybersecurity incident.\n15 Division 3 — Notification of data breaches\nInterpretation of this Division\n76. In this Division, “affected individual”, in relation to a data\nbreach, means any individual to whom any health i",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p89_c229",
+      "text": "90 NO. 1 OF 2026\n(a) anydutyorobligationunderanywrittenlaw,ruleoflawor\ncontract as to secrecy or other restriction on the disclosure\nof information; or\n(b) any rule of professional conduct or ethics applicable to the\n5 relevant person.\n(6) Subsection (1) applies concurrently with any obligation of the\nrelevant person —\n(a) underthisParttonotifytheMinisteroftheoccurrenceofa\nnotifiable data breach arising from or relating to a\n10 cybersecurity incident; or\n(b) under any other written law to notify any other person\n(including the Government or any public authority) of the\noccurrence of a cybersecurity incident, or to provide any\ninformation relating to a cybersecurity incident.\n15 Division 3 — Notification of data breaches\nInterpretation of this Division\n76. In this Division, “affected individual”, in relation to a data\nbreach, means any individual to whom any health information or\nrelevant",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 89,
@@ -98966,8 +99473,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p89_c191",
-      "text": "s\nInterpretation of this Division\n76. In this Division, “affected individual”, in relation to a data\nbreach, means any individual to whom any health information or\nrelevant information affected by the data breach relates.\n20 Notifiable data breaches\n77.—(1) Subject to subsection (4), a data breach in relation to\nhealth information or relevant information is a notifiable data breach\nunder this Division if the data breach —\n(a) results in, or is likely to result in, significant harm to an\n25 affected individual; or\n(b) is, or is likely to be, of a significant scale.\n(2) Without limiting subsection (1)(a), a data breach is deemed to\nresult in significant harm to an individual —\n(a) if the data breach is in relation to prescribed health\n30 information or relevant information or a prescribed class of\nhealth information or relevant information relating to the\nindividual; or\n88",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p89_c230",
+      "text": "is Division\n76. In this Division, “affected individual”, in relation to a data\nbreach, means any individual to whom any health information or\nrelevant information affected by the data breach relates.\n20 Notifiable data breaches\n77.—(1) Subject to subsection (4), a data breach in relation to\nhealth information or relevant information is a notifiable data breach\nunder this Division if the data breach —\n(a) results in, or is likely to result in, significant harm to an\n25 affected individual; or\n(b) is, or is likely to be, of a significant scale.\n(2) Without limiting subsection (1)(a), a data breach is deemed to\nresult in significant harm to an individual —\n(a) if the data breach is in relation to prescribed health\n30 informationorrelevantinformationoraprescribedclassof\nhealth information or relevant information relating to the\nindividual; or\n88",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 89,
@@ -98979,8 +99486,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p90_c192",
-      "text": "HEALTH INFORMATION 91\n(b) in other prescribed circumstances.\n(3) Without limiting subsection (1)(b), a data breach is deemed to\nbe of a significant scale —\n(a) if the data breach affects not fewer than the prescribed\n5number of affected individuals; or\n(b) in other prescribed circumstances.\n(4) Despite subsections (1), (2) and (3), a data breach is not a\nnotifiable data breach if it is of a type or description that is prescribed\nas such for the purposes of this subsection.\n10Duty to conduct assessment of data breach\n78.—(1) Where a relevant person has reason to believe that a data\nbreach affecting health information or relevant information in the\npossession or under the control of the relevant person has occurred,\nthe relevant person must conduct, in a reasonable and expeditious\n15manner, an assessment of whether the data breach is a notifiable data\nbreach.\n(2) Where a relevant HDI of a ",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p90_c231",
+      "text": "HEALTH INFORMATION 91\n(b) in other prescribed circumstances.\n(3) Without limiting subsection (1)(b), a data breach is deemed to\nbe of a significant scale —\n(a) if the data breach affects not fewer than the prescribed\n5number of affected individuals; or\n(b) in other prescribed circumstances.\n(4) Despite subsections (1), (2) and (3), a data breach is not a\nnotifiabledatabreachifitisofatypeordescriptionthatisprescribed\nas such for the purposes of this subsection.\n10Duty to conduct assessment of data breach\n78.—(1) Where a relevant person has reason to believe that a data\nbreach affecting health information or relevant information in the\npossession or under the control of the relevant person has occurred,\nthe relevant person must conduct, in a reasonable and expeditious\n15manner, an assessment of whetherthe data breach is a notifiable data\nbreach.\n(2) Where a relevant HDI of a contributor or",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 90,
@@ -98992,8 +99499,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p90_c193",
-      "text": "onduct, in a reasonable and expeditious\n15manner, an assessment of whether the data breach is a notifiable data\nbreach.\n(2) Where a relevant HDI of a contributor or user (other than a\nrelevant HDI mentioned in section 81) has reason to believe that a\ndata breach has occurred in relation to health information that the\n20relevant HDI is processing on behalf of and for the purposes of the\ncontributor or user, as the case may be —\n(a) the relevant HDI must, without undue delay, notify the\ncontributor or user (as the case may be) of the occurrence\nof the data breach; and\n25(b) the contributor or user (as the case may be) must, upon\nnotification by the relevant HDI, conduct an assessment of\nwhether the data breach is a notifiable data breach.\n(3) The relevant person must carry out the assessment mentioned in\nsubsection (1) or (2)(b) in accordance with any prescribed\n30requirements.\n89",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p90_c232",
+      "text": "reasonable and expeditious\n15manner, an assessment of whetherthe data breach is a notifiable data\nbreach.\n(2) Where a relevant HDI of a contributor or user (other than a\nrelevant HDI mentioned in section 81) has reason to believe that a\ndata breach has occurred in relation to health information that the\n20relevant HDI is processing on behalf of and for the purposes of the\ncontributor or user, as the case may be —\n(a) the relevant HDI must, without undue delay, notify the\ncontributor or user (as the case may be) of the occurrence\nof the data breach; and\n25(b) the contributor or user (as the case may be) must, upon\nnotificationbytherelevantHDI,conductanassessmentof\nwhether the data breach is a notifiable data breach.\n(3) Therelevantpersonmustcarryouttheassessmentmentionedin\nsubsection (1) or (2)(b) in accordance with any prescribed\n30requirements.\n89",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 90,
@@ -99005,8 +99512,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p91_c194",
-      "text": "92 NO. 1 OF 2026\nDuty to notify occurrence of notifiable data breach\n79.—(1) Where a relevant person assesses, in accordance with\nsection 78, that a data breach is a notifiable data breach, the relevant\nperson must notify the Minister as soon as is practicable, but in any\n5 case no later than the expiry of the prescribed period after the day the\nrelevant person makes that assessment.\n(2) The notification under subsection (1) must contain, to the best\nof the knowledge and belief of the relevant person at the time the\nrelevant person notifies the Minister, all the information that is\n10 prescribed for this purpose.\n(3) The notification under subsection (1) must be made in the form\nand submitted in the manner required by the Minister.\n(4) A relevant person is not, by reason only of notifying the\nMinister under subsection (1), to be regarded as being in breach of —\n15 (a) any duty or obligat",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p91_c233",
+      "text": "92 NO. 1 OF 2026\nDuty to notify occurrence of notifiable data breach\n79.—(1) Where a relevant person assesses, in accordance with\nsection 78, that a data breach is a notifiable data breach, the relevant\nperson must notify the Minister as soon as is practicable, but in any\n5 casenolaterthantheexpiryoftheprescribedperiodafterthedaythe\nrelevant person makes that assessment.\n(2) The notification under subsection (1) must contain, to the best\nof the knowledge and belief of the relevant person at the time the\nrelevant person notifies the Minister, all the information that is\n10 prescribed for this purpose.\n(3) The notification under subsection (1) must be made in the form\nand submitted in the manner required by the Minister.\n(4) A relevant person is not, by reason only of notifying the\nMinisterundersubsection(1),toberegardedasbeinginbreachof—\n15 (a) anydutyorobligationunderanywrittenlaw,ruleof",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 91,
@@ -99018,8 +99525,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p91_c195",
-      "text": "levant person is not, by reason only of notifying the\nMinister under subsection (1), to be regarded as being in breach of —\n15 (a) any duty or obligation under any written law, rule of law or\ncontract as to secrecy or other restriction on the disclosure\nof information; or\n(b) any rule of professional conduct or ethics applicable to the\nrelevant person.\n20 (5) Subsection (1) applies concurrently with any obligation of the\nrelevant person —\n(a) under this Part to notify the Minister of the occurrence of a\nnotifiable cybersecurity incident arising from or relating to\na data breach; or\n25 (b) under any other written law to notify any other person\n(including the Government or any public authority) of the\noccurrence of a data breach, or to provide any information\nrelating to a data breach.\n90",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p91_c234",
+      "text": " is not, by reason only of notifying the\nMinisterundersubsection(1),toberegardedasbeinginbreachof—\n15 (a) anydutyorobligationunderanywrittenlaw,ruleoflawor\ncontract as to secrecy or other restriction on the disclosure\nof information; or\n(b) any rule of professional conduct or ethics applicable to the\nrelevant person.\n20 (5) Subsection (1) applies concurrently with any obligation of the\nrelevant person —\n(a) underthisParttonotifytheMinisteroftheoccurrenceofa\nnotifiablecybersecurityincidentarisingfromorrelatingto\na data breach; or\n25 (b) under any other written law to notify any other person\n(including the Government or any public authority) of the\noccurrence of a data breach, or to provide any information\nrelating to a data breach.\n90",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 91,
@@ -99031,8 +99538,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p92_c196",
-      "text": "HEALTH INFORMATION 93\nDuty to notify affected individuals of occurrence of notifiable\ndata breach\n80.—(1) Subject to subsections (3), (4) and (5), a relevant person\nmust, on or after notifying the Minister under section 79(1), notify\n5each affected individual affected by a notifiable data breach\nmentioned in section 77(1)(a) in any manner that is reasonable in\nthe circumstances.\n(2) The notification under subsection (1) must contain, to the best\nof the knowledge and belief of the relevant person at the time the\n10relevant person notifies the affected individual, all the information\nthat is prescribed for this purpose.\n(3) Subsection (1) does not apply to a System Operator in respect of\na notifiable data breach mentioned in section 77(1)(a) that has\noccurred in relation to health information processed by or in the\n15national electronic records system.\n(4) Subsection (1) does not apply if ",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p92_c235",
+      "text": "HEALTH INFORMATION 93\nDuty to notify affected individuals of occurrence of notifiable\ndata breach\n80.—(1) Subject to subsections (3), (4) and (5), a relevant person\nmust, on or after notifying the Minister under section 79(1), notify\n5each affected individual affected by a notifiable data breach\nmentioned in section 77(1)(a) in any manner that is reasonable in\nthe circumstances.\n(2) The notification under subsection (1) must contain, to the best\nof the knowledge and belief of the relevant person at the time the\n10relevant person notifies the affected individual, all the information\nthat is prescribed for this purpose.\n(3) Subsection(1)doesnotapplytoaSystemOperatorinrespectof\na notifiable data breach mentioned in section 77(1)(a) that has\noccurred in relation to health information processed by or in the\n15national electronic records system.\n(4) Subsection (1) does not apply if the relevan",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 92,
@@ -99044,8 +99551,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p92_c197",
-      "text": "that has\noccurred in relation to health information processed by or in the\n15national electronic records system.\n(4) Subsection (1) does not apply if the relevant person —\n(a) upon or after assessing that a data breach is a notifiable\ndata breach mentioned in section 77(1)(a), takes any\naction, in accordance with the prescribed requirements (if\n20any), that renders it unlikely that the notifiable data breach\nwill result in significant harm to the affected individual; or\n(b) had implemented, prior to the occurrence of the notifiable\ndata breach mentioned in section 77(1)(a), any\ntechnological measure that renders it unlikely that the\n25notifiable data breach will result in significant harm to the\naffected individual.\n(5) A relevant person must not notify any affected individual in\naccordance with subsection (1) if —\n(a) a prescribed law enforcement agency so instructs; or\n30(b) the Minist",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p92_c236",
+      "text": "curred in relation to health information processed by or in the\n15national electronic records system.\n(4) Subsection (1) does not apply if the relevant person —\n(a) upon or after assessing that a data breach is a notifiable\ndata breach mentioned in section 77(1)(a), takes any\naction, in accordance with the prescribed requirements (if\n20any),thatrenders itunlikelythat thenotifiable databreach\nwillresult insignificantharmto theaffectedindividual;or\n(b) had implemented, prior to the occurrence of the notifiable\ndata breach mentioned in section 77(1)(a), any\ntechnological measure that renders it unlikely that the\n25notifiable data breach will result in significant harm to the\naffected individual.\n(5) A relevant person must not notify any affected individual in\naccordance with subsection (1) if —\n(a) a prescribed law enforcement agency so instructs; or\n30(b) the Minister so directs.\n(6) The M",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 92,
@@ -99057,8 +99564,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p92_c198",
-      "text": "st not notify any affected individual in\naccordance with subsection (1) if —\n(a) a prescribed law enforcement agency so instructs; or\n30(b) the Minister so directs.\n(6) The Minister may, on the written application of a relevant\nperson, waive the requirement to notify an affected individual under\nsubsection (1) subject to any conditions that the Minister thinks fit.\n91",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p92_c237",
+      "text": "ed individual in\naccordance with subsection (1) if —\n(a) a prescribed law enforcement agency so instructs; or\n30(b) the Minister so directs.\n(6) The Minister may, on the written application of a relevant\nperson, waive the requirement to notify an affected individual under\nsubsection (1) subject to any conditions that the Minister thinks fit.\n91",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 92,
@@ -99070,8 +99577,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p93_c199",
-      "text": "94 NO. 1 OF 2026\n(7) A relevant person is not, by reason only of notifying an affected\nindividual under subsection (1), to be regarded as being in breach\nof —\n(a) any duty or obligation under any written law, rule of law or\n5 contract as to secrecy or other restriction on the disclosure\nof information; or\n(b) any rule of professional conduct or ethics applicable to the\nrelevant person.\nObligations of relevant HDI of public agency\n10 81. Where a relevant HDI —\n(a) processes health information on behalf of and for the\npurposes of a contributor or user that is a public agency;\nand\n(b) has reason to believe that a data breach has occurred in\n15 relation to that health information,\nthe relevant HDI must, without undue delay, notify the public agency\nof the occurrence of the data breach.\nDivision 4 — Miscellaneous\nOffences under this Part\n20 82.—(1) A person who contravenes section 74(1) or (2",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p93_c238",
+      "text": "94 NO. 1 OF 2026\n(7) Arelevantpersonisnot,byreasononlyofnotifyinganaffected\nindividual under subsection (1), to be regarded as being in breach\nof —\n(a) anydutyorobligationunderanywrittenlaw,ruleoflawor\n5 contract as to secrecy or other restriction on the disclosure\nof information; or\n(b) any rule of professional conduct or ethics applicable to the\nrelevant person.\nObligations of relevant HDI of public agency\n10 81. Where a relevant HDI —\n(a) processes health information on behalf of and for the\npurposes of a contributor or user that is a public agency;\nand\n(b) has reason to believe that a data breach has occurred in\n15 relation to that health information,\ntherelevantHDImust,withoutunduedelay,notifythepublicagency\nof the occurrence of the data breach.\nDivision 4 — Miscellaneous\nOffences under this Part\n20 82.—(1) A person who contravenes section 74(1) or (2)(a) or (b),\n75(1)or(3),78(1)or(",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 93,
@@ -99083,8 +99590,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p93_c200",
-      "text": "ency\nof the occurrence of the data breach.\nDivision 4 — Miscellaneous\nOffences under this Part\n20 82.—(1) A person who contravenes section 74(1) or (2)(a) or (b),\n75(1) or (3), 78(1) or (2)(a) or (b), 79(1) or (2), 80(1) or (2) or 81 shall\nbe guilty of an offence and shall be liable on conviction —\n(a) in the case of an individual, to a fine not exceeding\n$200,000 or to imprisonment for a term not exceeding\n25 2 years or to both; or\n(b) in any other case, to a fine not exceeding $1 million.\n(2) A person who contravenes section 75(4) or 79(3) shall be guilty\nof an offence and shall be liable on conviction to a fine not exceeding\n$20,000 or to imprisonment for a term not exceeding 12 months or to\n30 both.\n92",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p93_c239",
+      "text": "ta breach.\nDivision 4 — Miscellaneous\nOffences under this Part\n20 82.—(1) A person who contravenes section 74(1) or (2)(a) or (b),\n75(1)or(3),78(1)or(2)(a)or(b),79(1)or(2),80(1)or(2)or81shall\nbe guilty of an offence and shall be liable on conviction —\n(a) in the case of an individual, to a fine not exceeding\n$200,000 or to imprisonment for a term not exceeding\n25 2 years or to both; or\n(b) in any other case, to a fine not exceeding $1 million.\n(2) Apersonwhocontravenessection75(4)or79(3)shallbeguilty\nofanoffenceandshallbeliableonconvictiontoafinenotexceeding\n$20,000ortoimprisonmentforatermnotexceeding12monthsorto\n30 both.\n92",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 93,
@@ -99096,8 +99603,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p94_c201",
-      "text": "HEALTH INFORMATION 95\nPART 6\nRESPONSES TO THREA TS AND INCIDENTS\nAFFECTING HEALTH INFORMA TION AND\nRELEV ANT INFORMA TION\n5Application of this Part\n83.—(1) This Part applies to the following persons:\n(a) a contributor;\n(b) a user;\n(c) a System Operator;\n10(d) a discloser as defined in section 45;\n(e) a recipient as defined in section 45.\n(2) To avoid doubt, this Part does not affect the operation of the\nCybersecurity Act 2018 in relation to a cybersecurity incident or\ncybersecurity threat as defined in section 2(1) of that Act.\n15Emergency measures and requirements\n84.—(1) Subsection (2) applies only if all of the following are\nsatisfied:\n(a) an event (called in this section a critical event) has\noccurred or is likely to occur that involves or results in or is\n20likely to involve or result in —\n(i) the unauthorised disclosure, modification,\ntransmission, conveyance or destruction of heal",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p94_c240",
+      "text": "HEALTH INFORMATION 95\nPART 6\nRESPONSES TO THREATS AND INCIDENTS\nAFFECTING HEALTH INFORMATION AND\nRELEVANT INFORMATION\n5Application of this Part\n83.—(1) This Part applies to the following persons:\n(a) a contributor;\n(b) a user;\n(c) a System Operator;\n10(d) a discloser as defined in section 45;\n(e) a recipient as defined in section 45.\n(2) To avoid doubt, this Part does not affect the operation of the\nCybersecurity Act 2018 in relation to a cybersecurity incident or\ncybersecurity threat as defined in section 2(1) of that Act.\n15Emergency measures and requirements\n84.—(1) Subsection (2) applies only if all of the following are\nsatisfied:\n(a) an event (called in this section a critical event) has\noccurredorislikelytooccurthatinvolvesorresultsinoris\n20likely to involve or result in —\n(i) the unauthorised disclosure, modification,\ntransmission, conveyance or destruction of health\ninformationor",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 94,
@@ -99109,8 +99616,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p94_c202",
-      "text": " or results in or is\n20likely to involve or result in —\n(i) the unauthorised disclosure, modification,\ntransmission, conveyance or destruction of health\ninformation or relevant information in the possession\nor under the control of a person mentioned in\n25section 83(1); or\n(ii) the inability to access health information or relevant\ninformation in the possession or under the control of\na person mentioned in section 83(1) in a timely\nmanner or at all;\n30(b) the occurrence or likely occurrence of a critical event, in\nthe Minister’s opinion —\n93",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p94_c241",
+      "text": "oris\n20likely to involve or result in —\n(i) the unauthorised disclosure, modification,\ntransmission, conveyance or destruction of health\ninformationorrelevantinformationinthepossession\nor under the control of a person mentioned in\n25section 83(1); or\n(ii) the inability to access health information or relevant\ninformation in the possession or under the control of\na person mentioned in section 83(1) in a timely\nmanner or at all;\n30(b) the occurrence or likely occurrence of a critical event, in\nthe Minister’s opinion —\n93",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 94,
@@ -99122,8 +99629,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p95_c203",
-      "text": "96 NO. 1 OF 2026\n(i) causes or is likely to cause serious and irreversible\nharm to the health, safety or welfare of a substantial\nnumber of individuals in Singapore;\n(ii) represents or is likely to represent a serious and\n5 imminent threat to public health; or\n(iii) causes or is likely to cause serious disruption to the\nsafe, secure and efficient provision of any healthcare\nservice or community health service in Singapore.\n(2) If the Minister is satisfied that it is necessary for the purpose of\n10 preventing, detecting or countering any critical event, the Minister\nmay, by a certificate under the Minister’s hand, authorise or direct a\nperson mentioned in section 83(1) that is specified in the certificate\n(called in this section the specified person) to take any measure, or\ncomply with any requirements, as may be necessary —\n15 (a) to prevent —\n(i) the loss of, or any damage to the accura",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p95_c242",
+      "text": "96 NO. 1 OF 2026\n(i) causes or is likely to cause serious and irreversible\nharm to the health, safety or welfare of a substantial\nnumber of individuals in Singapore;\n(ii) represents or is likely to represent a serious and\n5 imminent threat to public health; or\n(iii) causes or is likely to cause serious disruption to the\nsafe,secureandefficientprovisionofanyhealthcare\nservice or community health service in Singapore.\n(2) If the Minister is satisfied that it is necessary for the purpose of\n10 preventing, detecting or countering any critical event, the Minister\nmay, by a certificate under the Minister’s hand, authorise or direct a\nperson mentioned in section 83(1) that is specified in the certificate\n(called in this section the specified person) to take any measure, or\ncomply with any requirements, as may be necessary —\n15 (a) to prevent —\n(i) the loss of, or any damage to the accuracy, int",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 95,
@@ -99135,8 +99642,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p95_c204",
-      "text": "d person) to take any measure, or\ncomply with any requirements, as may be necessary —\n15 (a) to prevent —\n(i) the loss of, or any damage to the accuracy, integrity\nor completeness of, health information or relevant\ninformation in the possession or under the control of\nthe specified person; or\n20 (ii) the loss of, or any damage to, any computer,\ncomputer system, device or other equipment used\nby, in the possession of or under the control of the\nspecified person that is used to process health\ninformation or relevant information; or\n25 (b) to remedy or mitigate any loss or damage mentioned in\nparagraph (a) that has occurred.\n(3) A measure or requirement mentioned in subsection (2) may\nadditionally —\n(a) require or authorise the specified person to direct another\n30 person to take any measure in relation to the processing of\nhealth information or relevant information that is necessary\nto pre",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p95_c243",
+      "text": "n) to take any measure, or\ncomply with any requirements, as may be necessary —\n15 (a) to prevent —\n(i) the loss of, or any damage to the accuracy, integrity\nor completeness of, health information or relevant\ninformation in the possession or under the control of\nthe specified person; or\n20 (ii) the loss of, or any damage to, any computer,\ncomputer system, device or other equipment used\nby, in the possession of or under the control of the\nspecified person that is used to process health\ninformation or relevant information; or\n25 (b) to remedy or mitigate any loss or damage mentioned in\nparagraph (a) that has occurred.\n(3) A measure or requirement mentioned in subsection (2) may\nadditionally —\n(a) require or authorise the specified person to direct another\n30 person to take any measure in relation to the processing of\nhealthinformationorrelevantinformationthatisnecessary\nto prevent, detect o",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 95,
@@ -99148,8 +99655,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p95_c205",
-      "text": "n to direct another\n30 person to take any measure in relation to the processing of\nhealth information or relevant information that is necessary\nto prevent, detect or counter the critical event; or\n(b) require the specified person to provide to the Minister any\ninformation relating to —\n94",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p95_c244",
+      "text": "rect another\n30 person to take any measure in relation to the processing of\nhealthinformationorrelevantinformationthatisnecessary\nto prevent, detect or counter the critical event; or\n(b) require the specified person to provide to the Minister any\ninformation relating to —\n94",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 95,
@@ -99161,8 +99668,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p96_c206",
-      "text": "HEALTH INFORMATION 97\n(i) health information or relevant information that is or\nis likely to be affected by the critical event; or\n(ii) any computer, computer system, device or other\nequipment used by the specified person to process\n5health information or relevant information.\n(4) A measure or requirement mentioned in subsection (2), or a\ndirection given by a specified person pursuant to subsection (3)(a) —\n(a) does not confer any right to the production of, or of access\nto, information subject to legal privilege; and\n10(b) subject to paragraph (a), has effect despite any obligation\nor limitation imposed or any right, privilege or immunity\nconferred by or under any written law, rule of law, contract\nor rule of professional conduct or ethics, including any\nrestriction on the disclosure of information imposed by any\n15written law, rule of law, contract or rule of professional\nconduct or et",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p96_c245",
+      "text": "HEALTH INFORMATION 97\n(i) health information or relevant information that is or\nis likely to be affected by the critical event; or\n(ii) any computer, computer system, device or other\nequipment used by the specified person to process\n5health information or relevant information.\n(4) A measure or requirement mentioned in subsection (2), or a\ndirectiongivenbyaspecifiedpersonpursuanttosubsection(3)(a)—\n(a) does not confer any right to the production of, or of access\nto, information subject to legal privilege; and\n10(b) subject to paragraph (a), has effect despite any obligation\nor limitation imposed or any right, privilege or immunity\nconferredbyorunderanywrittenlaw,ruleoflaw,contract\nor rule of professional conduct or ethics, including any\nrestrictiononthedisclosureofinformationimposedbyany\n15written law, rule of law, contract or rule of professional\nconduct or ethics.\n(5) Aspecifiedpersonwh",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 96,
@@ -99174,8 +99681,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p96_c207",
-      "text": ", including any\nrestriction on the disclosure of information imposed by any\n15written law, rule of law, contract or rule of professional\nconduct or ethics.\n(5) A specified person who, without reasonable excuse, fails to take\nany measure or comply with any requirement directed by the Minister\nunder subsection (2) shall be guilty of an offence and shall be liable\n20on conviction to a fine not exceeding $500,000 or to imprisonment\nfor a term not exceeding 10 years or to both and, in the case of a\ncontinuing offence, to a further fine not exceeding $5,000 for every\nday or part of a day during which the offence continues after\nconviction.\n25(6) A person who, without reasonable excuse —\n(a) obstructs a specified person in the taking of any measure or\nin complying with any requirement under subsection (2);\nor\n(b) fails to comply with any direction given by a specified\n30person pursuant to subse",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p96_c246",
+      "text": "rictiononthedisclosureofinformationimposedbyany\n15written law, rule of law, contract or rule of professional\nconduct or ethics.\n(5) Aspecifiedpersonwho,withoutreasonableexcuse,failstotake\nanymeasureorcomplywithanyrequirementdirectedbytheMinister\nunder subsection (2) shall be guilty of an offence and shall be liable\n20on conviction to a fine not exceeding $500,000 or to imprisonment\nfor a term not exceeding 10 years or to both and, in the case of a\ncontinuing offence, to a further fine not exceeding $5,000 for every\nday or part of a day during which the offence continues after\nconviction.\n25(6) A person who, without reasonable excuse —\n(a) obstructsaspecifiedpersoninthetakingofanymeasureor\nin complying with any requirement under subsection (2);\nor\n(b) fails to comply with any direction given by a specified\n30person pursuant to subsection (3)(a),\nshallbeguiltyofanoffenceandshallbeliableonc",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 96,
@@ -99187,8 +99694,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p96_c208",
-      "text": "e or\nin complying with any requirement under subsection (2);\nor\n(b) fails to comply with any direction given by a specified\n30person pursuant to subsection (3)(a),\nshall be guilty of an offence and shall be liable on conviction to a fine\nnot exceeding $500,000 or to imprisonment for a term not exceeding\n10 years or to both and, in the case of a continuing offence, to a\n95",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p96_c247",
+      "text": "2);\nor\n(b) fails to comply with any direction given by a specified\n30person pursuant to subsection (3)(a),\nshallbeguiltyofanoffenceandshallbeliableonconvictiontoafine\nnot exceeding $500,000 or to imprisonment for a term not exceeding\n10 years or to both and, in the case of a continuing offence, to a\n95",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 96,
@@ -99200,8 +99707,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p97_c209",
-      "text": "98 NO. 1 OF 2026\nfurther fine not exceeding $5,000 for every day or part of a day during\nwhich the offence continues after conviction.\n(7) No civil or criminal liability is incurred by —\n(a) a specified person for doing or omitting to do any act if the\n5 specified person had done or omitted to do the act in good\nfaith and for the purpose of or as a result of taking any\nmeasure or complying with any requirement under\nsubsection (2); or\n(b) a person for doing or omitting to do any act if the person\n10 had done or omitted to do the act in good faith and for the\npurpose of or as a result of complying with a direction\ngiven by a specified person for the purpose of taking any\nsuch measure or complying with any such requirement.\n(8) The following persons are not considered to be in breach of any\n15 restriction upon the disclosure of information imposed by any written\nlaw, rule of law, contract ",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p97_c248",
+      "text": "98 NO. 1 OF 2026\nfurtherfinenotexceeding$5,000foreverydayorpartofadayduring\nwhich the offence continues after conviction.\n(7) No civil or criminal liability is incurred by —\n(a) aspecifiedpersonfordoingoromittingtodoanyactifthe\n5 specified person had done or omitted to do the act in good\nfaith and for the purpose of or as a result of taking any\nmeasure or complying with any requirement under\nsubsection (2); or\n(b) a person for doing or omitting to do any act if the person\n10 had done or omitted to do the act in good faith and for the\npurpose of or as a result of complying with a direction\ngiven by a specified person for the purpose of taking any\nsuch measure or complying with any such requirement.\n(8) Thefollowingpersonsarenotconsideredtobeinbreachofany\n15 restrictionuponthedisclosureofinformationimposedbyanywritten\nlaw, rule of law, contract or rule of professional conduct or ethics:\n(a",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 97,
@@ -99213,8 +99720,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p97_c210",
-      "text": "persons are not considered to be in breach of any\n15 restriction upon the disclosure of information imposed by any written\nlaw, rule of law, contract or rule of professional conduct or ethics:\n(a) a specified person who, in good faith, obtains any\ninformation for the purpose of taking any measure under\nsubsection (2) or complying with any requirement under\n20 that subsection, or who discloses any information to the\nMinister in compliance with any requirement under that\nsubsection;\n(b) a person who, in good faith, obtains any information, or\ndiscloses any information to a specified person, in\n25 compliance with a direction given by the specified\nperson for the purpose of taking any measure under\nsubsection (2) or complying with any requirement under\nthat subsection.\n(9) The following persons, namely:\n30 (a) a specified person to whom a person has provided\ninformation in compliance with a ",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p97_c249",
+      "text": "inbreachofany\n15 restrictionuponthedisclosureofinformationimposedbyanywritten\nlaw, rule of law, contract or rule of professional conduct or ethics:\n(a) a specified person who, in good faith, obtains any\ninformation for the purpose of taking any measure under\nsubsection (2) or complying with any requirement under\n20 that subsection, or who discloses any information to the\nMinister in compliance with any requirement under that\nsubsection;\n(b) a person who, in good faith, obtains any information, or\ndiscloses any information to a specified person, in\n25 compliance with a direction given by the specified\nperson for the purpose of taking any measure under\nsubsection (2) or complying with any requirement under\nthat subsection.\n(9) The following persons, namely:\n30 (a) a specified person to whom a person has provided\ninformation in compliance with a direction given by the\nspecified person for t",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 97,
@@ -99226,8 +99733,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p97_c211",
-      "text": "nt under\nthat subsection.\n(9) The following persons, namely:\n30 (a) a specified person to whom a person has provided\ninformation in compliance with a direction given by the\nspecified person for the purpose of taking any measure or\ncomplying with any requirement under subsection (2);\n96",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p97_c250",
+      "text": "ersons, namely:\n30 (a) a specified person to whom a person has provided\ninformation in compliance with a direction given by the\nspecified person for the purpose of taking any measure or\ncomplying with any requirement under subsection (2);\n96",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 97,
@@ -99239,8 +99746,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p98_c212",
-      "text": "HEALTH INFORMATION 99\n(b) a person to whom a specified person provides information\nin compliance with any requirement under subsection (2),\nmust not use or disclose the information except —\n(c) with the written permission of the person from whom the\n5information was obtained or, where the information is the\nconfidential information of a third person, with the written\npermission of the third person;\n(d) for the purpose mentioned in subsection (2)(a) or (b) in\nrelation to which the specified person or the person\n10mentioned in paragraph (b) (as the case may be) was\nprovided the information;\n(e) to disclose to any investigation officer, police officer or\nother law enforcement authority any information which\ndiscloses the commission of an offence under this Act or\n15any other written law; or\n(f) in compliance with the provisions of this Act or any other\nwritten law or an order of court.\n(10)",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p98_c251",
+      "text": "HEALTH INFORMATION 99\n(b) a person to whom a specified person provides information\nin compliance with any requirement under subsection (2),\nmust not use or disclose the information except —\n(c) with the written permission of the person from whom the\n5information was obtained or, where the information is the\nconfidential informationof a thirdperson, with the written\npermission of the third person;\n(d) for the purpose mentioned in subsection (2)(a) or (b) in\nrelation to which the specified person or the person\n10mentioned in paragraph (b) (as the case may be) was\nprovided the information;\n(e) to disclose to any investigation officer, police officer or\nother law enforcement authority any information which\ndiscloses the commission of an offence under this Act or\n15any other written law; or\n(f) in compliance with the provisions of this Act or any other\nwritten law or an order of court.\n(10) A",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 98,
@@ -99252,8 +99759,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p98_c213",
-      "text": "ce under this Act or\n15any other written law; or\n(f) in compliance with the provisions of this Act or any other\nwritten law or an order of court.\n(10) A person who, without reasonable excuse, contravenes\nsubsection (9) shall be guilty of an offence and shall be liable on\n20conviction to a fine not exceeding $50,000 or to imprisonment for a\nterm not exceeding 2 years or to both.\n(11) Where an offence is disclosed in the course of or pursuant to\nthe exercise of any power under this section —\n(a) no information for that offence may be admitted in\n25evidence in any civil or criminal proceedings; and\n(b) no witness in any civil or criminal proceedings is\nobliged —\n(i) to disclose the name, address or other particulars of\nany informer who has given information with respect\n30to that offence; or\n(ii) to answer any question if the answer would lead, or\nwould tend to lead, to the discovery of the",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p98_c252",
+      "text": " under this Act or\n15any other written law; or\n(f) in compliance with the provisions of this Act or any other\nwritten law or an order of court.\n(10) A person who, without reasonable excuse, contravenes\nsubsection (9) shall be guilty of an offence and shall be liable on\n20conviction to a fine not exceeding $50,000 or to imprisonment for a\nterm not exceeding 2 years or to both.\n(11) Where an offence is disclosed in the course of or pursuant to\nthe exercise of any power under this section —\n(a) no information for that offence may be admitted in\n25evidence in any civil or criminal proceedings; and\n(b) no witness in any civil or criminal proceedings is\nobliged —\n(i) to disclose the name, address or other particulars of\nanyinformerwhohasgiveninformationwithrespect\n30to that offence; or\n(ii) to answer any question if the answer would lead, or\nwould tend to lead, to the discovery of the name,\nad",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 98,
@@ -99265,8 +99772,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p98_c214",
-      "text": "en information with respect\n30to that offence; or\n(ii) to answer any question if the answer would lead, or\nwould tend to lead, to the discovery of the name,\naddress or other particulars of the informer.\n97",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p98_c253",
+      "text": "rmationwithrespect\n30to that offence; or\n(ii) to answer any question if the answer would lead, or\nwould tend to lead, to the discovery of the name,\naddress or other particulars of the informer.\n97",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 98,
@@ -99278,8 +99785,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p99_c215",
-      "text": "100 NO. 1 OF 2026\n(12) If any book, document, data or computer output which is\nadmitted in evidence or liable to inspection in any civil or criminal\nproceedings contains any entry in which any informer is named or\ndescribed or which may lead to the informer’s discovery, the court\n5 must cause those entries to be concealed from view or to be\nobliterated so far as may be necessary to protect the informer from\ndiscovery.\n(13) In this section, “relevant information” has the meaning given\nby section 46(1).\n10 Delegation by Minister of powers under this Part\n85.—(1) The Minister may delegate the exercise of his or her\npowers under this Part to any of the following office-holders in his or\nher Ministry by written notice to the person:\n(a) the Second Minister (if any) for his or her Ministry;\n15 (b) any Minister of State, including a Senior Minister of State,\nfor his or her Ministry;\n(c) any Par",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p99_c254",
+      "text": "100 NO. 1 OF 2026\n(12) If any book, document, data or computer output which is\nadmitted in evidence or liable to inspection in any civil or criminal\nproceedings contains any entry in which any informer is named or\ndescribed or which may lead to the informer’s discovery, the court\n5 must cause those entries to be concealed from view or to be\nobliterated so far as may be necessary to protect the informer from\ndiscovery.\n(13) In this section, “relevant information” has the meaning given\nby section 46(1).\n10 Delegation by Minister of powers under this Part\n85.—(1) The Minister may delegate the exercise of his or her\npowersunderthisParttoanyofthefollowingoffice-holdersinhisor\nher Ministry by written notice to the person:\n(a) the Second Minister (if any) for his or her Ministry;\n15 (b) anyMinisterofState,includingaSeniorMinisterofState,\nfor his or her Ministry;\n(c) any Parliamentary Secretary,",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 99,
@@ -99291,8 +99798,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p99_c216",
-      "text": "nd Minister (if any) for his or her Ministry;\n15 (b) any Minister of State, including a Senior Minister of State,\nfor his or her Ministry;\n(c) any Parliamentary Secretary, including a Senior\nParliamentary Secretary, to his or her Ministry.\n(2) A delegation by the Minister under subsection (1) may be\n20 general or for a particular case and is subject to any conditions or\nlimitations that the Minister may specify.\nPART 7\nPORTABILITY OF HEALTH INFORMA TION\nIN ELECTRONIC FORM\n25 Application of this Part\n86. This Part applies to a relevant HDI of a contributor or user in\nrespect of health information in electronic form that the relevant HDI\nprocesses on behalf of and for the purposes of the contributor or user,\nas the case may be.\n98",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p99_c255",
+      "text": "(if any) for his or her Ministry;\n15 (b) anyMinisterofState,includingaSeniorMinisterofState,\nfor his or her Ministry;\n(c) any Parliamentary Secretary, including a Senior\nParliamentary Secretary, to his or her Ministry.\n(2) A delegation by the Minister under subsection (1) may be\n20 general or for a particular case and is subject to any conditions or\nlimitations that the Minister may specify.\nPART 7\nPORTABILITY OF HEALTH INFORMATION\nIN ELECTRONIC FORM\n25 Application of this Part\n86. This Part applies to a relevant HDI of a contributor or user in\nrespectofhealthinformationinelectronicformthattherelevantHDI\nprocessesonbehalfofandforthepurposesofthecontributororuser,\nas the case may be.\n98",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 99,
@@ -99304,8 +99811,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p100_c217",
-      "text": "HEALTH INFORMATION 101\nPortability of health information\n87.—(1) A relevant HDI of a contributor or user must establish and\nimplement practices and processes in respect of the transfer, at the\nrequest of that contributor or user, of health information mentioned in\n5section 86 to —\n(a) the contributor or user, as the case may be; or\n(b) another relevant HDI designated by the contributor or user,\nas the case may be.\n(2) A relevant HDI of a contributor or user must, where the\n10contributor or user requests that the relevant HDI transfer health\ninformation mentioned in section 86 to a person mentioned in\nsubsection (1)(a) or (b), ensure that the health information is\ntransferred in accordance with the relevant HDI’s practices and\nprocesses mentioned in subsection (1).\n15(3) The relevant HDI must ensure that the practices and processes\nmentioned in subsection (1) contain measures or steps to ",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p100_c256",
+      "text": "HEALTH INFORMATION 101\nPortability of health information\n87.—(1) ArelevantHDIofacontributororusermustestablishand\nimplement practices and processes in respect of the transfer, at the\nrequestofthatcontributororuser,ofhealthinformationmentionedin\n5section 86 to —\n(a) the contributor or user, as the case may be; or\n(b) anotherrelevantHDIdesignatedbythecontributororuser,\nas the case may be.\n(2) A relevant HDI of a contributor or user must, where the\n10contributor or user requests that the relevant HDI transfer health\ninformation mentioned in section 86 to a person mentioned in\nsubsection (1)(a) or (b), ensure that the health information is\ntransferred in accordance with the relevant HDI’s practices and\nprocesses mentioned in subsection (1).\n15(3) The relevant HDI must ensure that the practices and processes\nmentioned in subsection (1) contain measures or steps to ensure\nthat —\n(a) the health",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 100,
@@ -99317,8 +99824,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p100_c218",
-      "text": "ioned in subsection (1).\n15(3) The relevant HDI must ensure that the practices and processes\nmentioned in subsection (1) contain measures or steps to ensure\nthat —\n(a) the health information that is transferred is accurate and\ncomplete; and\n20(b) the health information is transferred in a timely manner.\n(4) Without limiting subsection (1), the practices and processes\nmentioned in that subsection include practices and processes relating\nto —\n(a) the selection, preparation, extraction and transformation of\n25health information for the purposes of transfer; and\n(b) the identification and use of an appropriate format in which\nthe health information is or is to be transferred.\n(5) In addition to subsections (1), (2) and (3), a relevant HDI must\ncomply with any requirements relating to the transfer of health\n30information that may be prescribed.\n(6) For the purposes of subsection (5), the Mini",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p100_c257",
+      "text": "3) The relevant HDI must ensure that the practices and processes\nmentioned in subsection (1) contain measures or steps to ensure\nthat —\n(a) the health information that is transferred is accurate and\ncomplete; and\n20(b) the health information is transferred in a timely manner.\n(4) Without limiting subsection (1), the practices and processes\nmentioned in that subsection include practices and processes relating\nto —\n(a) theselection,preparation,extractionandtransformationof\n25health information for the purposes of transfer; and\n(b) theidentificationanduseofanappropriateformatinwhich\nthe health information is or is to be transferred.\n(5) In addition to subsections (1), (2) and (3), a relevant HDI must\ncomply with any requirements relating to the transfer of health\n30information that may be prescribed.\n(6) For the purposes of subsection (5), the Minister may prescribe\ndifferent requirements f",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 100,
@@ -99330,8 +99837,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p100_c219",
-      "text": "comply with any requirements relating to the transfer of health\n30information that may be prescribed.\n(6) For the purposes of subsection (5), the Minister may prescribe\ndifferent requirements for different relevant HDIs or classes of\nrelevant HDIs.\n99",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p100_c258",
+      "text": "e transfer of health\n30information that may be prescribed.\n(6) For the purposes of subsection (5), the Minister may prescribe\ndifferent requirements for different relevant HDIs or classes of\nrelevant HDIs.\n99",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 100,
@@ -99343,8 +99850,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p101_c220",
-      "text": "102 NO. 1 OF 2026\n(7) For the purposes of this section and section 88, the transfer of\nhealth information includes the preparation of copies of the health\ninformation and the provision of such copies to another person.\nDirections under this Part\n5 88.—(1) The Minister may, by written notice, direct a relevant HDI\nof a contributor or user to take any one or more actions specified in\nsubsection (2) if the Minister has reason to believe that the relevant\nHDI has contravened —\n(a) section 87(1), (2) or (3);\n10 (b) any requirement mentioned in section 87(5); or\n(c) any provision of any code of practice issued or approved\nunder section 90 in relation to the portability of health\ninformation under this Part.\n(2) The actions mentioned in subsection (1) are the following:\n15 (a) review the practices and processes of the relevant HDI\nmentioned in section 87(1);\n(b) review whether any transfer of h",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p101_c259",
+      "text": "102 NO. 1 OF 2026\n(7) For the purposes of this section and section 88, the transfer of\nhealth information includes the preparation of copies of the health\ninformation and the provision of such copies to another person.\nDirections under this Part\n5 88.—(1) TheMinistermay,bywrittennotice,directarelevantHDI\nof a contributor or user to take any one or more actions specified in\nsubsection (2) if the Minister has reason to believe that the relevant\nHDI has contravened —\n(a) section 87(1), (2) or (3);\n10 (b) any requirement mentioned in section 87(5); or\n(c) any provision of any code of practice issued or approved\nunder section 90 in relation to the portability of health\ninformation under this Part.\n(2) The actions mentioned in subsection (1) are the following:\n15 (a) review the practices and processes of the relevant HDI\nmentioned in section 87(1);\n(b) review whether any transfer of health inf",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 101,
@@ -99356,8 +99863,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p101_c221",
-      "text": " (1) are the following:\n15 (a) review the practices and processes of the relevant HDI\nmentioned in section 87(1);\n(b) review whether any transfer of health information by the\nrelevant HDI is in accordance with the practices and\nprocesses of the relevant HDI mentioned in section 87(1)\n20 and the provisions of this Part;\n(c) identify any error, failure, inadequacy or shortcoming\nrelating to the practices and processes of the relevant HDI\nor the transfer of health information, and take reasonable\nsteps to remedy the error, failure, inadequacy or\n25 shortcoming and prevent its recurrence;\n(d) any other action in relation to any matter in paragraph (a),\n(b) or (c) that the Minister may reasonably require.\n(3) A person who, without reasonable excuse, refuses or fails to\ncomply with a direction under subsection (1) shall be guilty of an\n30 offence and shall be liable on conviction to a fine not",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p101_c260",
+      "text": "the following:\n15 (a) review the practices and processes of the relevant HDI\nmentioned in section 87(1);\n(b) review whether any transfer of health information by the\nrelevant HDI is in accordance with the practices and\nprocesses of the relevant HDI mentioned in section 87(1)\n20 and the provisions of this Part;\n(c) identify any error, failure, inadequacy or shortcoming\nrelating to the practices and processes of the relevant HDI\nor the transfer of health information, and take reasonable\nsteps to remedy the error, failure, inadequacy or\n25 shortcoming and prevent its recurrence;\n(d) any other action in relation to any matter in paragraph (a),\n(b) or (c) that the Minister may reasonably require.\n(3) A person who, without reasonable excuse, refuses or fails to\ncomply with a direction under subsection (1) shall be guilty of an\n30 offence and shall be liable on conviction to a fine not exceedin",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 101,
@@ -99369,8 +99876,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p101_c222",
-      "text": "use, refuses or fails to\ncomply with a direction under subsection (1) shall be guilty of an\n30 offence and shall be liable on conviction to a fine not exceeding\n$20,000 or to imprisonment for a term not exceeding 12 months or to\nboth and, in the case of a continuing offence, to a further fine not\n100",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p101_c261",
+      "text": "ses or fails to\ncomply with a direction under subsection (1) shall be guilty of an\n30 offence and shall be liable on conviction to a fine not exceeding\n$20,000ortoimprisonmentforatermnotexceeding12monthsorto\nboth and, in the case of a continuing offence, to a further fine not\n100",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 101,
@@ -99382,8 +99889,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p102_c223",
-      "text": "HEALTH INFORMATION 103\nexceeding $1,000 for every day or part of a day during which the\noffence continues after conviction.\nPART 8\nADMINISTRA TION AND ENFORCEMENT\n5Administration of Act\n89.—(1) The Minister may —\n(a) appoint a public officer, an officer of a public authority, or\nany other individual who is suitably qualified, to be an\nauthorised officer to exercise the powers conferred on\n10authorised officers under this Part and Division 6 of Part 2;\nand\n(b) appoint a public officer or an officer of a public authority to\nbe an investigation officer to exercise the powers conferred\non investigation officers under this Part.\n15(2) Subject to subsection (3), the Minister may delegate the exercise\nof all or any of the powers conferred or duties imposed on the\nMinister under this Act to a public officer or an officer of a public\nauthority; and any reference in the provision of this Act to th",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p102_c262",
+      "text": "HEALTH INFORMATION 103\nexceeding $1,000 for every day or part of a day during which the\noffence continues after conviction.\nPART 8\nADMINISTRATION AND ENFORCEMENT\n5Administration of Act\n89.—(1) The Minister may —\n(a) appoint a public officer, an officer of a public authority, or\nany other individual who is suitably qualified, to be an\nauthorised officer to exercise the powers conferred on\n10authorisedofficersunderthisPartandDivision6ofPart2;\nand\n(b) appointapublicofficeroranofficerofapublicauthorityto\nbeaninvestigationofficertoexercisethepowersconferred\non investigation officers under this Part.\n15(2) Subjecttosubsection(3),theMinistermaydelegatetheexercise\nof all or any of the powers conferred or duties imposed on the\nMinister under this Act to a public officer or an officer of a public\nauthority; and any reference in the provision of this Act to the\nMinister includes a reference to that",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 102,
@@ -99395,8 +99902,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p102_c224",
-      "text": "s imposed on the\nMinister under this Act to a public officer or an officer of a public\nauthority; and any reference in the provision of this Act to the\nMinister includes a reference to that officer.\n20(3) Subsection (2) does not apply to the following powers and\nduties:\n(a) the power of appointment under subsection (1);\n(b) the power of delegation under subsection (2);\n(c) the Minister’s powers and duties under section 36;\n25(d) the Minister’s powers under section 84;\n(e) the Minister’s power to make subsidiary legislation.\n(4) Any delegation under subsection (2) may be general or specific,\nand may be subject to any conditions or limitations that the Minister\nmay specify.\n30(5) Every authorised officer or investigation officer in\nsubsection (1) who is not otherwise a public servant under\n101",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p102_c263",
+      "text": "t to a public officer or an officer of a public\nauthority; and any reference in the provision of this Act to the\nMinister includes a reference to that officer.\n20(3) Subsection (2) does not apply to the following powers and\nduties:\n(a) the power of appointment under subsection (1);\n(b) the power of delegation under subsection (2);\n(c) the Minister’s powers and duties under section 36;\n25(d) the Minister’s powers under section 84;\n(e) the Minister’s power to make subsidiary legislation.\n(4) Anydelegationundersubsection(2)maybegeneralorspecific,\nand may be subject to any conditions or limitations that the Minister\nmay specify.\n30(5) Every authorised officer or investigation officer in\nsubsection (1) who is not otherwise a public servant under\n101",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 102,
@@ -99408,8 +99915,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p103_c225",
-      "text": "104 NO. 1 OF 2026\nsection 21 of the Penal Code 1871, is taken to be one for the purposes\nof that Act.\nCodes of practice\n90.—(1) The Minister may —\n5 (a) issue one or more codes of practice;\n(b) approve as a code of practice any document prepared by a\nperson other than the Minister if the Minister considers the\ndocument suitable for this purpose; or\n(c) amend or revoke any code of practice issued under\n10 paragraph (a) or approved under paragraph (b),\nwith respect to all or any of the matters mentioned in subsection (2).\n(2) The matters for the purposes of subsection (1) are the following:\n(a) the conduct of contributors, users, disclosers, recipients,\nrelevant HDIs of contributors and users and health data\n15 intermediaries of disclosers and recipients;\n(b) the measures to ensure the confidentiality, integrity and\navailability of health information and relevant information;\n(c) the porta",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p103_c264",
+      "text": "104 NO. 1 OF 2026\nsection21ofthePenalCode1871,istakentobeoneforthepurposes\nof that Act.\nCodes of practice\n90.—(1) The Minister may —\n5 (a) issue one or more codes of practice;\n(b) approve as a code of practice any document prepared by a\npersonotherthantheMinisteriftheMinisterconsidersthe\ndocument suitable for this purpose; or\n(c) amend or revoke any code of practice issued under\n10 paragraph (a) or approved under paragraph (b),\nwith respect to all or any of the matters mentioned in subsection (2).\n(2) Themattersforthepurposesofsubsection(1)arethefollowing:\n(a) the conduct of contributors, users, disclosers, recipients,\nrelevant HDIs of contributors and users and health data\n15 intermediaries of disclosers and recipients;\n(b) the measures to ensure the confidentiality, integrity and\navailabilityofhealthinformationandrelevantinformation;\n(c) theportabilityofhealthinformationinelectronicfor",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 103,
@@ -99421,8 +99928,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p103_c226",
-      "text": "d recipients;\n(b) the measures to ensure the confidentiality, integrity and\navailability of health information and relevant information;\n(c) the portability of health information in electronic form that\nis processed by a relevant HDI of a contributor or user.\n20 (3) If any provision in any code of practice is inconsistent with any\nprovision of this Act, that provision, to the extent of the\ninconsistency —\n(a) is to have effect subject to this Act; or\n(b) having regard to this Act, is not to have effect.\n25 (4) Where a code of practice is issued, approved, amended or\nrevoked by the Minister under subsection (1), the Minister must —\n(a) publish a notice of the issue, approval, amendment or\nrevocation (as the case may be) of the code of practice in a\nmanner that will secure adequate publicity for the issue,\n30 approval, amendment or revocation;\n102",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p103_c265",
+      "text": " ensure the confidentiality, integrity and\navailabilityofhealthinformationandrelevantinformation;\n(c) theportabilityofhealthinformationinelectronicformthat\nis processed by a relevant HDI of a contributor or user.\n20 (3) If any provision in any code of practice is inconsistent with any\nprovision of this Act, that provision, to the extent of the\ninconsistency —\n(a) is to have effect subject to this Act; or\n(b) having regard to this Act, is not to have effect.\n25 (4) Where a code of practice is issued, approved, amended or\nrevoked by the Minister under subsection (1), the Minister must —\n(a) publish a notice of the issue, approval, amendment or\nrevocation(asthecasemaybe)ofthe codeofpracticeina\nmanner that will secure adequate publicity for the issue,\n30 approval, amendment or revocation;\n102",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 103,
@@ -99434,8 +99941,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p104_c227",
-      "text": "HEALTH INFORMATION 105\n(b) specify in the notice the date of the issue, approval,\namendment or revocation, as the case may be; and\n(c) ensure that, so long as the code of practice remains in force,\ncopies of that code of practice, and of all amendments to it,\n5are made available free of charge to the persons to whom\nthe code of practice applies.\n(5) No issued or approved code of practice, no amendment to any\ncode of practice, and no revocation of any code of practice, has any\nforce or effect until the notice mentioned in subsection (4) is\n10published in accordance with that subsection.\n(6) A code of practice issued or approved under this section does\nnot have legislative effect.\n(7) Subject to subsection (8), a person must comply with any code\nof practice that is applicable to that person.\n15(8) The Minister may, either generally or for any period that the\nMinister may specify, waive the",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p104_c266",
+      "text": "HEALTH INFORMATION 105\n(b) specify in the notice the date of the issue, approval,\namendment or revocation, as the case may be; and\n(c) ensurethat,solongasthecodeofpracticeremainsinforce,\ncopiesofthatcodeofpractice,andofallamendmentstoit,\n5are made available free of charge to the persons to whom\nthe code of practice applies.\n(5) No issued or approved code of practice, no amendment to any\ncode of practice, and no revocation of any code of practice, has any\nforce or effect until the notice mentioned in subsection (4) is\n10published in accordance with that subsection.\n(6) A code of practice issued or approved under this section does\nnot have legislative effect.\n(7) Subject to subsection (8), a person must comply with any code\nof practice that is applicable to that person.\n15(8) The Minister may, either generally or for any period that the\nMinister may specify, waive the application of any co",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 104,
@@ -99447,8 +99954,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p104_c228",
-      "text": "ode\nof practice that is applicable to that person.\n15(8) The Minister may, either generally or for any period that the\nMinister may specify, waive the application of any code of practice,\nor any part of a code of practice, issued or approved under this section\nto any person.\n(9) A contravention or failure by a person to comply with a code of\n20practice that applies to the person —\n(a) does not of itself render the person liable to criminal\nproceedings; but\n(b) in any proceedings (criminal or otherwise) may be relied\non by any party to those proceedings as tending to establish\n25or negate any liability which is in question in those\nproceedings.\nPower to obtain documents and information — authorised\nofficers\n91.—(1) An authorised officer may, by written notice, require any\n30person to provide, within a reasonable period or at the time or\nfrequency, and in the form or manner, specified in t",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p104_c267",
+      "text": "s applicable to that person.\n15(8) The Minister may, either generally or for any period that the\nMinister may specify, waive the application of any code of practice,\noranypartofacodeofpractice,issuedorapprovedunderthissection\nto any person.\n(9) Acontraventionorfailure byapersonto complywithacodeof\n20practice that applies to the person —\n(a) does not of itself render the person liable to criminal\nproceedings; but\n(b) in any proceedings (criminal or otherwise) may be relied\nonbyanypartytothoseproceedingsastendingtoestablish\n25or negate any liability which is in question in those\nproceedings.\nPower to obtain documents and information — authorised\nofficers\n91.—(1) An authorised officer may, by written notice, require any\n30person to provide, within a reasonable period or at the time or\nfrequency, and in the form or manner, specified in the notice, any\ndocument or information —\n103",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 104,
@@ -99460,20 +99967,7 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p104_c229",
-      "text": " by written notice, require any\n30person to provide, within a reasonable period or at the time or\nfrequency, and in the form or manner, specified in the notice, any\ndocument or information —\n103",
-      "metadata": {
-        "source": "health-information-act-2026.pdf",
-        "page": 104,
-        "category": "sg-hia",
-        "jurisdiction": "SG",
-        "document_id": "sg-hia",
-        "framework": "HIA",
-        "content_type": "primary"
-      }
-    },
-    {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p105_c230",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p105_c268",
       "text": "106 NO. 1 OF 2026\n(a) that the authorised officer considers necessary to\ndetermine —\n(i) the person’s compliance with this Act, or any\ndirection, notice or order issued under this Act;\n5 (ii) whether the person’s practices and procedures are in\ncompliance with an applicable code of practice; or\n(iii) whether information provided to the Minister or any\nauthorised officer under a provision of this Act is\ncorrect; and\n10 (b) that is —\n(i) within the knowledge of that person; or\n(ii) in the custody or under the control of that person.\n(2) An authorised officer is entitled without payment to keep any\ndocument or information, or any copy or extract of any document or\n15 information, provided to the authorised officer under subsection (1).\nPower to obtain documents and information — investigation\nofficers\n92.—(1) An investigation officer may, by written notice, require\nany person to provide, wi",
       "metadata": {
         "source": "health-information-act-2026.pdf",
@@ -99486,8 +99980,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p105_c231",
-      "text": "o obtain documents and information — investigation\nofficers\n92.—(1) An investigation officer may, by written notice, require\nany person to provide, within a reasonable period or at the time or\n20 frequency, and in the form or manner, specified in the notice, any\ndocument or information —\n(a) that the investigation officer considers necessary —\n(i) to determine the person’s compliance with this Act,\nincluding whether an offence under this Act has been\n25 committed;\n(ii) to determine the person’s compliance with any\ndirection, notice or order issued under this Act;\n(iii) to determine whether information provided to the\nMinister or an authorised officer under a provision of\n30 this Act is correct; or\n104",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p105_c269",
+      "text": "o obtain documents and information — investigation\nofficers\n92.—(1) An investigation officer may, by written notice, require\nany person to provide, within a reasonable period or at the time or\n20 frequency, and in the form or manner, specified in the notice, any\ndocument or information —\n(a) that the investigation officer considers necessary —\n(i) to determine the person’s compliance with this Act,\nincludingwhetheranoffenceunderthisActhasbeen\n25 committed;\n(ii) to determine the person’s compliance with any\ndirection, notice or order issued under this Act;\n(iii) to determine whether information provided to the\nMinisteroranauthorisedofficerunderaprovisionof\n30 this Act is correct; or\n104",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 105,
@@ -99499,8 +99993,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p106_c232",
-      "text": "HEALTH INFORMATION 107\n(iv) to determine whether the person’s practices and\nprocedures are in compliance with an applicable\ncode of practice; and\n(b) that is —\n5(i) within the knowledge of that person; or\n(ii) in the custody or under the control of that person.\n(2) The power under subsection (1) to require a person to provide\nany document or information includes the power —\n(a) to require that person, or any individual who is or was an\n10officer or employee of the person, to provide an\nexplanation of the document or information;\n(b) if the document or information is not provided, to require\nthat person to state, to the best of the knowledge and belief\nof that person, where it is;\n15(c) if the document or information is recorded otherwise than\nin legible form, to require the document or information to\nbe made available to the authorised officer in legible form;\nand\n(d) if the document or ",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p106_c270",
+      "text": "HEALTH INFORMATION 107\n(iv) to determine whether the person’s practices and\nprocedures are in compliance with an applicable\ncode of practice; and\n(b) that is —\n5(i) within the knowledge of that person; or\n(ii) in the custody or under the control of that person.\n(2) The power under subsection (1) to require a person to provide\nany document or information includes the power —\n(a) to require that person, or any individual who is or was an\n10officer or employee of the person, to provide an\nexplanation of the document or information;\n(b) if the document or information is not provided, to require\nthatpersontostate,tothebestoftheknowledgeandbelief\nof that person, where it is;\n15(c) if the document or information is recorded otherwise than\nin legible form, to require the document or information to\nbemadeavailabletotheauthorisedofficerinlegibleform;\nand\n(d) if the document or information is store",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 106,
@@ -99512,8 +100006,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p106_c233",
-      "text": "an\nin legible form, to require the document or information to\nbe made available to the authorised officer in legible form;\nand\n(d) if the document or information is stored in a computer or\n20other electronic device, and the person or individual is\nreasonably suspected to have knowledge of or access to\nany username, password or other authentication\ninformation required to gain access to the document or\ninformation, to require the person or individual to provide\n25assistance (including but not limited to providing any\nusername, password or other authentication information)\nto gain access to the computer or electronic device and the\ndocument or information in the computer or electronic\ndevice.\n30(3) An investigation officer is entitled without payment to keep any\ndocument or information, or any copy or extract of any document or\ninformation, provided to the investigation officer under\nsubse",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p106_c271",
+      "text": "le form, to require the document or information to\nbemadeavailabletotheauthorisedofficerinlegibleform;\nand\n(d) if the document or information is stored in a computer or\n20other electronic device, and the person or individual is\nreasonably suspected to have knowledge of or access to\nany username, password or other authentication\ninformation required to gain access to the document or\ninformation, to require the person or individual to provide\n25assistance (including but not limited to providing any\nusername, password or other authentication information)\nto gain access to the computer or electronic device and the\ndocument or information in the computer or electronic\ndevice.\n30(3) Aninvestigationofficerisentitledwithoutpaymenttokeepany\ndocument or information, or any copy or extract of any document or\ninformation, provided to the investigation officer under\nsubsection (1).\n105",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 106,
@@ -99525,21 +100019,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p106_c234",
-      "text": " payment to keep any\ndocument or information, or any copy or extract of any document or\ninformation, provided to the investigation officer under\nsubsection (1).\n105",
-      "metadata": {
-        "source": "health-information-act-2026.pdf",
-        "page": 106,
-        "category": "sg-hia",
-        "jurisdiction": "SG",
-        "document_id": "sg-hia",
-        "framework": "HIA",
-        "content_type": "primary"
-      }
-    },
-    {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p107_c235",
-      "text": "108 NO. 1 OF 2026\nPowers of entry and inspection — authorised officers\n93.—(1) An authorised officer may, during normal business hours,\nenter and inspect any premises or conveyance which the authorised\nofficer reasonably believes to be —\n5 (a) owned or occupied by a person; or\n(b) where any activity is being or has been conducted or\ncarried on by a person,\nfor the purpose of —\n(c) determining the person’s compliance with this Act, or any\n10 direction, notice or order issued under this Act; or\n(d) assessing whether the practices of the person are in\ncompliance with an applicable code of practice.\n(2) For the purposes of subsection (1), the authorised officer may do\nall or any of the following:\n15 (a) inspect or examine any thing or observe any activity\nconducted in or on the premises or conveyance;\n(b) make a still or moving image or recording of the premises\nor conveyance and any thing i",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p107_c272",
+      "text": "108 NO. 1 OF 2026\nPowers of entry and inspection — authorised officers\n93.—(1) An authorised officer may, during normal business hours,\nenter and inspect any premises or conveyance which the authorised\nofficer reasonably believes to be —\n5 (a) owned or occupied by a person; or\n(b) where any activity is being or has been conducted or\ncarried on by a person,\nfor the purpose of —\n(c) determining the person’s compliance with this Act, or any\n10 direction, notice or order issued under this Act; or\n(d) assessing whether the practices of the person are in\ncompliance with an applicable code of practice.\n(2) Forthepurposesofsubsection(1),theauthorisedofficermaydo\nall or any of the following:\n15 (a) inspect or examine any thing or observe any activity\nconducted in or on the premises or conveyance;\n(b) make a still or moving image or recording of the premises\nor conveyance and any thing in or on th",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 107,
@@ -99551,8 +100032,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p107_c236",
-      "text": "ny activity\nconducted in or on the premises or conveyance;\n(b) make a still or moving image or recording of the premises\nor conveyance and any thing in or on the premises or\nconveyance;\n20 (c) inspect and make copies of or take extracts from, or require\nthe occupier or any person having the management or\ncontrol of the premises or conveyance to provide copies of\nor extracts from, any book, document, record or electronic\nmaterial;\n25 (d) inspect and make copies of or take extracts from, or require\nthe occupier or any person having the management or\ncontrol of the premises or conveyance to provide copies of\nor extracts from, health information about any individual in\nthe possession or under the control of the occupier or\n30 person, even though the prior consent of that individual has\nnot been obtained;\n(e) take into or onto the premises or conveyance any\nequipment and material that the aut",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p107_c273",
+      "text": "y\nconducted in or on the premises or conveyance;\n(b) make a still or moving image or recording of the premises\nor conveyance and any thing in or on the premises or\nconveyance;\n20 (c) inspectandmakecopiesofortakeextractsfrom,orrequire\nthe occupier or any person having the management or\ncontrolofthepremisesorconveyancetoprovidecopiesof\nor extracts from, any book, document, record or electronic\nmaterial;\n25 (d) inspectandmakecopiesofortakeextractsfrom,orrequire\nthe occupier or any person having the management or\ncontrolofthepremisesorconveyancetoprovidecopiesof\norextractsfrom,healthinformationaboutanyindividualin\nthe possession or under the control of the occupier or\n30 person,eventhoughthepriorconsentofthatindividualhas\nnot been obtained;\n(e) take into or onto the premises or conveyance any\nequipment and material that the authorised officer\n106",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 107,
@@ -99564,21 +100045,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p107_c237",
-      "text": "h the prior consent of that individual has\nnot been obtained;\n(e) take into or onto the premises or conveyance any\nequipment and material that the authorised officer\n106",
-      "metadata": {
-        "source": "health-information-act-2026.pdf",
-        "page": 107,
-        "category": "sg-hia",
-        "jurisdiction": "SG",
-        "document_id": "sg-hia",
-        "framework": "HIA",
-        "content_type": "primary"
-      }
-    },
-    {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p108_c238",
-      "text": "HEALTH INFORMATION 109\nrequires for the purpose of exercising any power under this\nAct in relation to the premises or conveyance;\n(f) operate electronic equipment in or on the premises or\nconveyance.\n5(3) The power under subsection (2)(f) to operate electronic\nequipment in or on any premises or conveyance includes the\npower —\n(a) to use a disk, tape or other storage device that is in or on the\npremises or conveyance and can be used with the\n10equipment or in association with the equipment;\n(b) to operate electronic equipment in or on the premises or\nconveyance to put the relevant data in documentary form\nand remove the documents so produced from the premises\nor conveyance; and\n15(c) to operate electronic equipment in or on the premises or\nconveyance to transfer the relevant data to a disk, tape or\nother storage device that —\n(i) is brought to the premises or conveyance for the\nexercise o",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p108_c274",
+      "text": "HEALTH INFORMATION 109\nrequiresforthepurposeofexercisinganypowerunderthis\nAct in relation to the premises or conveyance;\n(f) operate electronic equipment in or on the premises or\nconveyance.\n5(3) The power under subsection (2)(f) to operate electronic\nequipment in or on any premises or conveyance includes the\npower —\n(a) touseadisk,tapeorotherstoragedevicethatisinoronthe\npremises or conveyance and can be used with the\n10equipment or in association with the equipment;\n(b) to operate electronic equipment in or on the premises or\nconveyance to put the relevant data in documentary form\nand remove the documents so produced from the premises\nor conveyance; and\n15(c) to operate electronic equipment in or on the premises or\nconveyance to transfer the relevant data to a disk, tape or\nother storage device that —\n(i) is brought to the premises or conveyance for the\nexercise of the power; or\n20(ii) ",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 108,
@@ -99590,8 +100058,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p108_c239",
-      "text": "onveyance to transfer the relevant data to a disk, tape or\nother storage device that —\n(i) is brought to the premises or conveyance for the\nexercise of the power; or\n20(ii) is in or on the premises or conveyance and the use of\nwhich for that purpose has been agreed in writing by\nthe occupier of the premises or conveyance,\nand to remove the disk, tape or other storage device from\nthose premises or that conveyance.\n25(4) Any individual who is present at any premises or conveyance\nmentioned in subsection (1) must render all assistance and\ncooperation to an authorised officer as are necessary for an entry\nor inspection or otherwise for the exercise of his or her powers under\nthis Act in relation to those premises or that conveyance.\n30Powers of entry, inspection and search, etc. — investigation\nofficers\n94.—(1) An investigation officer may, at any time and without\nnotice and without warrant,",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p108_c275",
+      "text": "he relevant data to a disk, tape or\nother storage device that —\n(i) is brought to the premises or conveyance for the\nexercise of the power; or\n20(ii) isinoronthepremisesorconveyanceandtheuseof\nwhich for thatpurpose hasbeen agreed in writing by\nthe occupier of the premises or conveyance,\nand to remove the disk, tape or other storage device from\nthose premises or that conveyance.\n25(4) Any individual who is present at any premises or conveyance\nmentioned in subsection (1) must render all assistance and\ncooperation to an authorised officer as are necessary for an entry\nor inspectionor otherwise for the exercise of hisor her powers under\nthis Act in relation to those premises or that conveyance.\n30Powers of entry, inspection and search, etc. — investigation\nofficers\n94.—(1) An investigation officer may, at any time and without\nnoticeandwithoutwarrant,enter,inspectandsearchanypremisesor\n107",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 108,
@@ -99603,21 +100071,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p108_c240",
-      "text": " entry, inspection and search, etc. — investigation\nofficers\n94.—(1) An investigation officer may, at any time and without\nnotice and without warrant, enter, inspect and search any premises or\n107",
-      "metadata": {
-        "source": "health-information-act-2026.pdf",
-        "page": 108,
-        "category": "sg-hia",
-        "jurisdiction": "SG",
-        "document_id": "sg-hia",
-        "framework": "HIA",
-        "content_type": "primary"
-      }
-    },
-    {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p109_c241",
-      "text": "110 NO. 1 OF 2026\nconveyance which the investigation officer reasonably believes to\nbe —\n(a) owned or occupied by a person; or\n(b) where any activity is being or has been conducted or\n5 carried on by a person,\nfor the purpose of —\n(c) investigating an offence under this Act or a contravention\nof or non‑compliance with a provision of this Act; or\n(d) assessing whether the practices of a person are in\n10 compliance with this Act or an applicable code of practice.\n(2) For the purposes of subsection (1), the investigation officer may\ndo all or any of the following:\n(a) inspect or examine any thing or observe any activity\nconducted in or on the premises or conveyance;\n15 (b) make a still or moving image or recording of the premises\nor conveyance and any thing in or on the premises or\nconveyance;\n(c) inspect and make copies of or take extracts from, or require\nthe occupier or any person having",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p109_c276",
+      "text": "110 NO. 1 OF 2026\nconveyance which the investigation officer reasonably believes to\nbe —\n(a) owned or occupied by a person; or\n(b) where any activity is being or has been conducted or\n5 carried on by a person,\nfor the purpose of —\n(c) investigating an offence under this Act or a contravention\nof or non‑compliance with a provision of this Act; or\n(d) assessing whether the practices of a person are in\n10 compliancewiththisActoranapplicablecodeofpractice.\n(2) Forthepurposesofsubsection(1),theinvestigationofficermay\ndo all or any of the following:\n(a) inspect or examine any thing or observe any activity\nconducted in or on the premises or conveyance;\n15 (b) make a still or moving image or recording of the premises\nor conveyance and any thing in or on the premises or\nconveyance;\n(c) inspectandmakecopiesofortakeextractsfrom,orrequire\nthe occupier or any person having the management or\n20 contro",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 109,
@@ -99629,8 +100084,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p109_c242",
-      "text": " and any thing in or on the premises or\nconveyance;\n(c) inspect and make copies of or take extracts from, or require\nthe occupier or any person having the management or\n20 control of the premises or conveyance to provide copies of\nor extracts from, any book, document, record or electronic\nmaterial;\n(d) inspect and make copies of or take extracts from, or require\nthe occupier or any person having the management or\n25 control of the premises or conveyance to provide copies of\nor extracts from, health information about any individual in\nthe possession or under the control of the occupier or\nperson, even though the prior consent of that individual has\nnot been obtained;\n30 (e) take into or onto the premises or conveyance any\nequipment and material that the investigation officer\nrequires for the purpose of exercising any power under\nthis Act in relation to the premises or conveyance;\n108",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p109_c277",
+      "text": "or on the premises or\nconveyance;\n(c) inspectandmakecopiesofortakeextractsfrom,orrequire\nthe occupier or any person having the management or\n20 controlofthepremisesorconveyancetoprovidecopiesof\nor extracts from, any book, document, record or electronic\nmaterial;\n(d) inspectandmakecopiesofortakeextractsfrom,orrequire\nthe occupier or any person having the management or\n25 controlofthepremisesorconveyancetoprovidecopiesof\norextractsfrom,healthinformationaboutanyindividualin\nthe possession or under the control of the occupier or\nperson,eventhoughthepriorconsentofthatindividualhas\nnot been obtained;\n30 (e) take into or onto the premises or conveyance any\nequipment and material that the investigation officer\nrequires for the purpose of exercising any power under\nthis Act in relation to the premises or conveyance;\n108",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 109,
@@ -99642,8 +100097,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p110_c243",
-      "text": "HEALTH INFORMATION 111\n(f) operate electronic equipment in or on the premises or\nconveyance;\n(g) seize any document or thing if all of the following are\nsatisfied:\n5(i) the investigation officer has reasonable grounds to\nbelieve that the document or thing is —\n(A) evidential material relevant to, or is intended to\nbe used for the purpose of committing, an\noffence under this Act or a contravention of or\n10non‑compliance with a provision of this Act; or\n(B) evidential material relevant to assessing a\nperson’s compliance with this Act or an\napplicable code of practice;\n(ii) it is necessary to seize the document or thing in order\n15to prevent it from being concealed, lost or destroyed.\n(3) The power under subsection (2)(f) to operate electronic\nequipment in or on any premises or conveyance includes the\npower —\n(a) to use a disk, tape or other storage device that is in or on the\n20premises or",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p110_c278",
+      "text": "HEALTH INFORMATION 111\n(f) operate electronic equipment in or on the premises or\nconveyance;\n(g) seize any document or thing if all of the following are\nsatisfied:\n5(i) the investigation officer has reasonable grounds to\nbelieve that the document or thing is —\n(A) evidentialmaterialrelevantto,orisintendedto\nbe used for the purpose of committing, an\noffence under this Act or a contravention of or\n10non‑compliancewithaprovisionofthisAct;or\n(B) evidential material relevant to assessing a\nperson’s compliance with this Act or an\napplicable code of practice;\n(ii) itisnecessarytoseizethedocumentorthinginorder\n15topreventitfrombeingconcealed,lostordestroyed.\n(3) The power under subsection (2)(f) to operate electronic\nequipment in or on any premises or conveyance includes the\npower —\n(a) touseadisk,tapeorotherstoragedevicethatisinoronthe\n20premises or conveyance and can be used with the\nequipment",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 110,
@@ -99655,8 +100110,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p110_c244",
-      "text": "\nequipment in or on any premises or conveyance includes the\npower —\n(a) to use a disk, tape or other storage device that is in or on the\n20premises or conveyance and can be used with the\nequipment or in association with the equipment;\n(b) to operate electronic equipment in or on the premises or\nconveyance to put the relevant data in documentary form\nand remove the documents so produced from the premises\n25or conveyance; and\n(c) to operate electronic equipment in or on the premises or\nconveyance to transfer the relevant data to a disk, tape or\nother storage device that —\n(i) is brought to the premises or conveyance for the\n30exercise of the power; or\n109",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p110_c279",
+      "text": " or conveyance includes the\npower —\n(a) touseadisk,tapeorotherstoragedevicethatisinoronthe\n20premises or conveyance and can be used with the\nequipment or in association with the equipment;\n(b) to operate electronic equipment in or on the premises or\nconveyance to put the relevant data in documentary form\nand remove the documents so produced from the premises\n25or conveyance; and\n(c) to operate electronic equipment in or on the premises or\nconveyance to transfer the relevant data to a disk, tape or\nother storage device that —\n(i) is brought to the premises or conveyance for the\n30exercise of the power; or\n109",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 110,
@@ -99668,8 +100123,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p111_c245",
-      "text": "112 NO. 1 OF 2026\n(ii) is in or on the premises or conveyance and the use of\nwhich for that purpose has been agreed in writing by\nthe occupier of the premises or conveyance,\nand to remove the disk, tape or other storage device from\n5 those premises or that conveyance.\n(4) Any individual who is present at any premises or conveyance\nmentioned in subsection (1) must render all assistance and\ncooperation to an investigation officer as are necessary for an\nentry, inspection or investigation or otherwise for the exercise of his\n10 or her powers under this Act in relation to those premises or that\nconveyance.\n(5) An investigation officer may for a purpose in subsection (1)(c)\nor (d) —\n(a) require any person —\n15 (i) to provide any information within the person’s\nknowledge; or\n(ii) to produce any book, document, record, electronic\nmaterial, article or thing within the person’s\npossession for ins",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p111_c280",
+      "text": "112 NO. 1 OF 2026\n(ii) isinoronthepremisesorconveyanceandtheuseof\nwhich for thatpurpose hasbeen agreed in writing by\nthe occupier of the premises or conveyance,\nand to remove the disk, tape or other storage device from\n5 those premises or that conveyance.\n(4) Any individual who is present at any premises or conveyance\nmentioned in subsection (1) must render all assistance and\ncooperation to an investigation officer as are necessary for an\nentry, inspection or investigation or otherwise for the exercise of his\n10 or her powers under this Act in relation to those premises or that\nconveyance.\n(5) An investigation officer may for a purpose in subsection (1)(c)\nor (d) —\n(a) require any person —\n15 (i) to provide any information within the person’s\nknowledge; or\n(ii) to produce any book, document, record, electronic\nmaterial, article or thing within the person’s\npossession for inspection by th",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 111,
@@ -99681,8 +100136,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p111_c246",
-      "text": "in the person’s\nknowledge; or\n(ii) to produce any book, document, record, electronic\nmaterial, article or thing within the person’s\npossession for inspection by the investigation\n20 officer and for him or her to make copies of the\nbook, document or other record, or to provide the\ninvestigation officer with copies of the book,\ndocument or other record;\n(b) orally examine any person who appears to be acquainted\n25 with the facts and circumstances of any contravention or\nsuspected contravention of a provision under this Act, and\nmust —\n(i) reduce to writing any statement made by the person\nso examined;\n30 (ii) read the statement over to the person so examined;\n(iii) if the person does not understand English, interpret,\nor cause to be interpreted, the statement in a language\nthat the person understands; and\n110",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p111_c281",
+      "text": "’s\nknowledge; or\n(ii) to produce any book, document, record, electronic\nmaterial, article or thing within the person’s\npossession for inspection by the investigation\n20 officer and for him or her to make copies of the\nbook, document or other record, or to provide the\ninvestigation officer with copies of the book,\ndocument or other record;\n(b) orally examine any person who appears to be acquainted\n25 with the facts and circumstances of any contravention or\nsuspected contravention of a provision under this Act, and\nmust —\n(i) reduce to writing any statement made by the person\nso examined;\n30 (ii) read the statement over to the person so examined;\n(iii) if the person does not understand English, interpret,\norcausetobeinterpreted,thestatementinalanguage\nthat the person understands; and\n110",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 111,
@@ -99694,8 +100149,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p112_c247",
-      "text": "HEALTH INFORMATION 113\n(iv) require the person so examined to sign the statement,\nafter correction, if necessary; and\n(c) require, by written order, the attendance before the\ninvestigation officer of any person, being within the\n5limits of Singapore, who, from information given or\notherwise, appears to be acquainted with the facts and\ncircumstances of any matter under this Act, and that person\nmust attend as so required.\n(6) A person examined under this section must state truly the facts\n10and circumstances with which the person is acquainted, except only\nthat the person need not say anything that might expose the person to\na criminal charge, penalty or forfeiture.\nOffence of obstructing, etc., authorised officer or investigation\nofficer in exercise of powers, etc.\n1595.—(1) A person who —\n(a) refuses to give access to, or obstructs, hinders, impedes or\ndelays, an authorised officer or i",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p112_c282",
+      "text": "HEALTH INFORMATION 113\n(iv) requirethepersonsoexaminedtosignthestatement,\nafter correction, if necessary; and\n(c) require, by written order, the attendance before the\ninvestigation officer of any person, being within the\n5limits of Singapore, who, from information given or\notherwise, appears to be acquainted with the facts and\ncircumstancesofanymatterunderthisAct,andthatperson\nmust attend as so required.\n(6) A person examined under this section must state truly the facts\n10and circumstances with which the person is acquainted, except only\nthatthepersonneednotsayanythingthatmightexposethepersonto\na criminal charge, penalty or forfeiture.\nOffenceofobstructing,etc.,authorisedofficerorinvestigation\nofficer in exercise of powers, etc.\n1595.—(1) A person who —\n(a) refuses to give access to, or obstructs, hinders, impedes or\ndelays, an authorised officer or investigation officer in the\nexercise",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 112,
@@ -99707,8 +100162,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p112_c248",
-      "text": " exercise of powers, etc.\n1595.—(1) A person who —\n(a) refuses to give access to, or obstructs, hinders, impedes or\ndelays, an authorised officer or investigation officer in the\nexercise of any power under this Part;\n(b) without reasonable excuse, does not comply with a\n20requirement under section 91(1), 92(1), 93(2)(c) or (d) or\n94(2)(c) or (d) or (5)(a), or with section 93(4) or 94(4); or\n(c) refuses to be examined under section 94(5)(b) or does not\nattend before an investigation officer as required under\nsection 94(5)(c),\n25shall be guilty of an offence and shall be liable on conviction to a fine\nnot exceeding $20,000 or to imprisonment for a term not exceeding\n12 months or to both.\n(2) For the purposes of subsection (1)(b), it is a reasonable excuse\nfor a person to refuse or fail to provide any information, produce any\n30book, document, record, electronic material, article or thing o",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p112_c283",
+      "text": "A person who —\n(a) refuses to give access to, or obstructs, hinders, impedes or\ndelays, an authorised officer or investigation officer in the\nexercise of any power under this Part;\n(b) without reasonable excuse, does not comply with a\n20requirement under section 91(1), 92(1), 93(2)(c) or (d) or\n94(2)(c) or (d) or (5)(a), or with section 93(4) or 94(4); or\n(c) refuses to be examined under section 94(5)(b) or does not\nattend before an investigation officer as required under\nsection 94(5)(c),\n25shallbeguiltyofanoffenceandshallbeliableonconvictiontoafine\nnot exceeding $20,000 or to imprisonment for a term not exceeding\n12 months or to both.\n(2) For the purposes of subsection (1)(b), it is a reasonable excuse\nfor a person to refuse or failto provide any information, produce any\n30book, document, record, electronic material, article or thing or\nansweranyquestionifdoingsomighttendtoincriminatet",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 112,
@@ -99720,8 +100175,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p112_c249",
-      "text": "onable excuse\nfor a person to refuse or fail to provide any information, produce any\n30book, document, record, electronic material, article or thing or\nanswer any question if doing so might tend to incriminate that person.\n111",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p112_c284",
+      "text": "vide any information, produce any\n30book, document, record, electronic material, article or thing or\nansweranyquestionifdoingsomighttendtoincriminatethatperson.\n111",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 112,
@@ -99733,8 +100188,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p113_c250",
-      "text": "114 NO. 1 OF 2026\nFalse or misleading statements, documents or information\n96. A person who, in relation to any matter under this Act —\n(a) makes any statement, or provides any document or\ninformation, that is false or misleading in a material\n5 particular; and\n(b) knows or ought reasonably to know that, or is reckless as to\nwhether, the statement, document or information is false or\nmisleading in a material particular,\nshall be guilty of an offence and shall be liable on conviction to a fine\n10 not exceeding $20,000 or to imprisonment for a term not exceeding\n12 months or to both.\nDisposal of things and documents\n97.—(1) Any thing or document produced, detained or seized under\nthis Act must —\n15 (a) where the thing or document is produced in any criminal\ntrial, be dealt with in accordance with section 364(1) of the\nCriminal Procedure Code 2010; or\n(b) in any other case, be returned to t",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p113_c285",
+      "text": "114 NO. 1 OF 2026\nFalse or misleading statements, documents or information\n96. A person who, in relation to any matter under this Act —\n(a) makes any statement, or provides any document or\ninformation, that is false or misleading in a material\n5 particular; and\n(b) knowsoroughtreasonablytoknowthat,orisrecklessasto\nwhether,thestatement,documentorinformationisfalseor\nmisleading in a material particular,\nshallbeguiltyofanoffenceandshallbeliableonconvictiontoafine\n10 not exceeding $20,000 or to imprisonment for a term not exceeding\n12 months or to both.\nDisposal of things and documents\n97.—(1) Anythingordocumentproduced,detainedorseizedunder\nthis Act must —\n15 (a) where the thing or document is produced in any criminal\ntrial,bedealtwithinaccordancewithsection364(1)ofthe\nCriminal Procedure Code 2010; or\n(b) in any other case, be returned to the owner or reported to a\nMagistrate’s Court.\n20 (2",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 113,
@@ -99746,8 +100201,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p113_c251",
-      "text": "in any criminal\ntrial, be dealt with in accordance with section 364(1) of the\nCriminal Procedure Code 2010; or\n(b) in any other case, be returned to the owner or reported to a\nMagistrate’s Court.\n20 (2) Where the report of any thing or document is made to a\nMagistrate’s Court under subsection (1)(b), the Magistrate’s Court\nmay order the thing or document —\n(a) to be forfeited; or\n(b) to be disposed of in any manner that the Magistrate’s Court\n25 thinks fit.\n(3) This section does not affect any right to retain or dispose of\nproperty which may exist in law apart from this section.\n112",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p113_c286",
+      "text": "ancewithsection364(1)ofthe\nCriminal Procedure Code 2010; or\n(b) in any other case, be returned to the owner or reported to a\nMagistrate’s Court.\n20 (2) Where the report of any thing or document is made to a\nMagistrate’s Court under subsection (1)(b), the Magistrate’s Court\nmay order the thing or document —\n(a) to be forfeited; or\n(b) tobedisposedofinanymannerthattheMagistrate’sCourt\n25 thinks fit.\n(3) This section does not affect any right to retain or dispose of\nproperty which may exist in law apart from this section.\n112",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 113,
@@ -99759,8 +100214,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p114_c252",
-      "text": "HEALTH INFORMATION 115\nPART 9\nMISCELLANEOUS\nLegal protections — contributors\n98.—(1) This section applies to a contributor, or an authorised\n5individual of a contributor, in relation to the contribution of health\ninformation about any individual under this Act by the contributor if,\nand only if, the health information is contributed —\n(a) in good faith and with reasonable care; and\n(b) in accordance with this Act.\n10(2) No liability shall lie against the contributor or the authorised\nindividual of a contributor for anything done in relation to the\ncontribution of the health information about the individual.\n(3) Subject to subsection (4), the contribution of the health\ninformation by the contributor is not a breach of —\n15(a) any obligation of confidentiality; or\n(b) any prohibition or restriction in respect of the disclosure or\nuse of the health information,\nthat is imposed under any wri",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p114_c287",
+      "text": "HEALTH INFORMATION 115\nPART 9\nMISCELLANEOUS\nLegal protections — contributors\n98.—(1) This section applies to a contributor, or an authorised\n5individual of a contributor, in relation to the contribution of health\ninformationaboutanyindividualunderthisActbythecontributorif,\nand only if, the health information is contributed —\n(a) in good faith and with reasonable care; and\n(b) in accordance with this Act.\n10(2) No liability shall lie against the contributor or the authorised\nindividual of a contributor for anything done in relation to the\ncontribution of the health information about the individual.\n(3) Subject to subsection (4), the contribution of the health\ninformation by the contributor is not a breach of —\n15(a) any obligation of confidentiality; or\n(b) anyprohibitionorrestrictioninrespectofthedisclosureor\nuse of the health information,\nthat is imposed under any written law, rule of l",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 114,
@@ -99772,8 +100227,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p114_c253",
-      "text": "of confidentiality; or\n(b) any prohibition or restriction in respect of the disclosure or\nuse of the health information,\nthat is imposed under any written law, rule of law, contract or rule of\nprofessional conduct or ethics.\n20(4) Subsection (3) does not apply in relation to any obligation of\nconfidentiality, or any prohibition or restriction in respect of the\ndisclosure or use of the health information, that is imposed under any\nprescribed written law.\n(5) The contribution of the health information by the contributor is\n25not an act of infringement of any copyright in the health information\nthat is held by any person.\n(6) In this section, “authorised individual” of a contributor means\nan individual who —\n(a) is any of the following:\n30(i) an individual who is employed or engaged by the\ncontributor;\n113",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p114_c288",
+      "text": "ntiality; or\n(b) anyprohibitionorrestrictioninrespectofthedisclosureor\nuse of the health information,\nthat is imposed under any written law, rule of law, contract or rule of\nprofessional conduct or ethics.\n20(4) Subsection (3) does not apply in relation to any obligation of\nconfidentiality, or any prohibition or restriction in respect of the\ndisclosureoruseofthehealthinformation,thatisimposedunderany\nprescribed written law.\n(5) The contribution of the health information by the contributor is\n25not an act of infringement of any copyright in the health information\nthat is held by any person.\n(6) In this section, “authorised individual” of a contributor means\nan individual who —\n(a) is any of the following:\n30(i) an individual who is employed or engaged by the\ncontributor;\n113",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 114,
@@ -99785,8 +100240,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p115_c254",
-      "text": "116 NO. 1 OF 2026\n(ii) an individual who provides, as a volunteer, any\nservice to the contributor; and\n(b) is authorised by the contributor to do any thing to enable or\nfacilitate the contribution of health information by the\n5 contributor in accordance with this Act.\nLegal protections — users\n99.—(1) This section applies in relation to the access, collection or\ndisclosure of accessible health information about any individual\nunder this Act —\n10 (a) by a user if, and only if, the user accesses, collects or\ndiscloses the accessible health information —\n(i) in good faith and with reasonable care; and\n(ii) in accordance with this Act; and\n(b) by an authorised individual of a user as defined in\n15 section 18(1) or (2) (as the case may be) if, and only if,\nthe authorised individual accesses, collects or discloses the\naccessible health information —\n(i) in good faith and with reasonable care;\n",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p115_c289",
+      "text": "116 NO. 1 OF 2026\n(ii) an individual who provides, as a volunteer, any\nservice to the contributor; and\n(b) isauthorisedbythecontributortodoanythingtoenableor\nfacilitate the contribution of health information by the\n5 contributor in accordance with this Act.\nLegal protections — users\n99.—(1) This section applies in relation to the access, collection or\ndisclosure of accessible health information about any individual\nunder this Act —\n10 (a) by a user if, and only if, the user accesses, collects or\ndiscloses the accessible health information —\n(i) in good faith and with reasonable care; and\n(ii) in accordance with this Act; and\n(b) by an authorised individual of a user as defined in\n15 section 18(1) or (2) (as the case may be) if, and only if,\ntheauthorisedindividualaccesses,collectsordisclosesthe\naccessible health information —\n(i) in good faith and with reasonable care;\n(ii) in accordance",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 115,
@@ -99798,8 +100253,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p115_c255",
-      "text": "nd only if,\nthe authorised individual accesses, collects or discloses the\naccessible health information —\n(i) in good faith and with reasonable care;\n(ii) in accordance with this Act; and\n20 (iii) in the ordinary course of the duties of the authorised\nindividual.\n(2) No liability shall lie against the user or the authorised individual\nof a user for anything done in relation to the access, collection or\ndisclosure of the accessible health information.\n25 (3) The access, collection or disclosure of the accessible health\ninformation by the user or the authorised individual of a user is not a\nbreach of —\n(a) any obligation of confidentiality; or\n114",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p115_c290",
+      "text": "\ntheauthorisedindividualaccesses,collectsordisclosesthe\naccessible health information —\n(i) in good faith and with reasonable care;\n(ii) in accordance with this Act; and\n20 (iii) in the ordinary course of the duties of the authorised\nindividual.\n(2) Noliabilityshalllieagainsttheuserortheauthorisedindividual\nof a user for anything done in relation to the access, collection or\ndisclosure of the accessible health information.\n25 (3) The access, collection or disclosure of the accessible health\ninformation by the user or the authorised individual of a user is not a\nbreach of —\n(a) any obligation of confidentiality; or\n114",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 115,
@@ -99811,8 +100266,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p116_c256",
-      "text": "HEALTH INFORMATION 117\n(b) any prohibition or restriction in respect of the access or\ncollection (as the case may be) of the accessible health\ninformation,\nthat is imposed under any written law, rule of law, contract or rule of\n5professional conduct or ethics.\n(4) The access, collection or disclosure of the accessible health\ninformation by the user or the authorised individual of a user is not an\nact of infringement of any copyright in the health information that is\nheld by any person.\n10Legal protections — requestors\n100.—(1) This section applies in relation to the access, collection,\ndisclosure or use of derived information within the meaning given by\nsection 6 —\n(a) by a requestor if, and only if, the requestor accesses,\n15collects, discloses or uses the derived information —\n(i) in good faith and with reasonable care; and\n(ii) in accordance with this Act; and\n(b) by an authorised ind",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p116_c291",
+      "text": "HEALTH INFORMATION 117\n(b) any prohibition or restriction in respect of the access or\ncollection (as the case may be) of the accessible health\ninformation,\nthat is imposed under any written law, rule of law, contract or rule of\n5professional conduct or ethics.\n(4) The access, collection or disclosure of the accessible health\ninformationbytheuserortheauthorisedindividualofauserisnotan\nact of infringement of any copyright in the health information that is\nheld by any person.\n10Legal protections — requestors\n100.—(1) This section applies in relation to the access, collection,\ndisclosureoruseofderivedinformationwithinthemeaninggivenby\nsection 6 —\n(a) by a requestor if, and only if, the requestor accesses,\n15collects, discloses or uses the derived information —\n(i) in good faith and with reasonable care; and\n(ii) in accordance with this Act; and\n(b) by an authorised individual of a requestor ",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 116,
@@ -99824,8 +100279,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p116_c257",
-      "text": "loses or uses the derived information —\n(i) in good faith and with reasonable care; and\n(ii) in accordance with this Act; and\n(b) by an authorised individual of a requestor if, and only if,\nthe authorised individual accesses, collects, discloses or\n20uses the derived information —\n(i) in good faith and with reasonable care;\n(ii) in accordance with this Act; and\n(iii) in the ordinary course of the duties of the authorised\nindividual.\n25(2) No liability shall lie against the requestor or the authorised\nindividual of a requestor for anything done in relation to the access,\ncollection, disclosure or use of the derived information.\n(3) The access, collection, disclosure or use of the derived\ninformation by the requestor or the authorised individual of a\n30requestor is not a breach of —\n(a) any obligation of confidentiality; or\n115",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p116_c292",
+      "text": "ed information —\n(i) in good faith and with reasonable care; and\n(ii) in accordance with this Act; and\n(b) by an authorised individual of a requestor if, and only if,\nthe authorised individual accesses, collects, discloses or\n20uses the derived information —\n(i) in good faith and with reasonable care;\n(ii) in accordance with this Act; and\n(iii) in the ordinary course of the duties of the authorised\nindividual.\n25(2) No liability shall lie against the requestor or the authorised\nindividual of a requestor for anything done in relation to the access,\ncollection, disclosure or use of the derived information.\n(3) The access, collection, disclosure or use of the derived\ninformation by the requestor or the authorised individual of a\n30requestor is not a breach of —\n(a) any obligation of confidentiality; or\n115",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 116,
@@ -99837,8 +100292,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p117_c258",
-      "text": "118 NO. 1 OF 2026\n(b) any prohibition or restriction in respect of the access,\ncollection, disclosure or use (as the case may be) of the\nderived information,\nthat is imposed under any written law, rule of law, contract or rule of\n5 professional conduct or ethics.\n(4) The access, collection, disclosure or use of the derived\ninformation by the requestor or the authorised individual of a\nrequestor is not an act of infringement of any copyright in the derived\ninformation that is held by any person.\n10 (5) In this section, “authorised individual” of a requestor means an\nindividual who is, or who belongs to a class of individuals that is,\nspecified in the approval granted by the Minister in accordance with\nsection 25(10)(b).\nLegal protections — System Operator, etc.\n15 101.—(1) This section applies, in relation to anything done or\nomitted to be done —\n(a) by a System Operator if, and only if, ",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p117_c293",
+      "text": "118 NO. 1 OF 2026\n(b) any prohibition or restriction in respect of the access,\ncollection, disclosure or use (as the case may be) of the\nderived information,\nthat is imposed under any written law, rule of law, contract or rule of\n5 professional conduct or ethics.\n(4) The access, collection, disclosure or use of the derived\ninformation by the requestor or the authorised individual of a\nrequestorisnotanactofinfringementofanycopyrightinthederived\ninformation that is held by any person.\n10 (5) In this section, “authorised individual” of a requestor means an\nindividual who is, or who belongs to a class of individuals that is,\nspecified in the approval granted by the Minister in accordance with\nsection 25(10)(b).\nLegal protections — System Operator, etc.\n15 101.—(1) This section applies, in relation to anything done or\nomitted to be done —\n(a) by a System Operator if, and only if, the System O",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 117,
@@ -99850,8 +100305,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p117_c259",
-      "text": "ystem Operator, etc.\n15 101.—(1) This section applies, in relation to anything done or\nomitted to be done —\n(a) by a System Operator if, and only if, the System Operator\ndoes or omits to do so —\n(i) in good faith and with reasonable care; and\n20 (ii) in accordance with this Act; and\n(b) by any officer, employee or contractor of a System\nOperator if, and only if, the officer, employee or\ncontractor (as the case may be) does so or omits to do so —\n(i) in good faith and with reasonable care;\n25 (ii) in accordance with this Act; and\n(iii) in the ordinary course of the duties of the officer,\nemployee or contractor (as the case may be) for the\nSystem Operator.\n(2) No liability shall lie against the System Operator or the officer,\n30 employee or contractor of a System Operator for anything done or\nomitted to be done in relation to any specified matter.\n116",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p117_c294",
+      "text": "or, etc.\n15 101.—(1) This section applies, in relation to anything done or\nomitted to be done —\n(a) by a System Operator if, and only if, the System Operator\ndoes or omits to do so —\n(i) in good faith and with reasonable care; and\n20 (ii) in accordance with this Act; and\n(b) by any officer, employee or contractor of a System\nOperator if, and only if, the officer, employee or\ncontractor(asthecasemaybe)doessooromitstodoso—\n(i) in good faith and with reasonable care;\n25 (ii) in accordance with this Act; and\n(iii) in the ordinary course of the duties of the officer,\nemployee or contractor (as the case may be) for the\nSystem Operator.\n(2) No liability shall lie against the System Operator or the officer,\n30 employee or contractor of a System Operator for anything done or\nomitted to be done in relation to any specified matter.\n116",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 117,
@@ -99863,8 +100318,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p118_c260",
-      "text": "HEALTH INFORMATION 119\n(3) No liability shall lie against the System Operator or the officer,\nemployee or contractor of a System Operator for any of the following:\n(a) any error or inaccuracy in —\n(i) accessible health information about any individual\n5that is made available to any user or any authorised\nindividual of a user; or\n(ii) derived information that is provided to a requestor in\nrelation to an application approved under\nsection 25(2) or (3);\n10(b) any loss or damage arising from any error or inaccuracy\nin —\n(i) accessible health information about any individual\nthat is made available to any user or any authorised\nindividual of a user; or\n15(ii) derived information that is provided to a requestor in\nrelation to an application approved under\nsection 25(2) or (3);\n(c) any loss or damage arising from —\n(i) any failure or delay by any contributor to contribute\n20health information ab",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p118_c295",
+      "text": "HEALTH INFORMATION 119\n(3) No liability shall lie against the System Operator or the officer,\nemployeeorcontractorofaSystemOperatorforanyofthefollowing:\n(a) any error or inaccuracy in —\n(i) accessible health information about any individual\n5that is made available to any user or any authorised\nindividual of a user; or\n(ii) derivedinformationthatisprovidedtoarequestorin\nrelation to an application approved under\nsection 25(2) or (3);\n10(b) any loss or damage arising from any error or inaccuracy\nin —\n(i) accessible health information about any individual\nthat is made available to any user or any authorised\nindividual of a user; or\n15(ii) derivedinformationthatisprovidedtoarequestorin\nrelation to an application approved under\nsection 25(2) or (3);\n(c) any loss or damage arising from —\n(i) any failure or delay by any contributor to contribute\n20health information about any individual; or\n(ii)",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 118,
@@ -99876,8 +100331,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p118_c261",
-      "text": "ed under\nsection 25(2) or (3);\n(c) any loss or damage arising from —\n(i) any failure or delay by any contributor to contribute\n20health information about any individual; or\n(ii) the inability of, or any interruption, suspension or\nrestriction of the ability of, any contributor to\ncontribute health information about any individual;\n(d) any loss or damage arising from —\n25(i) any failure or delay by any user or any authorised\nindividual of a user to access or collect accessible\nhealth information about any individual; or\n(ii) the inability of, or any interruption, suspension or\nrestriction of the ability of, any user or any\n30authorised individual of a user to access or collect\naccessible health information about any individual.\n(4) No liability shall lie against the System Operator or the officer,\nemployee or contractor of a System Operator for any loss or damage\n117",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p118_c296",
+      "text": "3);\n(c) any loss or damage arising from —\n(i) any failure or delay by any contributor to contribute\n20health information about any individual; or\n(ii) the inability of, or any interruption, suspension or\nrestriction of the ability of, any contributor to\ncontribute health information about any individual;\n(d) any loss or damage arising from —\n25(i) any failure or delay by any user or any authorised\nindividual of a user to access or collect accessible\nhealth information about any individual; or\n(ii) the inability of, or any interruption, suspension or\nrestriction of the ability of, any user or any\n30authorised individual of a user to access or collect\naccessible health information about any individual.\n(4) No liability shall lie against the System Operator or the officer,\nemployee or contractor of a System Operator for any loss or damage\n117",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 118,
@@ -99889,8 +100344,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p119_c262",
-      "text": "120 NO. 1 OF 2026\nthat arises solely from or in relation to the imposition or operation of\nan access restriction in relation to accessible health information about\nany individual, or the revocation of any such access restriction.\n(5) The System Operator or the officer, employee or contractor of a\n5 System Operator who does or omits to do anything in relation to any\nspecified matter does not commit an act of infringement of any\ncopyright in health information concerned that is held by any person.\n(6) In this section, “specified matter” means any of the following\nmatters:\n10 (a) the processing of health information for the purposes of\nPart 2, including —\n(i) the collection of health information about any\nindividual that is contributed by any contributor;\n(ii) the processing of health information stored in the\n15 national electronic records system for the purpose of\nmaking available accessi",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p119_c297",
+      "text": "120 NO. 1 OF 2026\nthat arises solely from or in relation to the imposition or operation of\nanaccessrestrictioninrelationtoaccessiblehealthinformationabout\nany individual, or the revocation of any such access restriction.\n(5) TheSystemOperatorortheofficer,employeeorcontractorofa\n5 System Operator who does or omits to do anything in relation to any\nspecified matter does not commit an act of infringement of any\ncopyrightinhealthinformationconcernedthatisheldbyanyperson.\n(6) In this section, “specified matter” means any of the following\nmatters:\n10 (a) the processing of health information for the purposes of\nPart 2, including —\n(i) the collection of health information about any\nindividual that is contributed by any contributor;\n(ii) the processing of health information stored in the\n15 national electronic records system for the purpose of\nmaking available accessible health information\nabout ",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 119,
@@ -99902,8 +100357,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p119_c263",
-      "text": "contributor;\n(ii) the processing of health information stored in the\n15 national electronic records system for the purpose of\nmaking available accessible health information\nabout any individual to any user or any authorised\nindividual of a user;\n(iii) the implementation of any request to impose an\n20 access restriction in relation to accessible health\ninformation about any individual, or to revoke any\nsuch access restriction; and\n(iv) the provision of derived information to a requestor in\naccordance with an application approved under\n25 section 25(2) or (3);\n(b) the operation, administration and maintenance of the\nnational electronic records system, including the access\nand use of health information stored in the national\nelectronic records system for that purpose.\n30 Legal protections — disclosers\n102.—(1) This section applies in relation to the disclosure of\nrelevant information, pursu",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p119_c298",
+      "text": "ing of health information stored in the\n15 national electronic records system for the purpose of\nmaking available accessible health information\nabout any individual to any user or any authorised\nindividual of a user;\n(iii) the implementation of any request to impose an\n20 access restriction in relation to accessible health\ninformation about any individual, or to revoke any\nsuch access restriction; and\n(iv) theprovisionofderivedinformationtoarequestorin\naccordance with an application approved under\n25 section 25(2) or (3);\n(b) the operation, administration and maintenance of the\nnational electronic records system, including the access\nand use of health information stored in the national\nelectronic records system for that purpose.\n30 Legal protections — disclosers\n102.—(1) This section applies in relation to the disclosure of\nrelevant information, pursuant to a data sharing agreement —\n118",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 119,
@@ -99915,21 +100370,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p119_c264",
-      "text": " system for that purpose.\n30 Legal protections — disclosers\n102.—(1) This section applies in relation to the disclosure of\nrelevant information, pursuant to a data sharing agreement —\n118",
-      "metadata": {
-        "source": "health-information-act-2026.pdf",
-        "page": 119,
-        "category": "sg-hia",
-        "jurisdiction": "SG",
-        "document_id": "sg-hia",
-        "framework": "HIA",
-        "content_type": "primary"
-      }
-    },
-    {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p120_c265",
-      "text": "HEALTH INFORMATION 121\n(a) by a discloser if, and only if, the discloser discloses the\nrelevant information —\n(i) in good faith and with reasonable care; and\n(ii) in accordance with this Act; and\n5(b) by an authorised personnel of a discloser if, and only if, the\nauthorised personnel discloses the relevant information —\n(i) in good faith and with reasonable care;\n(ii) in accordance with this Act; and\n(iii) in the ordinary course of the duties of the authorised\n10personnel.\n(2) No liability shall lie against the discloser or the authorised\npersonnel of a discloser for anything done in relation to the disclosure\nof the relevant information.\n(3) The disclosure of the relevant information by the discloser or\n15the authorised individual of a discloser is not a breach of —\n(a) any obligation of confidentiality; or\n(b) any prohibition or restriction in respect of the disclosure of\nthe relevant ",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p120_c299",
+      "text": "HEALTH INFORMATION 121\n(a) by a discloser if, and only if, the discloser discloses the\nrelevant information —\n(i) in good faith and with reasonable care; and\n(ii) in accordance with this Act; and\n5(b) byanauthorisedpersonnelofadiscloserif,andonlyif,the\nauthorised personnel discloses the relevant information —\n(i) in good faith and with reasonable care;\n(ii) in accordance with this Act; and\n(iii) in the ordinary course of the duties of the authorised\n10personnel.\n(2) No liability shall lie against the discloser or the authorised\npersonnelofadiscloserforanythingdoneinrelationtothedisclosure\nof the relevant information.\n(3) The disclosure of the relevant information by the discloser or\n15the authorised individual of a discloser is not a breach of —\n(a) any obligation of confidentiality; or\n(b) anyprohibitionorrestrictioninrespectofthedisclosureof\nthe relevant information,\nthat is imposed un",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 120,
@@ -99941,8 +100383,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p120_c266",
-      "text": "closer is not a breach of —\n(a) any obligation of confidentiality; or\n(b) any prohibition or restriction in respect of the disclosure of\nthe relevant information,\nthat is imposed under any written law, rule of law, contract or rule of\n20professional conduct or ethics.\n(4) The disclosure of the relevant information by the discloser or\nthe authorised individual of a discloser is not an act of infringement of\nany copyright in the relevant information that is held by any person.\n(5) In this section, “authorised personnel” of a discloser means a\n25personnel (as defined in section 45) of the discloser who is specified\nin a data sharing agreement in accordance with section 52(3)(d).\nLegal protections — recipients\n103.—(1) This section applies in relation to the collection or use of\nrelevant information, pursuant to a data sharing agreement —\n30(a) by a recipient if, and only if, the recipient c",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p120_c300",
+      "text": " of —\n(a) any obligation of confidentiality; or\n(b) anyprohibitionorrestrictioninrespectofthedisclosureof\nthe relevant information,\nthat is imposed under any written law, rule of law, contract or rule of\n20professional conduct or ethics.\n(4) The disclosure of the relevant information by the discloser or\ntheauthorisedindividualofadiscloserisnotanactofinfringementof\nany copyright in the relevant information that is held by any person.\n(5) In this section, “authorised personnel” of a discloser means a\n25personnel (as defined in section 45) of the discloser who is specified\nin a data sharing agreement in accordance with section 52(3)(d).\nLegal protections — recipients\n103.—(1) Thissectionappliesinrelationtothecollectionoruseof\nrelevant information, pursuant to a data sharing agreement —\n30(a) by a recipient if, and only if, the recipient collects or uses\nthe relevant information —\n119",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 120,
@@ -99954,21 +100396,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p120_c267",
-      "text": "elation to the collection or use of\nrelevant information, pursuant to a data sharing agreement —\n30(a) by a recipient if, and only if, the recipient collects or uses\nthe relevant information —\n119",
-      "metadata": {
-        "source": "health-information-act-2026.pdf",
-        "page": 120,
-        "category": "sg-hia",
-        "jurisdiction": "SG",
-        "document_id": "sg-hia",
-        "framework": "HIA",
-        "content_type": "primary"
-      }
-    },
-    {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p121_c268",
-      "text": "122 NO. 1 OF 2026\n(i) in good faith and with reasonable care; and\n(ii) in accordance with this Act; and\n(b) by an authorised personnel of a recipient if, and only if, the\nauthorised personnel collects or uses the relevant\n5 information —\n(i) in good faith and with reasonable care;\n(ii) in accordance with this Act; and\n(iii) in the ordinary course of the duties of the authorised\npersonnel.\n10 (2) No liability shall lie against the recipient or the authorised\npersonnel of a recipient for anything done in relation to the collection\nor use of the relevant information.\n(3) The collection or use of the relevant information by the recipient\nor the authorised individual of a recipient is not a breach of —\n15 (a) any obligation of confidentiality; or\n(b) any prohibition or restriction in respect of the collection or\nuse (as the case may be) of the relevant information,\nthat is imposed under any w",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p121_c301",
+      "text": "122 NO. 1 OF 2026\n(i) in good faith and with reasonable care; and\n(ii) in accordance with this Act; and\n(b) byanauthorisedpersonnelofarecipientif,andonlyif,the\nauthorised personnel collects or uses the relevant\n5 information —\n(i) in good faith and with reasonable care;\n(ii) in accordance with this Act; and\n(iii) in the ordinary course of the duties of the authorised\npersonnel.\n10 (2) No liability shall lie against the recipient or the authorised\npersonnelofarecipientforanythingdoneinrelationtothecollection\nor use of the relevant information.\n(3) Thecollectionoruseoftherelevantinformationbytherecipient\nor the authorised individual of a recipient is not a breach of —\n15 (a) any obligation of confidentiality; or\n(b) anyprohibitionorrestrictionin respectofthecollectionor\nuse (as the case may be) of the relevant information,\nthat is imposed under any written law, rule of law, contract or rul",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 121,
@@ -99980,8 +100409,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p121_c269",
-      "text": "r\n(b) any prohibition or restriction in respect of the collection or\nuse (as the case may be) of the relevant information,\nthat is imposed under any written law, rule of law, contract or rule of\nprofessional conduct or ethics.\n20 (4) The collection or use of the relevant information by the recipient\nor the authorised individual of a recipient is not an act of infringement\nof any copyright in the relevant information that is held by any\nperson.\n(5) In this section, “authorised personnel” of a recipient means a\n25 personnel (as defined in section 45) of the recipient who is specified\nin a data sharing agreement in accordance with section 52(3)(e).\nLegal protections — others\n104. No liability shall lie personally against any authorised officer\nor investigation officer who, acting in good faith and with reasonable\n30 care, does or omits to do anything in the execution or purported\nexecution ",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p121_c302",
+      "text": "nin respectofthecollectionor\nuse (as the case may be) of the relevant information,\nthat is imposed under any written law, rule of law, contract or rule of\nprofessional conduct or ethics.\n20 (4) Thecollectionoruseoftherelevantinformationbytherecipient\northeauthorisedindividualofarecipientisnotanactofinfringement\nof any copyright in the relevant information that is held by any\nperson.\n(5) In this section, “authorised personnel” of a recipient means a\n25 personnel (as defined in section 45) of the recipient who is specified\nin a data sharing agreement in accordance with section 52(3)(e).\nLegal protections — others\n104. No liability shall lie personally against any authorised officer\norinvestigationofficerwho,actingingoodfaithandwithreasonable\n30 care, does or omits to do anything in the execution or purported\nexecution of this Act.\n120",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 121,
@@ -99993,21 +100422,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p121_c270",
-      "text": "\nor investigation officer who, acting in good faith and with reasonable\n30 care, does or omits to do anything in the execution or purported\nexecution of this Act.\n120",
-      "metadata": {
-        "source": "health-information-act-2026.pdf",
-        "page": 121,
-        "category": "sg-hia",
-        "jurisdiction": "SG",
-        "document_id": "sg-hia",
-        "framework": "HIA",
-        "content_type": "primary"
-      }
-    },
-    {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p122_c271",
-      "text": "HEALTH INFORMATION 123\nOffences by corporations\n105.—(1) Where, in a proceeding for an offence under this Act, it is\nnecessary to prove the state of mind of a corporation in relation to a\nparticular conduct, evidence that —\n5(a) an officer, employee or agent of the corporation engaged in\nthat conduct within the scope of his or her actual or\napparent authority; and\n(b) the officer, employee or agent had that state of mind,\nis evidence that the corporation had that state of mind.\n10(2) Where a corporation commits an offence under this Act, a\nperson —\n(a) who is —\n(i) an officer of the corporation; or\n(ii) an individual involved in the management of the\n15corporation and in a position to influence the conduct\nof the corporation in relation to the commission of\nthe offence; and\n(b) who —\n(i) consented or connived, or conspired with others, to\n20effect the commission of the offence;\n(ii) is i",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p122_c303",
+      "text": "HEALTH INFORMATION 123\nOffences by corporations\n105.—(1) Where,inaproceedingforanoffenceunderthisAct,itis\nnecessary to prove the state of mind of a corporation in relation to a\nparticular conduct, evidence that —\n5(a) anofficer,employeeoragentofthecorporationengagedin\nthat conduct within the scope of his or her actual or\napparent authority; and\n(b) the officer, employee or agent had that state of mind,\nis evidence that the corporation had that state of mind.\n10(2) Where a corporation commits an offence under this Act, a\nperson —\n(a) who is —\n(i) an officer of the corporation; or\n(ii) an individual involved in the management of the\n15corporationandinapositiontoinfluencetheconduct\nof the corporation in relation to the commission of\nthe offence; and\n(b) who —\n(i) consented or connived, or conspired with others, to\n20effect the commission of the offence;\n(ii) is in any other way, whether by ",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 122,
@@ -100019,8 +100435,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p122_c272",
-      "text": "the commission of\nthe offence; and\n(b) who —\n(i) consented or connived, or conspired with others, to\n20effect the commission of the offence;\n(ii) is in any other way, whether by act or omission,\nknowingly concerned in, or is party to, the\ncommission of the offence by the corporation; or\n(iii) knew or ought reasonably to have known that the\n25offence by the corporation (or an offence of the same\ntype) would be or is being committed, and failed to\ntake all reasonable steps to prevent or stop the\ncommission of that offence,\nshall be guilty of that same offence as is the corporation, and shall be\n30liable on conviction to be punished accordingly.\n(3) A person mentioned in subsection (2) may rely on a defence that\nwould be available to the corporation if it were charged with the\n121",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p122_c304",
+      "text": "e; and\n(b) who —\n(i) consented or connived, or conspired with others, to\n20effect the commission of the offence;\n(ii) is in any other way, whether by act or omission,\nknowingly concerned in, or is party to, the\ncommission of the offence by the corporation; or\n(iii) knew or ought reasonably to have known that the\n25offencebythecorporation(oranoffenceofthesame\ntype) would be or is being committed, and failed to\ntake all reasonable steps to prevent or stop the\ncommission of that offence,\nshallbe guiltyof thatsameoffenceas isthecorporation, andshall be\n30liable on conviction to be punished accordingly.\n(3) Apersonmentionedinsubsection(2)mayrelyonadefencethat\nwould be available to the corporation if it were charged with the\n121",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 122,
@@ -100032,8 +100448,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p123_c273",
-      "text": "124 NO. 1 OF 2026\noffence with which the person is charged and, in doing so, the person\nbears the same burden of proof that the corporation would bear.\n(4) To avoid doubt, this section does not affect the application of —\n(a) Chapters 5 and 5A of the Penal Code 1871; or\n5 (b) the Evidence Act 1893 or any other law or practice\nregarding the admissibility of evidence.\n(5) To avoid doubt, subsection (2) also does not affect the liability\nof the corporation for an offence under this Act, and applies whether\nor not the corporation is convicted of the offence.\n10 (6) In this section —\n“corporation” includes a limited liability partnership within the\nmeaning given by section 2(1) of the Limited Liability\nPartnerships Act 2005;\n“officer”, in relation to a corporation, means any director,\n15 partner, chief executive, manager, secretary or other similar\nofficer of the corporation, and includes —\n(",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p123_c305",
+      "text": "124 NO. 1 OF 2026\noffencewithwhichthepersonischargedand,indoingso,theperson\nbears the same burden of proof that the corporation would bear.\n(4) Toavoiddoubt,thissectiondoesnotaffecttheapplicationof—\n(a) Chapters 5 and 5A of the Penal Code 1871; or\n5 (b) the Evidence Act 1893 or any other law or practice\nregarding the admissibility of evidence.\n(5) To avoid doubt, subsection (2) also does not affect the liability\nof the corporation for an offence under this Act, and applies whether\nor not the corporation is convicted of the offence.\n10 (6) In this section —\n“corporation” includes a limited liability partnership within the\nmeaning given by section 2(1) of the Limited Liability\nPartnerships Act 2005;\n“officer”, in relation to a corporation, means any director,\n15 partner, chief executive, manager, secretary or other similar\nofficer of the corporation, and includes —\n(a) anypersonpurportingt",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 123,
@@ -100045,8 +100461,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p123_c274",
-      "text": "on to a corporation, means any director,\n15 partner, chief executive, manager, secretary or other similar\nofficer of the corporation, and includes —\n(a) any person purporting to act in any such capacity; and\n(b) for a corporation whose affairs are managed by its\nmembers, any of those members as if the member\n20 were a director of the corporation;\n“state of mind” of a person includes —\n(a) the knowledge, intention, opinion, belief or purpose\nof the person; and\n(b) the person’s reasons for the intention, opinion, belief\n25 or purpose.\nOffences by unincorporated associations or partnerships\n106.—(1) Where, in a proceeding for an offence under this Act, it is\nnecessary to prove the state of mind of an unincorporated association\nor a partnership in relation to a particular conduct, evidence that —\n30 (a) an employee or agent of the unincorporated association or\npartnership engaged in that con",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p123_c306",
+      "text": "ans any director,\n15 partner, chief executive, manager, secretary or other similar\nofficer of the corporation, and includes —\n(a) anypersonpurportingtoactinanysuchcapacity;and\n(b) for a corporation whose affairs are managed by its\nmembers, any of those members as if the member\n20 were a director of the corporation;\n“state of mind” of a person includes —\n(a) the knowledge, intention, opinion, belief or purpose\nof the person; and\n(b) the person’s reasons for the intention, opinion, belief\n25 or purpose.\nOffences by unincorporated associations or partnerships\n106.—(1) Where,inaproceedingforanoffenceunderthisAct,itis\nnecessarytoprovethestateofmindofanunincorporatedassociation\nor a partnership in relation to a particular conduct, evidence that —\n30 (a) an employee or agent of the unincorporated association or\npartnershipengagedinthatconductwithinthescopeofhis\nor her actual or apparent authori",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 123,
@@ -100058,8 +100474,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p123_c275",
-      "text": " in relation to a particular conduct, evidence that —\n30 (a) an employee or agent of the unincorporated association or\npartnership engaged in that conduct within the scope of his\nor her actual or apparent authority; and\n122",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p123_c307",
+      "text": "\n30 (a) an employee or agent of the unincorporated association or\npartnershipengagedinthatconductwithinthescopeofhis\nor her actual or apparent authority; and\n122",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 123,
@@ -100071,7 +100487,7 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p124_c276",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p124_c308",
       "text": "HEALTH INFORMATION 125\n(b) the employee or agent had that state of mind,\nis evidence that the unincorporated association or partnership (as the\ncase may be) had that state of mind.\n(2) Where an unincorporated association or a partnership commits\n5an offence under this Act, a person —\n(a) who is —\n(i) an officer of the unincorporated association or a\nmember of its governing body;\n(ii) a partner in the partnership; or\n10(iii) an individual involved in the management of the\nunincorporated association or partnership and in a\nposition to influence the conduct of the\nunincorporated association or partnership (as the\ncase may be) in relation to the commission of the\n15offence; and\n(b) who —\n(i) consented or connived, or conspired with others, to\neffect the commission of the offence;\n(ii) is in any other way, whether by act or omission,\n20knowingly concerned in, or is party to, the\ncommission of",
       "metadata": {
         "source": "health-information-act-2026.pdf",
@@ -100084,8 +100500,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p124_c277",
-      "text": "ffect the commission of the offence;\n(ii) is in any other way, whether by act or omission,\n20knowingly concerned in, or is party to, the\ncommission of the offence by the unincorporated\nassociation or partnership; or\n(iii) knew or ought reasonably to have known that the\noffence by the unincorporated association or\n25partnership (or an offence of the same type) would\nbe or is being committed, and failed to take all\nreasonable steps to prevent or stop the commission of\nthat offence,\nshall be guilty of the same offence as is the unincorporated\n30association or partnership (as the case may be), and shall be liable\non conviction to be punished accordingly.\n(3) A person mentioned in subsection (2) may rely on a defence that\nwould be available to the unincorporated association or partnership if\n123",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p124_c309",
+      "text": "ffect the commission of the offence;\n(ii) is in any other way, whether by act or omission,\n20knowingly concerned in, or is party to, the\ncommission of the offence by the unincorporated\nassociation or partnership; or\n(iii) knew or ought reasonably to have known that the\noffence by the unincorporated association or\n25partnership (or an offence of the same type) would\nbe or is being committed, and failed to take all\nreasonablestepstopreventorstopthecommissionof\nthat offence,\nshall be guilty of the same offence as is the unincorporated\n30association or partnership (as the case may be), and shall be liable\non conviction to be punished accordingly.\n(3) Apersonmentionedinsubsection(2)mayrelyonadefencethat\nwouldbeavailabletotheunincorporatedassociationorpartnershipif\n123",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 124,
@@ -100097,8 +100513,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p125_c278",
-      "text": "126 NO. 1 OF 2026\nit were charged with the offence with which the person is charged\nand, in doing so, the person bears the same burden of proof that the\nunincorporated association or partnership would bear.\n(4) To avoid doubt, this section does not affect the application of —\n5 (a) Chapters 5 and 5A of the Penal Code 1871; or\n(b) the Evidence Act 1893 or any other law or practice\nregarding the admissibility of evidence.\n(5) To avoid doubt, subsection (2) also does not affect the liability\nof an unincorporated association or a partnership for an offence under\n10 this Act, and applies whether or not the unincorporated association or\npartnership is convicted of the offence.\n(6) In this section —\n“officer”, in relation to an unincorporated association (other than\na partnership), means the president, the secretary or any\n15 member of the committee of the unincorporated association,\nand includ",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p125_c310",
+      "text": "126 NO. 1 OF 2026\nit were charged with the offence with which the person is charged\nand, in doing so, the person bears the same burden of proof that the\nunincorporated association or partnership would bear.\n(4) Toavoiddoubt,thissectiondoesnotaffecttheapplicationof—\n5 (a) Chapters 5 and 5A of the Penal Code 1871; or\n(b) the Evidence Act 1893 or any other law or practice\nregarding the admissibility of evidence.\n(5) To avoid doubt, subsection (2) also does not affect the liability\nofanunincorporatedassociationorapartnershipforanoffenceunder\n10 thisAct,andapplieswhetherornottheunincorporatedassociationor\npartnership is convicted of the offence.\n(6) In this section —\n“officer”,inrelationtoanunincorporatedassociation(otherthan\na partnership), means the president, the secretary or any\n15 member of the committee of the unincorporated association,\nand includes —\n(a) any person holding a position ",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 125,
@@ -100110,8 +100526,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p125_c279",
-      "text": "ciation (other than\na partnership), means the president, the secretary or any\n15 member of the committee of the unincorporated association,\nand includes —\n(a) any person holding a position analogous to that of\npresident, secretary or member of a committee of the\nunincorporated association; and\n20 (b) any person purporting to act in any such capacity;\n“partner” includes a person purporting to act as a partner;\n“state of mind” of a person includes —\n(a) the knowledge, intention, opinion, belief or purpose\nof the person; and\n25 (b) the person’s reasons for the intention, opinion, belief\nor purpose.\nService of documents\n107.—(1) A document that is permitted or required by or under this\nAct to be served on a person may be served as described in this\n30 section.\n(2) A document permitted or required by or under this Act to be\nserved on an individual may be served —\n124",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p125_c311",
+      "text": "ns the president, the secretary or any\n15 member of the committee of the unincorporated association,\nand includes —\n(a) any person holding a position analogous to that of\npresident, secretary or member of a committee of the\nunincorporated association; and\n20 (b) any person purporting to act in any such capacity;\n“partner” includes a person purporting to act as a partner;\n“state of mind” of a person includes —\n(a) the knowledge, intention, opinion, belief or purpose\nof the person; and\n25 (b) the person’s reasons for the intention, opinion, belief\nor purpose.\nService of documents\n107.—(1) Adocumentthatispermittedorrequiredbyorunderthis\nAct to be served on a person may be served as described in this\n30 section.\n(2) A document permitted or required by or under this Act to be\nserved on an individual may be served —\n124",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 125,
@@ -100123,7 +100539,7 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p126_c280",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p126_c312",
       "text": "HEALTH INFORMATION 127\n(a) by giving it to the individual personally;\n(b) by sending it by prepaid registered post to the address\nspecified by the individual for the service of documents\ngenerally, or specifically for the document, or (if no\n5address is so specified) the individual’s residential address\nor business address;\n(c) by leaving it at the individual’s residential address with an\nadult apparently resident there, or at the individual’s\nbusiness address with an adult apparently employed there;\n10(d) by affixing a copy of the document in a conspicuous place\nat the individual’s residential address or business address;\n(e) by sending it by fax to the fax number last known to the\nperson giving or serving the document as the fax number\nfor the service of documents on the individual; or\n15(f) by sending it by email to the individual’s last email\naddress.\n(3) A document permitted or requ",
       "metadata": {
         "source": "health-information-act-2026.pdf",
@@ -100136,7 +100552,7 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p126_c281",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p126_c313",
       "text": "r the service of documents on the individual; or\n15(f) by sending it by email to the individual’s last email\naddress.\n(3) A document permitted or required by or under this Act to be\nserved on a partnership (other than a limited liability partnership)\nmay be served —\n20(a) by giving it to any partner or other similar officer, or an\nauthorised representative, of the partnership;\n(b) by leaving it at, or by sending it by prepaid registered post\nto, the partnership’s business address;\n(c) by sending it by fax to the fax number used at the\n25partnership’s business address; or\n(d) by sending it by email to the partnership’s last email\naddress.\n(4) A document permitted or required by or under this Act to be\nserved on a body corporate (including a limited liability partnership)\n30or an unincorporated association may be served —\n(a) by giving it to the secretary or other similar officer of the\nbo",
       "metadata": {
         "source": "health-information-act-2026.pdf",
@@ -100149,7 +100565,7 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p126_c282",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p126_c314",
       "text": "limited liability partnership)\n30or an unincorporated association may be served —\n(a) by giving it to the secretary or other similar officer of the\nbody corporate or unincorporated association, or the\nlimited liability partnership’s manager;\n125",
       "metadata": {
         "source": "health-information-act-2026.pdf",
@@ -100162,8 +100578,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p127_c283",
-      "text": "128 NO. 1 OF 2026\n(b) by leaving it at, or by sending it by prepaid registered post\nto, the registered office or principal office in Singapore of\nthe body corporate or unincorporated association;\n(c) by sending it by fax to the fax number used at the registered\n5 office or principal office in Singapore of the body\ncorporate or unincorporated association; or\n(d) by sending it by email to the last email address of the body\ncorporate or unincorporated association.\n(5) Service of a document under this section takes effect —\n10 (a) if the document is sent by prepaid registered post, 2 days\nafter the day the document was posted (even if it is returned\nundelivered);\n(b) if the document is sent by fax and a notification of\nsuccessful transmission is received, on the day of\n15 transmission; or\n(c) if the document is sent by email, at the time that the email\nbecomes capable of being retrieved by t",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p127_c315",
+      "text": "128 NO. 1 OF 2026\n(b) by leaving it at, or by sending it by prepaid registered post\nto, the registered office or principal office in Singapore of\nthe body corporate or unincorporated association;\n(c) bysendingitbyfaxtothefaxnumberusedattheregistered\n5 office or principal office in Singapore of the body\ncorporate or unincorporated association; or\n(d) bysendingitbyemailtothelastemailaddressofthebody\ncorporate or unincorporated association.\n(5) Service of a document under this section takes effect —\n10 (a) if the document is sent by prepaid registered post, 2 days\nafterthedaythedocumentwasposted(evenifitisreturned\nundelivered);\n(b) if the document is sent by fax and a notification of\nsuccessful transmission is received, on the day of\n15 transmission; or\n(c) if the document is sent by email, at the time that the email\nbecomescapableofbeingretrievedbythepersontowhom\nit is sent.\n(6) However,se",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 127,
@@ -100175,8 +100591,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p127_c284",
-      "text": "s received, on the day of\n15 transmission; or\n(c) if the document is sent by email, at the time that the email\nbecomes capable of being retrieved by the person to whom\nit is sent.\n(6) However, service of any document under this Act on a person by\n20 email may be effected only with the person’s prior written consent to\nservice in that way.\n(7) This section does not apply to documents to be served in\nproceedings in court.\n(8) In this section —\n25 “authorised representative”, in relation to a partnership (other\nthan a limited liability partnership), means any person\nauthorised to accept service of documents on behalf of the\npartnership;\n“business address” means —\n30 (a) in the case of an individual, the individual’s usual or\nlast known place of business in Singapore; or\n126",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p127_c316",
+      "text": "ission; or\n(c) if the document is sent by email, at the time that the email\nbecomescapableofbeingretrievedbythepersontowhom\nit is sent.\n(6) However,serviceofanydocumentunderthisActonapersonby\n20 email may be effected only with the person’s prior written consent to\nservice in that way.\n(7) This section does not apply to documents to be served in\nproceedings in court.\n(8) In this section —\n25 “authorised representative”, in relation to a partnership (other\nthan a limited liability partnership), means any person\nauthorised to accept service of documents on behalf of the\npartnership;\n“business address” means —\n30 (a) in the case of an individual, the individual’s usual or\nlast known place of business in Singapore; or\n126",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 127,
@@ -100188,8 +100604,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p128_c285",
-      "text": "HEALTH INFORMATION 129\n(b) in the case of a partnership (other than a limited\nliability partnership), the partnership’s principal or\nlast known place of business in Singapore;\n“document” includes an order or a notice permitted or required\n5by or under this Act to be served;\n“last email address” means the last email address given by the\naddressee concerned to the person giving or serving the\ndocument as the email address for the service of documents\nunder this Act;\n10“residential address” means an individual’s usual or last known\nplace of residence in Singapore.\nJurisdiction of court\n108. Despite the Criminal Procedure Code 2010, a District Court\nhas jurisdiction to try any offence under this Act and has power to\n15impose the full punishment for the offence.\nComposition of offences\n109.—(1) The Minister may compound any offence under this Act\n(except an offence mentioned in subsection (2)",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p128_c317",
+      "text": "HEALTH INFORMATION 129\n(b) in the case of a partnership (other than a limited\nliability partnership), the partnership’s principal or\nlast known place of business in Singapore;\n“document” includes an order or a notice permitted or required\n5by or under this Act to be served;\n“last email address” means the last email address given by the\naddressee concerned to the person giving or serving the\ndocument as the email address for the service of documents\nunder this Act;\n10“residential address” means an individual’s usual or last known\nplace of residence in Singapore.\nJurisdiction of court\n108. Despite the Criminal Procedure Code 2010, a District Court\nhas jurisdiction to try any offence under this Act and has power to\n15impose the full punishment for the offence.\nComposition of offences\n109.—(1) The Minister may compound any offence under this Act\n(exceptanoffencementionedinsubsection(2))thati",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 128,
@@ -100201,8 +100617,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p128_c286",
-      "text": " for the offence.\nComposition of offences\n109.—(1) The Minister may compound any offence under this Act\n(except an offence mentioned in subsection (2)) that is prescribed as a\ncompoundable offence by collecting from a person reasonably\n20suspected of having committed the offence a sum not exceeding\nthe lower of the following:\n(a) one half of the amount of the maximum fine that is\nprescribed for the offence;\n(b) $10,000.\n25(2) The Minister may compound any offence under Part 4 or 5\n(other than an offence under section 70, 71 or 82(2)) that is prescribed\nas a compoundable offence by collecting from a person (X)\nreasonably suspected of having committed the offence —\n(a) where X is an individual, a sum not exceeding the lower of\n30the following:\n127",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p128_c318",
+      "text": " for the offence.\nComposition of offences\n109.—(1) The Minister may compound any offence under this Act\n(exceptanoffencementionedinsubsection(2))thatisprescribedasa\ncompoundable offence by collecting from a person reasonably\n20suspected of having committed the offence a sum not exceeding\nthe lower of the following:\n(a) one half of the amount of the maximum fine that is\nprescribed for the offence;\n(b) $10,000.\n25(2) The Minister may compound any offence under Part 4 or 5\n(otherthananoffenceundersection70,71or82(2))thatisprescribed\nas a compoundable offence by collecting from a person (X)\nreasonably suspected of having committed the offence —\n(a) whereXisanindividual,asumnotexceedingthelowerof\n30the following:\n127",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 128,
@@ -100214,8 +100630,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p129_c287",
-      "text": "130 NO. 1 OF 2026\n(i) one half of the amount of the maximum fine\nprescribed for the offence that may be imposed on\nan individual who is convicted of that offence;\n(ii) $20,000; or\n5 (b) in any other case, a sum not exceeding the lower of the\nfollowing:\n(i) one half of the amount of the maximum fine\nprescribed for the offence that may be imposed on\na person (other than an individual) who is convicted\n10 of that offence;\n(ii) $200,000.\n(3) On payment of the sum of money, no further proceedings are to\nbe taken against that person in respect of the offence.\n(4) All sums collected under this section must be paid into the\n15 Consolidated Fund.\nExemption\n110. The Minister may, by order in the Gazette, exempt any person\nor class of persons, or any health information or type of health\ninformation, from all or any of the provisions of this Act, either\n20 generally or in a particular case and subje",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p129_c319",
+      "text": "130 NO. 1 OF 2026\n(i) one half of the amount of the maximum fine\nprescribed for the offence that may be imposed on\nan individual who is convicted of that offence;\n(ii) $20,000; or\n5 (b) in any other case, a sum not exceeding the lower of the\nfollowing:\n(i) one half of the amount of the maximum fine\nprescribed for the offence that may be imposed on\na person (other than an individual) who is convicted\n10 of that offence;\n(ii) $200,000.\n(3) On paymentof the sum of money, no furtherproceedings are to\nbe taken against that person in respect of the offence.\n(4) All sums collected under this section must be paid into the\n15 Consolidated Fund.\nExemption\n110. The Minister may, by order in theGazette, exempt any person\nor class of persons, or any health information or type of health\ninformation, from all or any of the provisions of this Act, either\n20 generallyorinaparticularcaseandsubjecttoanycon",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 129,
@@ -100227,8 +100643,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p129_c288",
-      "text": "health information or type of health\ninformation, from all or any of the provisions of this Act, either\n20 generally or in a particular case and subject to any conditions that the\nMinister may impose.\nAmendment of Schedules\n111.—(1) The Minister may, by order in the Gazette, amend, add to\nor vary the Schedules.\n25 (2) The Minister may, in an order under subsection (1), make\nprovisions of a saving or transitional nature consequent on the\nenactment of the order that the Minister may consider necessary or\nexpedient.\nRegulations\n30 112.—(1) The Minister may make regulations necessary or\nconvenient to be prescribed for carrying out or giving effect to this\nAct.\n128",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p129_c320",
+      "text": "lth information or type of health\ninformation, from all or any of the provisions of this Act, either\n20 generallyorinaparticularcaseandsubjecttoanyconditionsthatthe\nMinister may impose.\nAmendment of Schedules\n111.—(1) TheMinistermay,byorderinthe Gazette,amend,addto\nor vary the Schedules.\n25 (2) The Minister may, in an order under subsection (1), make\nprovisions of a saving or transitional nature consequent on the\nenactment of the order that the Minister may consider necessary or\nexpedient.\nRegulations\n30 112.—(1) The Minister may make regulations necessary or\nconvenient to be prescribed for carrying out or giving effect to this\nAct.\n128",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 129,
@@ -100240,8 +100656,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p130_c289",
-      "text": "HEALTH INFORMATION 131\n(2) Without limiting subsection (1), the Minister may make\nregulations for any of the following:\n(a) the form and manner in which an application to be\napproved as an approved contributor or approved user may\nbe made;\n(b) the form and manner in which health information about\nany individual is to be contributed, including any other\ninformation that is to be provided to a System Operator\ntogether with that health information;\n(c) the requirements and standards applicable to health\ninformation about any individual that is contributed in\naccordance with this Act;\n(d) the form and manner in which an application in respect of\nan authorised individual of a user may be made to a System\nOperator;\n(e) the form and manner in which an application to obtain\nderived information may be made;\n(f) any matter that is required or permitted to be prescribed\nunder this Act.\n(3) The regu",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p130_c321",
+      "text": "HEALTH INFORMATION 131\n(2) Without limiting subsection (1), the Minister may make\nregulations for any of the following:\n(a) the form and manner in which an application to be\napprovedasanapprovedcontributororapprovedusermay\nbe made;\n(b) the form and manner in which health information about\nany individual is to be contributed, including any other\ninformation that is to be provided to a System Operator\ntogether with that health information;\n(c) the requirements and standards applicable to health\ninformation about any individual that is contributed in\naccordance with this Act;\n(d) the form and manner in which an application in respect of\nanauthorisedindividualofausermaybemadetoaSystem\nOperator;\n(e) the form and manner in which an application to obtain\nderived information may be made;\n(f) any matter that is required or permitted to be prescribed\nunder this Act.\n(3) The regulations made under ",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 130,
@@ -100253,8 +100669,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p130_c290",
-      "text": "h an application to obtain\nderived information may be made;\n(f) any matter that is required or permitted to be prescribed\nunder this Act.\n(3) The regulations made under this section may provide that any\ncontravention of any provision of the regulations shall be an offence \npunishable with a fine not exceeding $50,000 or with imprisonment \nfor a term not exceeding 12 months or with both and, in the case of a \ncontinuing offence, with a further fine not exceeding $1,000 for every \nday or part of a day during which the offence continues after \nconviction.\nRelated amendment to Human Organ Transplant Act 1987\n113. In the Human Organ Transplant Act 1987, in section 28(2), \nafter paragraph (b), insert —\n“(ba) as required or permitted under the Health Information \nAct 2026;”.\n129",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p130_c322",
+      "text": " obtain\nderived information may be made;\n(f) any matter that is required or permitted to be prescribed\nunder this Act.\n(3) The regulations made under this section may provide that any\ncontravention of any provision of the regulations shall be an offence \npunishable with a fine not exceeding $50,000 or with imprisonment \nfor a term not exceeding 12 months or with both and, in the case of a \ncontinuing offence, with a further fine not exceeding $1,000 for every \nday or part of a day during which the offence continues after \nconviction.\nRelated amendment to Human Organ Transplant Act 1987\n113. In the Human Organ Transplant Act 1987, in section 28(2), \nafter paragraph (b), insert —\n“(ba) as required or permitted under the Health Information \nAct 2026;”.\n129",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 130,
@@ -100266,8 +100682,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p131_c291",
-      "text": "132 NO. 1 OF 2026\nSaving and transitional provision\n114. For a period of 2 years after the date of commencement of any\nprovision of this Act, the Minister may, by regulations, prescribe any\nadditional provisions of a saving or transitional nature consequent on\n the enactment of that provision that the Minister may consider\nnecessary or expedient.\nFIRST SCHEDULE\nSection 12\nCONTRIBUTION OF HEALTH INFORMA TION BY\nSPECIFIED CONTRIBUTORS\nPART 1\nSPECIFIED CONTRIBUTORS AND TYPES OF\nHEALTH INFORMA TION TO BE CONTRIBUTED\nFirst column . Second column\nSpecified contributor or\nclass of specified contributors\nTypes of health information\n1. An HCSA licensee licensed to\nprovide an acute hospital\nservice\n. (a) Visit event\n(b) Adverse drug event history\n(c) Ordered (prescribed)\nmedications\n(d) Dispensed medications\n(e) Medication list\n(f) V accines administered\n(g) Cardiac report\n(h) Surgical procedure n",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p131_c323",
+      "text": "132 NO. 1 OF 2026\nSaving and transitional provision\n114. Foraperiodof2yearsafterthedateofcommencementofany\nprovision of this Act, the Minister may, by regulations, prescribe any\nadditional provisions of a saving or transitional nature consequent on\n the enactment of that provision that the Minister may consider\nnecessary or expedient.\nFIRST SCHEDULE\nSection 12\nCONTRIBUTION OF HEALTH INFORMATION BY\nSPECIFIED CONTRIBUTORS\nPART 1\nSPECIFIED CONTRIBUTORS AND TYPES OF\nHEALTH INFORMATION TO BE CONTRIBUTED\nFirst column . Second column\nSpecified contributor or\nclass of specified contributors\nTypes of health information\n1. An HCSA licensee licensed to\nprovide an acute hospital\nservice\n. (a) Visit event\n(b) Adverse drug event history\n(c) Ordered (prescribed)\nmedications\n(d) Dispensed medications\n(e) Medication list\n(f) Vaccines administered\n(g) Cardiac report\n(h) Surgical procedure notes\n(i) Dental",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 131,
@@ -100279,8 +100695,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p131_c292",
-      "text": " Ordered (prescribed)\nmedications\n(d) Dispensed medications\n(e) Medication list\n(f) V accines administered\n(g) Cardiac report\n(h) Surgical procedure notes\n(i) Dental notes\n(j) Visit diagnoses/reasons for visit\nor patient problem list\n(k) Discharge summary\n(l) Emergency Department/Urgent\nCare summary\n(m) Referral memorandum\n130",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p131_c324",
+      "text": "cribed)\nmedications\n(d) Dispensed medications\n(e) Medication list\n(f) Vaccines administered\n(g) Cardiac report\n(h) Surgical procedure notes\n(i) Dental notes\n(j) Visit diagnoses/reasons for visit\nor patient problem list\n(k) Discharge summary\n(l) Emergency Department/Urgent\nCare summary\n(m) Referral memorandum\n130",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 131,
@@ -100292,8 +100708,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p132_c293",
-      "text": "HEALTH INFORMATION 133\nFIRST SCHEDULE — continued\nFirst column . Second column\nSpecified contributor or\nclass of specified contributors\nTypes of health information\n52. An HCSA licensee licensed to\nprovide an ambulatory surgical\ncentre service\n(a) Visit event\n(b) Adverse drug event history\n(c) Ordered (prescribed)\n10\nmedications\n(d) Dispensed medications\n(e) Medication list\n(f) V accines administered\n(g) Cardiac report\n15\n(h) Surgical procedure notes\n(i) Dental notes\n(j) Visit diagnoses/reasons for visit\nor patient problem list\n(k) Discharge summary\n20\n(l) Referral memorandum\n3. An HCSA licensee licensed to\nprovide an assisted\nreproduction service\n(a) Visit event\n(b) Adverse drug event history\n25\n(c) Ordered (prescribed)\nmedications\n(d) Dispensed medications\n(e) Medication list\n(f) Cardiac report\n30\n(g) Surgical procedure notes\n(h) Visit diagnoses/reasons for visit\nor patient problem list",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p132_c325",
+      "text": "HEALTH INFORMATION 133\nFIRST SCHEDULE —continued\nFirst column . Second column\nSpecified contributor or\nclass of specified contributors\nTypes of health information\n52. An HCSA licensee licensed to\nprovide an ambulatory surgical\ncentre service\n(a) Visit event\n(b) Adverse drug event history\n(c) Ordered (prescribed)\n10\nmedications\n(d) Dispensed medications\n(e) Medication list\n(f) Vaccines administered\n(g) Cardiac report\n15\n(h) Surgical procedure notes\n(i) Dental notes\n(j) Visit diagnoses/reasons for visit\nor patient problem list\n(k) Discharge summary\n20\n(l) Referral memorandum\n3. An HCSA licensee licensed to\nprovide an assisted\nreproduction service\n(a) Visit event\n(b) Adverse drug event history\n25\n(c) Ordered (prescribed)\nmedications\n(d) Dispensed medications\n(e) Medication list\n(f) Cardiac report\n30\n(g) Surgical procedure notes\n(h) Visit diagnoses/reasons for visit\nor patient problem list\n(",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 132,
@@ -100305,8 +100721,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p132_c294",
-      "text": "ensed medications\n(e) Medication list\n(f) Cardiac report\n30\n(g) Surgical procedure notes\n(h) Visit diagnoses/reasons for visit\nor patient problem list\n(i) Discharge summary\n(j) Referral memorandum\n131",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p132_c326",
+      "text": "sed medications\n(e) Medication list\n(f) Cardiac report\n30\n(g) Surgical procedure notes\n(h) Visit diagnoses/reasons for visit\nor patient problem list\n(i) Discharge summary\n(j) Referral memorandum\n131",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 132,
@@ -100318,8 +100734,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p133_c295",
-      "text": "134 NO. 1 OF 2026\nFIRST SCHEDULE — continued\nFirst column . Second column\nSpecified contributor or\nclass of specified contributors\nTypes of health information\n5 4. An HCSA licensee licensed to\nprovide a clinical laboratory\nservice\n(a) Laboratory test reports\n5. An HCSA licensee licensed to\nprovide a community hospital\n10 service\n(a) Visit event\n(b) Adverse drug event history\n(c) Ordered (prescribed)\nmedications\n(d) Dispensed medications\n15\n(e) Medication list\n(f) V accines administered\n(g) Cardiac report\n(h) Surgical procedure notes\n(i) Visit diagnoses/reasons for visit\n20\nor patient problem list\n(j) Discharge summary\n(k) Referral memorandum\n6. An HCSA licensee licensed to\nprovide a contingency care\n25\nservice\n(a) Visit event\n(b) Adverse drug event history\n(c) Ordered (prescribed)\nmedications\n(d) Dispensed medications\n30\n(e) Medication list\n(f) V accines administered\n(g) Cardiac report\n(",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p133_c327",
+      "text": "134 NO. 1 OF 2026\nFIRST SCHEDULE —continued\nFirst column . Second column\nSpecified contributor or\nclass of specified contributors\nTypes of health information\n5 4. An HCSA licensee licensed to\nprovide a clinical laboratory\nservice\n(a) Laboratory test reports\n5. An HCSA licensee licensed to\nprovide a community hospital\n10 service\n(a) Visit event\n(b) Adverse drug event history\n(c) Ordered (prescribed)\nmedications\n(d) Dispensed medications\n15\n(e) Medication list\n(f) Vaccines administered\n(g) Cardiac report\n(h) Surgical procedure notes\n(i) Visit diagnoses/reasons for visit\n20\nor patient problem list\n(j) Discharge summary\n(k) Referral memorandum\n6. An HCSA licensee licensed to\nprovide a contingency care\n25\nservice\n(a) Visit event\n(b) Adverse drug event history\n(c) Ordered (prescribed)\nmedications\n(d) Dispensed medications\n30\n(e) Medication list\n(f) Vaccines administered\n(g) Cardiac report\n(h) ",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 133,
@@ -100331,8 +100747,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p133_c296",
-      "text": "ug event history\n(c) Ordered (prescribed)\nmedications\n(d) Dispensed medications\n30\n(e) Medication list\n(f) V accines administered\n(g) Cardiac report\n(h) Surgical procedure notes\n(i) Visit diagnoses/reasons for visit\nor patient problem list\n(j) Discharge summary\n132",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p133_c328",
+      "text": " event history\n(c) Ordered (prescribed)\nmedications\n(d) Dispensed medications\n30\n(e) Medication list\n(f) Vaccines administered\n(g) Cardiac report\n(h) Surgical procedure notes\n(i) Visit diagnoses/reasons for visit\nor patient problem list\n(j) Discharge summary\n132",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 133,
@@ -100344,8 +100760,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p134_c297",
-      "text": "HEALTH INFORMATION 135\nFIRST SCHEDULE — continued\nFirst column . Second column\nSpecified contributor or\nclass of specified contributors\nTypes of health information\n5(k) Referral memorandum\n7. An HCSA licensee licensed to\nprovide a nuclear medicine\nservice\n(a) Adverse drug event history\n(b) Ordered (prescribed)\n10\nmedications\n(c) Dispensed medications\n(d) Laboratory test reports\n(e) Radiology/imaging reports\n(f) Cardiac report\n15\n(g) Surgical procedure notes\n8. An HCSA licensee licensed to\nprovide a nursing home service\n(a) Visit event\n(b) Adverse drug event history\n(c) Ordered (prescribed)\n20\nmedications\n(d) Dispensed medications\n(e) Medication list\n(f) V accines administered\n(g) Cardiac report\n25\n(h) Surgical procedure notes\n(i) Visit diagnoses/reasons for visit\nor patient problem list\n(j) Discharge summary\n(k) Referral memorandum\n30\n9. An HCSA licensee licensed to\nprovide an outpatient",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p134_c329",
+      "text": "HEALTH INFORMATION 135\nFIRST SCHEDULE —continued\nFirst column . Second column\nSpecified contributor or\nclass of specified contributors\nTypes of health information\n5(k) Referral memorandum\n7. An HCSA licensee licensed to\nprovide a nuclear medicine\nservice\n(a) Adverse drug event history\n(b) Ordered (prescribed)\n10\nmedications\n(c) Dispensed medications\n(d) Laboratory test reports\n(e) Radiology/imaging reports\n(f) Cardiac report\n15\n(g) Surgical procedure notes\n8. An HCSA licensee licensed to\nprovide a nursing home service\n(a) Visit event\n(b) Adverse drug event history\n(c) Ordered (prescribed)\n20\nmedications\n(d) Dispensed medications\n(e) Medication list\n(f) Vaccines administered\n(g) Cardiac report\n25\n(h) Surgical procedure notes\n(i) Visit diagnoses/reasons for visit\nor patient problem list\n(j) Discharge summary\n(k) Referral memorandum\n30\n9. An HCSA licensee licensed to\nprovide an outpatient d",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 134,
@@ -100357,8 +100773,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p134_c298",
-      "text": "noses/reasons for visit\nor patient problem list\n(j) Discharge summary\n(k) Referral memorandum\n30\n9. An HCSA licensee licensed to\nprovide an outpatient dental\nservice\n(a) Visit event\n(b) Adverse drug event history\n(c) Ordered (prescribed)\nmedications\n(d) Dispensed medications\n133",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p134_c330",
+      "text": "ses/reasons for visit\nor patient problem list\n(j) Discharge summary\n(k) Referral memorandum\n30\n9. An HCSA licensee licensed to\nprovide an outpatient dental\nservice\n(a) Visit event\n(b) Adverse drug event history\n(c) Ordered (prescribed)\nmedications\n(d) Dispensed medications\n133",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 134,
@@ -100370,8 +100786,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p135_c299",
-      "text": "136 NO. 1 OF 2026\nFIRST SCHEDULE — continued\nFirst column . Second column\nSpecified contributor or\nclass of specified contributors\nTypes of health information\n5 (e) Medication list\n(f) V accines administered\n(g) Cardiac report\n(h) Surgical procedure notes\n(i) Dental notes\n10 (j) Visit diagnoses/reasons for visit\nor patient problem list\n(k) Referral memorandum\n10. An HCSA licensee licensed to\nprovide an outpatient medical\n15 service\n(a) Visit event\n(b) Adverse drug event history\n(c) Ordered (prescribed)\nmedications\n(d) Dispensed medications\n20\n(e) Medication list\n(f) V accines administered\n(g) Cardiac report\n(h) Surgical procedure notes\n(i) Visit diagnoses/reasons for visit\n25\nor patient problem list\n(j) Referral memorandum\n11. An HCSA licensee licensed to\nprovide an outpatient renal\ndialysis service\n(a) Visit event\n30\n(b) Adverse drug event history\n(c) Ordered (prescribed)\nmedications\n(d",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p135_c331",
+      "text": "136 NO. 1 OF 2026\nFIRST SCHEDULE —continued\nFirst column . Second column\nSpecified contributor or\nclass of specified contributors\nTypes of health information\n5 (e) Medication list\n(f) Vaccines administered\n(g) Cardiac report\n(h) Surgical procedure notes\n(i) Dental notes\n10 (j) Visit diagnoses/reasons for visit\nor patient problem list\n(k) Referral memorandum\n10. An HCSA licensee licensed to\nprovide an outpatient medical\n15 service\n(a) Visit event\n(b) Adverse drug event history\n(c) Ordered (prescribed)\nmedications\n(d) Dispensed medications\n20\n(e) Medication list\n(f) Vaccines administered\n(g) Cardiac report\n(h) Surgical procedure notes\n(i) Visit diagnoses/reasons for visit\n25\nor patient problem list\n(j) Referral memorandum\n11. An HCSA licensee licensed to\nprovide an outpatient renal\ndialysis service\n(a) Visit event\n30\n(b) Adverse drug event history\n(c) Ordered (prescribed)\nmedications\n(d) D",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 135,
@@ -100383,8 +100799,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p135_c300",
-      "text": "see licensed to\nprovide an outpatient renal\ndialysis service\n(a) Visit event\n30\n(b) Adverse drug event history\n(c) Ordered (prescribed)\nmedications\n(d) Dispensed medications\n(e) Medication list\n(f) V accines administered\n134",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p135_c332",
+      "text": " licensed to\nprovide an outpatient renal\ndialysis service\n(a) Visit event\n30\n(b) Adverse drug event history\n(c) Ordered (prescribed)\nmedications\n(d) Dispensed medications\n(e) Medication list\n(f) Vaccines administered\n134",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 135,
@@ -100396,8 +100812,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p136_c301",
-      "text": "HEALTH INFORMATION 137\nFIRST SCHEDULE — continued\nFirst column . Second column\nSpecified contributor or\nclass of specified contributors\nTypes of health information\n5(g) Cardiac report\n(h) Surgical procedure notes\n(i) Visit diagnoses/reasons for visit\nor patient problem list\n(j) Referral memorandum\n1012. An HCSA licensee licensed to\nprovide a radiological service\n(a) Adverse drug event history\n(b) Ordered (prescribed)\nmedications\n(c) Dispensed medications\n15\n(d) Radiology/imaging reports\n(e) Cardiac report\n(f) Surgical procedure notes\n13. A retail pharmacy licensee (a) Adverse drug event history\n(b) Ordered (prescribed)\n20\nmedications\n(c) Dispensed medications\n(d) Medication list\n(e) V accines administered\nPART 2\n25\nDEFINITIONS\n1. In this Schedule —\n“acute hospital service”, “ambulatory surgical centre service”, “assisted\nreproduction service”, “clinical laboratory service”, “community ho",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p136_c333",
+      "text": "HEALTH INFORMATION 137\nFIRST SCHEDULE —continued\nFirst column . Second column\nSpecified contributor or\nclass of specified contributors\nTypes of health information\n5(g) Cardiac report\n(h) Surgical procedure notes\n(i) Visit diagnoses/reasons for visit\nor patient problem list\n(j) Referral memorandum\n1012. An HCSA licensee licensed to\nprovide a radiological service\n(a) Adverse drug event history\n(b) Ordered (prescribed)\nmedications\n(c) Dispensed medications\n15\n(d) Radiology/imaging reports\n(e) Cardiac report\n(f) Surgical procedure notes\n13. A retail pharmacy licensee (a) Adverse drug event history\n(b) Ordered (prescribed)\n20\nmedications\n(c) Dispensed medications\n(d) Medication list\n(e) Vaccines administered\nPART 2\n25\nDEFINITIONS\n1. In this Schedule —\n“acute hospital service”, “ambulatory surgical centre service”, “assisted\nreproduction service”, “clinical laboratory service”, “community hosp",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 136,
@@ -100409,8 +100825,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p136_c302",
-      "text": "hedule —\n“acute hospital service”, “ambulatory surgical centre service”, “assisted\nreproduction service”, “clinical laboratory service”, “community hospital \nservice”, “contingency care service”, “inpatient”, “nuclear medicine \nservice”, “nursing home service”, “outpatient dental service”, “outpatient \nmedical service”, “outpatient renal dialysis service” and “radiological \nservice” have the meanings given by paragraph 2 of the First Schedule to\nthe Healthcare Services Act 2020;\n135\n30",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p136_c334",
+      "text": "dule —\n“acute hospital service”, “ambulatory surgical centre service”, “assisted\nreproduction service”, “clinical laboratory service”, “community hospital \nservice”, “contingency care service”, “inpatient”, “nuclear medicine \nservice”, “nursing home service”, “outpatient dental service”, “outpatient \nmedical service”, “outpatient renal dialysis service” and “radiological \nservice” have the meanings given by paragraph 2 of the First Schedule to\nthe Healthcare Services Act 2020;\n135\n30",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 136,
@@ -100422,8 +100838,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p137_c303",
-      "text": "138 NO. 1 OF 2026\nFIRST SCHEDULE — continued\n“adverse drug event history” means health information about an individual\nregarding any event where the administration to the individual of a\nmedication has or is likely to have any debilitating, harmful, toxic or\n5 detrimental effect on the individual’s body or health;\n“cardiac report” means health information relating to the condition of an\nindividual’s cardiovascular system that is generated by any medical\ndevice used for the purpose of assessing or diagnosing the individual’s\ncondition;\n10 “dispensed medication” means —\n(a) in relation to an HCSA licensee — health information about any\nmedication prescribed for an individual that is dispensed to the\nindividual at the conclusion of a visit event; or\n(b) in relation to a retail pharmacy licensee — health information\n15 about any medication sold or dispensed to an individual by a\nqualified ph",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p137_c335",
+      "text": "138 NO. 1 OF 2026\nFIRST SCHEDULE —continued\n“adverse drug event history” means health information about an individual\nregarding any event where the administration to the individual of a\nmedication has or is likely to have any debilitating, harmful, toxic or\n5 detrimental effect on the individual’s body or health;\n“cardiac report” means health information relating to the condition of an\nindividual’s cardiovascular system that is generated by any medical\ndevice used for the purpose of assessing or diagnosing the individual’s\ncondition;\n10 “dispensed medication” means —\n(a) inrelationtoanHCSAlicensee—healthinformationaboutany\nmedication prescribed for an individual that is dispensed to the\nindividual at the conclusion of a visit event; or\n(b) in relation to a retail pharmacy licensee — health information\n15 about any medication sold or dispensed to an individual by a\nqualified pharmacist en",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 137,
@@ -100435,8 +100851,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p137_c304",
-      "text": "nt; or\n(b) in relation to a retail pharmacy licensee — health information\n15 about any medication sold or dispensed to an individual by a\nqualified pharmacist engaged or employed by the retail\npharmacy licensee;\n“medical device” means a health product categorised as a medical device in\nthe First Schedule to the Health Products Act 2007;\n20 “medication” means —\n(a) a health product categorised as a therapeutic product in the\nFirst Schedule to the Health Products Act 2007; or\n(b) a medicinal product within the meaning given by section 3 of\nthe Medicines Act 1975;\n25 “ordered (prescribed) medication” —\n(a) in relation to an HCSA licensee that is licensed to provide an\nacute hospital service, a community hospital service, a\ncontingency care service or a nursing home service —\n(i) means health information about any medication\n30 prescribed for an individual (P) who is a patient of\nthe HCSA li",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p137_c336",
+      "text": "in relation to a retail pharmacy licensee — health information\n15 about any medication sold or dispensed to an individual by a\nqualified pharmacist engaged or employed by the retail\npharmacy licensee;\n“medical device” means a health product categorised as a medical device in\nthe First Schedule to the Health Products Act 2007;\n20 “medication” means —\n(a) a health product categorised as a therapeutic product in the\nFirst Schedule to the Health Products Act 2007; or\n(b) a medicinal product within the meaning given by section 3 of\nthe Medicines Act 1975;\n25 “ordered (prescribed) medication” —\n(a) in relation to an HCSA licensee that is licensed to provide an\nacute hospital service, a community hospital service, a\ncontingency care service or a nursing home service —\n(i) means health information about any medication\n30 prescribed for an individual (P) who is a patient of\nthe HCSA licensee that",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 137,
@@ -100448,8 +100864,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p137_c305",
-      "text": "vice or a nursing home service —\n(i) means health information about any medication\n30 prescribed for an individual (P) who is a patient of\nthe HCSA licensee that is to be dispensed to P at the\nconclusion of a visit event; but\n(ii) does not include health information about any\nmedication prescribed for P for administration while\n35 P is an inpatient, whether or not the medication is\ndispensed to P; or\n136",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p137_c337",
+      "text": "ursing home service —\n(i) means health information about any medication\n30 prescribed for an individual (P) who is a patient of\nthe HCSA licensee that is to be dispensed toP at the\nconclusion of a visit event; but\n(ii) does not include health information about any\nmedication prescribed forP for administration while\n35 P is an inpatient, whether or not the medication is\ndispensed toP; or\n136",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 137,
@@ -100461,8 +100877,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p138_c306",
-      "text": "HEALTH INFORMATION 139\nFIRST SCHEDULE — continued\n(b) in relation to an HCSA licensee that is licensed to provide an\nambulatory surgical centre service, an assisted reproduction\nservice, a nuclear medicine service, an outpatient dental service,\n5an outpatient medical service, an outpatient renal dialysis\nservice or a radiological service —\n(i) means health information about any medication\nprescribed for P that is to be dispensed to P at the\nconclusion of a visit event; but\n10(ii) does not include health information about any\nmedication prescribed for P for administration during\nthe visit event, whether or not the medication is\ndispensed to P;\n“referral memorandum” means a document or information in respect of an\n15individual that is issued by a specified contributor for the purpose of\nenabling or facilitating the provision of a healthcare service or community\nhealth service to the indivi",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p138_c338",
+      "text": "HEALTH INFORMATION 139\nFIRST SCHEDULE —continued\n(b) in relation to an HCSA licensee that is licensed to provide an\nambulatory surgical centre service, an assisted reproduction\nservice,anuclearmedicineservice,anoutpatientdentalservice,\n5an outpatient medical service, an outpatient renal dialysis\nservice or a radiological service —\n(i) means health information about any medication\nprescribed for P that is to be dispensed toP at the\nconclusion of a visit event; but\n10(ii) does not include health information about any\nmedication prescribed forP for administration during\nthe visit event, whether or not the medication is\ndispensed toP;\n“referral memorandum” means a document or information in respect of an\n15individual that is issued by a specified contributor for the purpose of\nenablingorfacilitatingtheprovisionofahealthcareserviceorcommunity\nhealth service to the individual by another person",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 138,
@@ -100474,8 +100890,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p138_c307",
-      "text": "by a specified contributor for the purpose of\nenabling or facilitating the provision of a healthcare service or community\nhealth service to the individual by another person, but excludes an\nindividual employed or engaged by the specified contributor;\n“surgical procedure notes” means health information about any surgical\n20procedure performed on an individual that is listed in the Table of Surgical\nProcedures, other than a surgical procedure with table ranking “MSP”;\n“Table of Surgical Procedures” means the Table of Surgical Procedures\nissued by the Ministry of Health and accessible at the website at\nhttps://www.moh.gov.sg/managing-expenses/schemes-and-\n25subsidies/medisave/inpatient-care;\n“visit event”, in relation to a specified contributor, means health information\nabout any occasion on which an individual consults the specified\ncontributor or receives a service provided by the specifi",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p138_c339",
+      "text": "ed contributor for the purpose of\nenablingorfacilitatingtheprovisionofahealthcareserviceorcommunity\nhealth service to the individual by another person, but excludes an\nindividual employed or engaged by the specified contributor;\n“surgical procedure notes” means health information about any surgical\n20procedureperformedonanindividualthatislistedintheTableofSurgical\nProcedures, other than a surgical procedure with table ranking “MSP”;\n“Table of Surgical Procedures” means the Table of Surgical Procedures\nissued by the Ministry of Health and accessible at the website at\nhttps://www.moh.gov.sg/managing-expenses/schemes-and-\n25subsidies/medisave/inpatient-care;\n“visit event”,in relation toa specified contributor, means health information\nabout any occasion on which an individual consults the specified\ncontributor or receives a service provided by the specified contributor,\nwhether by attending",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 138,
@@ -100487,8 +100903,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p138_c308",
-      "text": "r, means health information\nabout any occasion on which an individual consults the specified\ncontributor or receives a service provided by the specified contributor,\nwhether by attending at the premises or conveyance of the specified\n30contributor or by electronic or other means.\n137",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p138_c340",
+      "text": "y occasion on which an individual consults the specified\ncontributor or receives a service provided by the specified contributor,\nwhether by attending at the premises or conveyance of the specified\n30contributor or by electronic or other means.\n137",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 138,
@@ -100500,8 +100916,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p139_c309",
-      "text": "140 NO. 1 OF 2026\nSECOND SCHEDULE\nSections 18(1)(a)(i) and 19(1)(c)\nACCESS AND COLLECTION OF\nACCESSIBLE HEALTH INFORMA TION\n5 PART 1\nSPECIFIED USERS AND\nAUTHORISED INDIVIDUALS\nFirst column . Second column\nSpecified user or class\n10 of specified users\nAuthorised individual or class\nof authorised individuals\n1. An HCSA licensee licensed to\nprovide an acute hospital\nservice\n. (a) Registered allied health\nprofessionals\n(b) Registered dentists\n15\n(c) Registered medical practitioners\n(d) Registered midwives\n(e) Registered nurses\n(f) Registered optometrists\n(g) Registered oral health therapists\n20\n(h) Registered pharmacists\n(i) Audiologists\n(j) Clinical psychologists\n(k) Dietitians\n(l) Medical technologists\n25\n(m) Pharmacy technicians\n(n) Podiatrists\n(o) Pre‑registration pharmacists\n2. An HCSA licensee licensed to\nprovide an ambulatory surgical\n30\ncentre service\n(a) Registered medical practitio",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p139_c341",
+      "text": "140 NO. 1 OF 2026\nSECOND SCHEDULE\nSections 18(1)(a)(i) and 19(1)(c)\nACCESS AND COLLECTION OF\nACCESSIBLE HEALTH INFORMATION\n5 PART 1\nSPECIFIED USERS AND\nAUTHORISED INDIVIDUALS\nFirst column . Second column\nSpecified user or class\n10 of specified users\nAuthorised individual or class\nof authorised individuals\n1. An HCSA licensee licensed to\nprovide an acute hospital\nservice\n. (a) Registered allied health\nprofessionals\n(b) Registered dentists\n15\n(c) Registeredmedicalpractitioners\n(d) Registered midwives\n(e) Registered nurses\n(f) Registered optometrists\n(g) Registered oral health therapists\n20\n(h) Registered pharmacists\n(i) Audiologists\n(j) Clinical psychologists\n(k) Dietitians\n(l) Medical technologists\n25\n(m) Pharmacy technicians\n(n) Podiatrists\n(o) Pre‑registration pharmacists\n2. An HCSA licensee licensed to\nprovide an ambulatory surgical\n30\ncentre service\n(a) Registeredmedicalpractitioners\n",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 139,
@@ -100513,8 +100929,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p139_c310",
-      "text": "sts\n(o) Pre‑registration pharmacists\n2. An HCSA licensee licensed to\nprovide an ambulatory surgical\n30\ncentre service\n(a) Registered medical practitioners\n(b) Registered nurses\n3. An HCSA licensee licensed to\nprovide an assisted\nreproduction service\n(a) Registered medical practitioners\n(b) Registered nurses\n138",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p139_c342",
+      "text": "\n(o) Pre‑registration pharmacists\n2. An HCSA licensee licensed to\nprovide an ambulatory surgical\n30\ncentre service\n(a) Registeredmedicalpractitioners\n(b) Registered nurses\n3. An HCSA licensee licensed to\nprovide an assisted\nreproduction service\n(a) Registeredmedicalpractitioners\n(b) Registered nurses\n138",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 139,
@@ -100526,8 +100942,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p140_c311",
-      "text": "HEALTH INFORMATION 141\nSECOND SCHEDULE — continued\nFirst column . Second column\nSpecified user or class\nof specified users\nAuthorised individual or class\nof authorised individuals\n54. An HCSA licensee licensed to\nprovide a blood banking service\n(a) Registered medical practitioners\n(b) Registered nurses\n5. An HCSA licensee licensed to\nprovide a clinical laboratory\n10\nservice\n(a) Registered medical practitioners\n(b) Registered nurses\n6. An HCSA licensee licensed to\nprovide a community hospital\nservice\n(a) Registered allied health\nprofessionals\n15\n(b) Registered dentists\n(c) Registered medical practitioners\n(d) Registered midwives\n(e) Registered nurses\n(f) Registered oral health therapists\n20\n(g) Registered pharmacists\n(h) Audiologists\n(i) Clinical psychologists\n(j) Dietitians\n(k) Medical technologists\n25\n(l) Podiatrists\n(m) Pre‑registration pharmacists\n7. An HCSA licensee licensed to\nprovi",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p140_c343",
+      "text": "HEALTH INFORMATION 141\nSECOND SCHEDULE —continued\nFirst column . Second column\nSpecified user or class\nof specified users\nAuthorised individual or class\nof authorised individuals\n54. An HCSA licensee licensed to\nprovideabloodbankingservice\n(a) Registeredmedicalpractitioners\n(b) Registered nurses\n5. An HCSA licensee licensed to\nprovide a clinical laboratory\n10\nservice\n(a) Registeredmedicalpractitioners\n(b) Registered nurses\n6. An HCSA licensee licensed to\nprovide a community hospital\nservice\n(a) Registered allied health\nprofessionals\n15\n(b) Registered dentists\n(c) Registeredmedicalpractitioners\n(d) Registered midwives\n(e) Registered nurses\n(f) Registered oral health therapists\n20\n(g) Registered pharmacists\n(h) Audiologists\n(i) Clinical psychologists\n(j) Dietitians\n(k) Medical technologists\n25\n(l) Podiatrists\n(m) Pre‑registration pharmacists\n7. An HCSA licensee licensed to\nprovide a cord b",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 140,
@@ -100539,8 +100955,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p140_c312",
-      "text": "nical psychologists\n(j) Dietitians\n(k) Medical technologists\n25\n(l) Podiatrists\n(m) Pre‑registration pharmacists\n7. An HCSA licensee licensed to\nprovide a cord blood banking\nservice\n(a) Registered medical practitioners\n(b) Registered nurses\n8. An HCSA licensee licensed to\nprovide an emergency\nambulance service\n(a) Registered medical practitioners\n(b) Registered nurses\n9. An HCSA licensee licensed to\nprovide a human tissue banking\nservice\n(a) Registered medical practitioners\n(b) Registered nurses\n139",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p140_c344",
+      "text": "ologists\n(j) Dietitians\n(k) Medical technologists\n25\n(l) Podiatrists\n(m) Pre‑registration pharmacists\n7. An HCSA licensee licensed to\nprovide a cord blood banking\nservice\n(a) Registeredmedicalpractitioners\n(b) Registered nurses\n8. An HCSA licensee licensed to\nprovide an emergency\nambulance service\n(a) Registeredmedicalpractitioners\n(b) Registered nurses\n9. An HCSA licensee licensed to\nprovideahumantissuebanking\nservice\n(a) Registeredmedicalpractitioners\n(b) Registered nurses\n139",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 140,
@@ -100552,8 +100968,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p141_c313",
-      "text": "142 NO. 1 OF 2026\nSECOND SCHEDULE — continued\nFirst column . Second column\nSpecified user or class\nof specified users\nAuthorised individual or class\nof authorised individuals\n5 10. An HCSA licensee licensed to\nprovide a medical transport\nservice\n(a) Registered medical practitioners\n(b) Registered nurses\n11. An HCSA licensee licensed to\n10\nprovide a nuclear medicine\nservice\n(a) Registered medical practitioners\n(b) Registered nurses\n12. An HCSA licensee licensed to\nprovide a nursing home service\n(a) Registered allied health\nprofessionals\n15\n(b) Registered medical practitioners\n(c) Registered nurses\n(d) Registered pharmacists\n(e) Audiologists\n(f) Clinical psychologists\n20\n(g) Dietitians\n(h) Medical technologists\n(i) Podiatrists\n13. An HCSA licensee licensed to\nprovide an outpatient dental\n25\nservice\n(a) Registered dentists\n(b) Registered medical practitioners\n(c) Registered nurses\n(d) Regis",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p141_c345",
+      "text": "142 NO. 1 OF 2026\nSECOND SCHEDULE —continued\nFirst column . Second column\nSpecified user or class\nof specified users\nAuthorised individual or class\nof authorised individuals\n5 10. An HCSA licensee licensed to\nprovide a medical transport\nservice\n(a) Registeredmedicalpractitioners\n(b) Registered nurses\n11. An HCSA licensee licensed to\n10\nprovide a nuclear medicine\nservice\n(a) Registeredmedicalpractitioners\n(b) Registered nurses\n12. An HCSA licensee licensed to\nprovide a nursing home service\n(a) Registered allied health\nprofessionals\n15\n(b) Registeredmedicalpractitioners\n(c) Registered nurses\n(d) Registered pharmacists\n(e) Audiologists\n(f) Clinical psychologists\n20\n(g) Dietitians\n(h) Medical technologists\n(i) Podiatrists\n13. An HCSA licensee licensed to\nprovide an outpatient dental\n25\nservice\n(a) Registered dentists\n(b) Registeredmedicalpractitioners\n(c) Registered nurses\n(d) Registered ora",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 141,
@@ -100565,8 +100981,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p141_c314",
-      "text": "ensee licensed to\nprovide an outpatient dental\n25\nservice\n(a) Registered dentists\n(b) Registered medical practitioners\n(c) Registered nurses\n(d) Registered oral health therapists\n14. An HCSA licensee licensed to\n30\nprovide an outpatient medical\nservice\n(a) Registered allied health\nprofessionals\n(b) Registered medical practitioners\n(c) Registered nurses\n(d) Registered optometrists\n(e) Registered pharmacists\n(f) Audiologists\n(g) Clinical psychologists\n140",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p141_c346",
+      "text": "icensed to\nprovide an outpatient dental\n25\nservice\n(a) Registered dentists\n(b) Registeredmedicalpractitioners\n(c) Registered nurses\n(d) Registered oral health therapists\n14. An HCSA licensee licensed to\n30\nprovide an outpatient medical\nservice\n(a) Registered allied health\nprofessionals\n(b) Registeredmedicalpractitioners\n(c) Registered nurses\n(d) Registered optometrists\n(e) Registered pharmacists\n(f) Audiologists\n(g) Clinical psychologists\n140",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 141,
@@ -100578,8 +100994,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p142_c315",
-      "text": "HEALTH INFORMATION 143\nSECOND SCHEDULE — continued\nFirst column . Second column\nSpecified user or class\nof specified users\nAuthorised individual or class\nof authorised individuals\n5(h) Dietitians\n(i) Podiatrists\n15. An HCSA licensee licensed to\nprovide an outpatient renal\ndialysis service\n(a) Registered medical practitioners\n10\n(b) Registered nurses\n16. An HCSA licensee licensed to\nprovide a radiological service\n(a) Registered medical practitioners\n(b) Registered nurses\n17. A retail pharmacy licensee (a) Registered pharmacists\n15\n(b) Pre‑registration pharmacists\n(c) Pharmacy technicians\n18. Ministry of Defence (a) Registered allied health\nprofessionals\n(b) Registered dentists\n20\n(c) Registered medical practitioners\n(d) Registered nurses\n(e) Registered optometrists\n(f) Registered oral health therapists\n(g) Registered pharmacists\n25\n(h) Paramedics\n(i) Pharmacy technicians\n19. Ministry of H",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p142_c347",
+      "text": "HEALTH INFORMATION 143\nSECOND SCHEDULE —continued\nFirst column . Second column\nSpecified user or class\nof specified users\nAuthorised individual or class\nof authorised individuals\n5(h) Dietitians\n(i) Podiatrists\n15. An HCSA licensee licensed to\nprovide an outpatient renal\ndialysis service\n(a) Registeredmedicalpractitioners\n10\n(b) Registered nurses\n16. An HCSA licensee licensed to\nprovide a radiological service\n(a) Registeredmedicalpractitioners\n(b) Registered nurses\n17. A retail pharmacy licensee (a) Registered pharmacists\n15\n(b) Pre‑registration pharmacists\n(c) Pharmacy technicians\n18. Ministry of Defence (a) Registered allied health\nprofessionals\n(b) Registered dentists\n20\n(c) Registeredmedicalpractitioners\n(d) Registered nurses\n(e) Registered optometrists\n(f) Registered oral health therapists\n(g) Registered pharmacists\n25\n(h) Paramedics\n(i) Pharmacy technicians\n19. Ministry of Home Aff",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 142,
@@ -100591,8 +101007,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p142_c316",
-      "text": " Registered optometrists\n(f) Registered oral health therapists\n(g) Registered pharmacists\n25\n(h) Paramedics\n(i) Pharmacy technicians\n19. Ministry of Home Affairs Registered medical practitioners\n20. Singapore Armed Forces (a) Registered allied health\nprofessionals\n30\n(b) Registered dentists\n(c) Registered medical practitioners\n(d) Registered nurses\n(e) Registered optometrists\n141",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p142_c348",
+      "text": "ered optometrists\n(f) Registered oral health therapists\n(g) Registered pharmacists\n25\n(h) Paramedics\n(i) Pharmacy technicians\n19. Ministry of Home Affairs Registered medical practitioners\n20. Singapore Armed Forces (a) Registered allied health\nprofessionals\n30\n(b) Registered dentists\n(c) Registeredmedicalpractitioners\n(d) Registered nurses\n(e) Registered optometrists\n141",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 142,
@@ -100604,8 +101020,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p143_c317",
-      "text": "144 NO. 1 OF 2026\nSECOND SCHEDULE — continued\nFirst column . Second column\nSpecified user or class\nof specified users\nAuthorised individual or class\nof authorised individuals\n5 (f) Registered oral health therapists\n(g) Registered pharmacists\n(h) Paramedics\n(i) Pharmacy technicians\n21. Singapore Civil Defence Force (a) Registered medical practitioners\n10 (b) Registered nurses\n(c) Paramedics\n22. Singapore Prison Service (a) Registered allied health\nprofessionals\n(b) Registered dentists\n15 (c) Registered medical practitioners\n(d) Registered nurses\n(e) Registered pharmacists\n(f) Clinical psychologists\n(g) Pharmacy technicians\n20 PART 2\nDEFINITIONS\n1. In this Schedule —\n“enlisted personnel” has the meaning given by section 6;\n“paramedic” means an individual who —\n25 (a) is employed or engaged by a specified user to perform the\nfunctions of a paramedic; or\n(b) is an enlisted personnel of a spe",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p143_c349",
+      "text": "144 NO. 1 OF 2026\nSECOND SCHEDULE —continued\nFirst column . Second column\nSpecified user or class\nof specified users\nAuthorised individual or class\nof authorised individuals\n5 (f) Registered oral health therapists\n(g) Registered pharmacists\n(h) Paramedics\n(i) Pharmacy technicians\n21. Singapore Civil Defence Force (a) Registeredmedicalpractitioners\n10 (b) Registered nurses\n(c) Paramedics\n22. Singapore Prison Service (a) Registered allied health\nprofessionals\n(b) Registered dentists\n15 (c) Registeredmedicalpractitioners\n(d) Registered nurses\n(e) Registered pharmacists\n(f) Clinical psychologists\n(g) Pharmacy technicians\n20 PART 2\nDEFINITIONS\n1. In this Schedule —\n“enlisted personnel” has the meaning given by section 6;\n“paramedic” means an individual who —\n25 (a) is employed or engaged by a specified user to perform the\nfunctions of a paramedic; or\n(b) is an enlisted personnel of a specifie",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 143,
@@ -100617,8 +101033,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p143_c318",
-      "text": "n individual who —\n25 (a) is employed or engaged by a specified user to perform the\nfunctions of a paramedic; or\n(b) is an enlisted personnel of a specified user and is appointed or\nauthorised by the specified user to perform the functions of a\nparamedic;\n142",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p143_c350",
+      "text": "ividual who —\n25 (a) is employed or engaged by a specified user to perform the\nfunctions of a paramedic; or\n(b) is an enlisted personnel of a specified user and is appointed or\nauthorised by the specified user to perform the functions of a\nparamedic;\n142",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 143,
@@ -100630,8 +101046,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p144_c319",
-      "text": "HEALTH INFORMATION 145\nSECOND SCHEDULE — continued\n“pre‑registration pharmacist” means an individual who, for the purpose of\nthe individual satisfying the requirements for registration as a registered\npharmacist under the Pharmacists Registration Act 2007, is approved by\n5the Singapore Pharmacy Council to undergo pre‑registration training with\nan HCSA licensee licensed to provide an acute hospital service or a\ncommunity hospital service or a retail pharmacy licensee that is approved\nby the Council;\n“registered allied health professional” means an individual who is an allied\n10health professional registered under the Allied Health Professions\nAct 2011 and holds a valid practising certificate under that Act;\n“registered dentist” means an individual who is registered under the Dental\nRegistration Act 1999 as a registered dentist and holds a valid practising\ncertificate under that Act;\n15“re",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p144_c351",
+      "text": "HEALTH INFORMATION 145\nSECOND SCHEDULE —continued\n“pre‑registration pharmacist” means an individual who, for the purpose of\nthe individual satisfying the requirements for registration as a registered\npharmacist under the Pharmacists Registration Act 2007, is approved by\n5theSingaporePharmacyCounciltoundergopre‑registrationtrainingwith\nan HCSA licensee licensed to provide an acute hospital service or a\ncommunityhospitalserviceoraretailpharmacylicenseethatisapproved\nby the Council;\n“registered allied health professional” means an individual who is an allied\n10health professional registered under the Allied Health Professions\nAct 2011 and holds a valid practising certificate under that Act;\n“registered dentist” means an individual who is registered under the Dental\nRegistration Act 1999 as a registered dentist and holds a valid practising\ncertificate under that Act;\n15“registered medical pr",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 144,
@@ -100643,8 +101059,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p144_c320",
-      "text": "vidual who is registered under the Dental\nRegistration Act 1999 as a registered dentist and holds a valid practising\ncertificate under that Act;\n15“registered medical practitioner” means an individual who is registered\nunder the Medical Registration Act 1997 and holds a valid practising\ncertificate under that Act;\n“registered midwife” means an individual who is registered under the Nurses\nand Midwives Act 1999 as a registered midwife and holds a valid\n20practising certificate under that Act;\n“registered nurse” means an individual who is registered under the Nurses\nand Midwives Act 1999 as a registered nurse and holds a valid practising\ncertificate under that Act;\n“registered optometrist” means an individual who is registered under the\n25Optometrists and Opticians Act 2007 for the carrying out of any practice\nof optometry and holds a valid practising certificate under that Act;\n“registere",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p144_c352",
+      "text": "tered under the Dental\nRegistration Act 1999 as a registered dentist and holds a valid practising\ncertificate under that Act;\n15“registered medical practitioner” means an individual who is registered\nunder the Medical Registration Act 1997 and holds a valid practising\ncertificate under that Act;\n“registeredmidwife”meansanindividualwhoisregisteredundertheNurses\nand Midwives Act 1999 as a registered midwife and holds a valid\n20practising certificate under that Act;\n“registered nurse” means an individual who is registered under the Nurses\nand Midwives Act 1999 as a registered nurse and holds a valid practising\ncertificate under that Act;\n“registered optometrist” means an individual who is registered under the\n25Optometrists and Opticians Act 2007 for the carrying out of any practice\nof optometry and holds a valid practising certificate under that Act;\n“registeredoralhealththerapist”meansani",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 144,
@@ -100656,8 +101072,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p144_c321",
-      "text": "ometrists and Opticians Act 2007 for the carrying out of any practice\nof optometry and holds a valid practising certificate under that Act;\n“registered oral health therapist” means an individual who is registered under\nthe Dental Registration Act 1999 as a registered oral health therapist and\nholds a valid practising certificate under that Act;\n30“registered pharmacist” means an individual who is registered under the\nPharmacists Registration Act 2007 as a registered pharmacist and holds a\nvalid practising certificate under that Act.\n143",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p144_c353",
+      "text": "007 for the carrying out of any practice\nof optometry and holds a valid practising certificate under that Act;\n“registeredoralhealththerapist”meansanindividualwhoisregisteredunder\nthe Dental Registration Act 1999 as a registered oral health therapist and\nholds a valid practising certificate under that Act;\n30“registered pharmacist” means an individual who is registered under the\nPharmacists Registration Act 2007 as a registered pharmacist and holds a\nvalid practising certificate under that Act.\n143",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 144,
@@ -100669,8 +101085,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p145_c322",
-      "text": "146 NO. 1 OF 2026\nTHIRD SCHEDULE\nSection 19(3)\nWRITTEN LAWS UNDER WHICH\nSPECIFIED EXAMINA TIONS CARRIED OUT FOR\n5 PURPOSES OF SECTION 19(3)\nProtection of public health\n1. Biological Agents and Toxins Act 2005\n(a) Medical examination of an individual under section 6(6)(e)(i),\n7(3)(b)(v)(A), 15(5)(e)(i), 16(2)(b)(v)(A), 23(2)(e)(i), 27(3)(e)(i),\n10 31(4)(b)(v)(A), 45(1)(b)(v)(A), 50(7)(e)(v)(A), 51(6)(h)(i), 52(1)(f)\nor 53(1)(i)(i)\n2. Control of V ectors and Pesticides Act 1998\n(a) Medical examination of an individual under section 20 or 35(2)(a)\n(b) Post-mortem examination of a corpse under section 35(2)(c)\n15 3. Coroners Act 2010\n(a) Post‑mortem examination under section 18(1) or (2)\n(b) Special examination by a person appointed by a pathologist under\nsection 19(2)(b)\n4. Environmental Public Health Act 1987\n20 (a) Medical examination of an individual under section 37(1)\n5. Immigration Ac",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p145_c354",
+      "text": "146 NO. 1 OF 2026\nTHIRD SCHEDULE\nSection 19(3)\nWRITTEN LAWS UNDER WHICH\nSPECIFIED EXAMINATIONS CARRIED OUT FOR\n5 PURPOSES OF SECTION 19(3)\nProtection of public health\n1. Biological Agents and Toxins Act 2005\n(a) Medical examination of an individual under section 6(6)(e)(i),\n7(3)(b)(v)(A), 15(5)(e)(i), 16(2)(b)(v)(A), 23(2)(e)(i), 27(3)(e)(i),\n10 31(4)(b)(v)(A), 45(1)(b)(v)(A), 50(7)(e)(v)(A), 51(6)(h)(i), 52(1)(f)\nor 53(1)(i)(i)\n2. Control of Vectors and Pesticides Act 1998\n(a) Medical examination of an individual under section 20 or 35(2)(a)\n(b) Post-mortem examination of a corpse under section 35(2)(c)\n15 3. Coroners Act 2010\n(a) Post‑mortem examination under section 18(1) or (2)\n(b) Special examination by a person appointed by a pathologist under\nsection 19(2)(b)\n4. Environmental Public Health Act 1987\n20 (a) Medical examination of an individual under section 37(1)\n5. Immigration Act ",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 145,
@@ -100682,8 +101098,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p145_c323",
-      "text": "ogist under\nsection 19(2)(b)\n4. Environmental Public Health Act 1987\n20 (a) Medical examination of an individual under section 37(1)\n5. Immigration Act 1959\n(a) Medical examination of an individual under section 29(1)\n6. Immigration Regulations (Rg 1)\n(a) Medical surveillance of an individual under regulation 8(2A)\n25 7. Infectious Diseases Act 1976\n(a) Medical examination of an individual under section 7(2)(b), 8(1),\n17(3)(d), 29(1)(b), 45A(1), 45B(1) or 55(1)(f)\n(b) Post‑mortem examination of the body of a deceased person under\nsection 9\n30 8. Infectious Diseases (Quarantine) Regulations (Rg 1)\n(a) Medical examination of an individual under regulation 21(1)\n144",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p145_c355",
+      "text": "ist under\nsection 19(2)(b)\n4. Environmental Public Health Act 1987\n20 (a) Medical examination of an individual under section 37(1)\n5. Immigration Act 1959\n(a) Medical examination of an individual under section 29(1)\n6. Immigration Regulations (Rg 1)\n(a) Medical surveillance of an individual under regulation 8(2A)\n25 7. Infectious Diseases Act 1976\n(a) Medical examination of an individual under section 7(2)(b), 8(1),\n17(3)(d), 29(1)(b), 45A(1), 45B(1) or 55(1)(f)\n(b) Post‑mortem examination of the body of a deceased person under\nsection 9\n30 8. Infectious Diseases (Quarantine) Regulations (Rg 1)\n(a) Medical examination of an individual under regulation 21(1)\n144",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 145,
@@ -100695,8 +101111,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p146_c324",
-      "text": "HEALTH INFORMATION 147\nTHIRD SCHEDULE — continued\n9. Registration of Births and Deaths Act 2021\n(a) Examination of the body of a deceased person by a medical\npractitioner under section 23(1)(a)\n5(b) Ascertainment of relevant information about a deceased person’s\nmedical history and the circumstances of the deceased person’s death\nby a medical practitioner under section 23(1)(b)\n10. Sale of Food Act 1973\n(a) Medical examination of an individual under section 22(1)\n1011. Wholesome Meat and Fish (Processing Establishments and Cold Stores)\nRules (R 3)\n(a) Medical examination of an individual for the purposes of rule 7(2)\n(b) Medical examination or medical test of an individual for the purposes\nof rule 7(4)\n1512. Wholesome Meat and Fish (Slaughter‑houses) Rules (R 4)\n(a) Medical examination of an individual for the purposes of rule 7(2)\n(b) Medical examination or medical test of an individual",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p146_c356",
+      "text": "HEALTH INFORMATION 147\nTHIRD SCHEDULE —continued\n9. Registration of Births and Deaths Act 2021\n(a) Examination of the body of a deceased person by a medical\npractitioner under section 23(1)(a)\n5(b) Ascertainment of relevant information about a deceased person’s\nmedical history and the circumstances of the deceased person’s death\nby a medical practitioner under section 23(1)(b)\n10. Sale of Food Act 1973\n(a) Medical examination of an individual under section 22(1)\n1011. Wholesome Meat and Fish (Processing Establishments and Cold Stores)\nRules (R 3)\n(a) Medical examination of an individual for the purposes of rule 7(2)\n(b) Medical examination or medical test of an individual for the purposes\nof rule 7(4)\n1512. Wholesome Meat and Fish (Slaughter‑houses) Rules (R 4)\n(a) Medical examination of an individual for the purposes of rule 7(2)\n(b) Medical examination or medical test of an individual ",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 146,
@@ -100708,8 +101124,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p146_c325",
-      "text": "er‑houses) Rules (R 4)\n(a) Medical examination of an individual for the purposes of rule 7(2)\n(b) Medical examination or medical test of an individual for the purposes\nof rule 7(4)\nIndividuals involved in hazardous work\n2013. Hydrogen Cyanide (Fumigation) Regulations 1989\n(a) Medical examination of an individual for the purposes of obtaining a\ncertificate under regulation 12(a)\n(b) Medical examination of an individual under regulation 12(b)\n14. Radiation Protection (Ionising Radiation) Regulations 2023\n25(a) Medical examination of an individual under regulation 16(2)(a)\n(b) Medical examination of an individual for the purposes of\nregulation 30(6)(b) or (7)(c) or 35(9)(c) or (11)(d)\n(c) Medical examination of an individual affected by any radiation\naccident occurring in a non‑medical application of ionising radiation\n30or radioactive materials in relation to the preparation of a prelimina",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p146_c357",
+      "text": "r‑houses) Rules (R 4)\n(a) Medical examination of an individual for the purposes of rule 7(2)\n(b) Medical examination or medical test of an individual for the purposes\nof rule 7(4)\nIndividuals involved in hazardous work\n2013. Hydrogen Cyanide (Fumigation) Regulations 1989\n(a) Medical examination of an individual for the purposes of obtaining a\ncertificate under regulation 12(a)\n(b) Medical examination of an individual under regulation 12(b)\n14. Radiation Protection (Ionising Radiation) Regulations 2023\n25(a) Medical examination of an individual under regulation 16(2)(a)\n(b) Medical examination of an individual for the purposes of\nregulation 30(6)(b) or (7)(c) or 35(9)(c) or (11)(d)\n(c) Medical examination of an individual affected by any radiation\naccident occurring in a non‑medical application of ionising radiation\n30or radioactive materials in relation to the preparation of a preliminar",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 146,
@@ -100721,8 +101137,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p146_c326",
-      "text": "diation\naccident occurring in a non‑medical application of ionising radiation\n30or radioactive materials in relation to the preparation of a preliminary\nwritten report or final full written report mentioned in regulation 72(2)\n15. Radiation Protection (Non‑Ionising Radiation) Regulations (Rg 1)\n(a) Medical examination of an individual for the purposes of regulation 8\n145",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p146_c358",
+      "text": "iation\naccident occurring in a non‑medical application of ionising radiation\n30or radioactive materials in relation to the preparation of a preliminary\nwrittenreportorfinalfullwrittenreportmentionedinregulation72(2)\n15. Radiation Protection (Non‑Ionising Radiation) Regulations (Rg 1)\n(a) Medical examination of an individual for the purposes of regulation 8\n145",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 146,
@@ -100734,8 +101150,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p147_c327",
-      "text": "148 NO. 1 OF 2026\nTHIRD SCHEDULE — continued\n(b) Medical examination of an individual under regulation 20(c)\n16. Workplace Safety and Health (Construction) Regulations 2007\n(a) Medical examination of an individual for the purposes of\n5 regulation 102(6)\n17. Workplace Safety and Health (Medical Examinations) Regulations 2011\n(a) Medical examination of an individual for the purposes of\nregulation 4(1) or (2), 5(1) or 6(1)\n18. Workplace Safety and Health (Operation of Cranes) Regulations 2011\n10 (a) Medical examination of an individual for the purpose of obtaining a\nmedical certificate mentioned in regulation 7(2) or 12(2)(c)\nLicensing of drivers\n19. Road Traffic Act 1961\n(a) Carrying out a prescribed medical examination of an individual\n15 mentioned in section 35(10A)(a)\n(b) Carrying out a prescribed test of an individual mentioned in\nsection 37(5) or (8)\n20. Road Traffic (Motor V ehicles,",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p147_c359",
+      "text": "148 NO. 1 OF 2026\nTHIRD SCHEDULE —continued\n(b) Medical examination of an individual under regulation 20(c)\n16. Workplace Safety and Health (Construction) Regulations 2007\n(a) Medical examination of an individual for the purposes of\n5 regulation 102(6)\n17. Workplace Safety and Health (Medical Examinations) Regulations 2011\n(a) Medical examination of an individual for the purposes of\nregulation 4(1) or (2), 5(1) or 6(1)\n18. Workplace Safety and Health (Operation of Cranes) Regulations 2011\n10 (a) Medical examination of an individual for the purpose of obtaining a\nmedical certificate mentioned in regulation 7(2) or 12(2)(c)\nLicensing of drivers\n19. Road Traffic Act 1961\n(a) Carrying out a prescribed medical examination of an individual\n15 mentioned in section 35(10A)(a)\n(b) Carrying out a prescribed test of an individual mentioned in\nsection 37(5) or (8)\n20. Road Traffic (Motor Vehicles, D",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 147,
@@ -100747,8 +101163,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p147_c328",
-      "text": "ntioned in section 35(10A)(a)\n(b) Carrying out a prescribed test of an individual mentioned in\nsection 37(5) or (8)\n20. Road Traffic (Motor V ehicles, Driving Licences) Rules (R 27)\n(a) Medical examination of an individual for the purposes of rule 4A(1)(a)\n20 or 5(2)(a)\nUniformed and related services and enlistment\n21. Civil Defence Act 1986\n(a) Medical or dental examination or test of an individual under\nsection 32A(a)\n25 (b) Medical examination of an individual under section 101A(1)(f)\n22. Enlistment Act 1970\n(a) Examination of an individual required to report for a fitness\nexamination within the meaning given by section 2\n(b) Medical examination of an individual under section 8(6) or (7)\n30 23. Home Team Corps Regulations 2018\n(a) Medical examination of an individual for the purposes of regulation 15\nor 36\n146",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p147_c360",
+      "text": "tioned in section 35(10A)(a)\n(b) Carrying out a prescribed test of an individual mentioned in\nsection 37(5) or (8)\n20. Road Traffic (Motor Vehicles, Driving Licences) Rules (R 27)\n(a) Medicalexaminationofanindividualforthepurposesofrule4A(1)(a)\n20 or 5(2)(a)\nUniformed and related services and enlistment\n21. Civil Defence Act 1986\n(a) Medical or dental examination or test of an individual under\nsection 32A(a)\n25 (b) Medical examination of an individual under section 101A(1)(f)\n22. Enlistment Act 1970\n(a) Examination of an individual required to report for a fitness\nexamination within the meaning given by section 2\n(b) Medical examination of an individual under section 8(6) or (7)\n30 23. Home Team Corps Regulations 2018\n(a) Medicalexaminationofanindividualforthepurposesofregulation15\nor 36\n146",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 147,
@@ -100760,8 +101176,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p148_c329",
-      "text": "HEALTH INFORMATION 149\nTHIRD SCHEDULE — continued\n24. National Cadet Corps Regulations (Rg 1)\n(a) Medical examination of an individual for the purposes of regulation 10\n25. Police Force Act 2004\n5(a) Medical or dental examination or test of a police officer that is required\nunder any lawful order (whether given orally or in writing) or under the\nPolice General Orders, any Force Orders or any Standing Orders made\nunder the Act\n26. Police (Special Constabulary) Regulations (Rg 3)\n10(a) Medical examination of an individual for the purposes of\nregulation 6A(1) or (2)\n27. Singapore Armed Forces (V olunteers) Regulations (Rg 7)\n(a) Medical examination of an individual for the purposes of\nregulation 6(1)\n15Individuals providing healthcare services\n28. Allied Health Professions Act 2011\n(a) Medical examination of an individual for the purposes of section 21(2)\n29. Allied Health Professions (Prof",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p148_c361",
+      "text": "HEALTH INFORMATION 149\nTHIRD SCHEDULE —continued\n24. National Cadet Corps Regulations (Rg 1)\n(a) Medicalexaminationofanindividualforthepurposesofregulation10\n25. Police Force Act 2004\n5(a) Medicalordentalexaminationortestofapoliceofficerthatisrequired\nunderanylawfulorder(whethergivenorallyorinwriting)orunderthe\nPoliceGeneralOrders,anyForceOrdersoranyStandingOrdersmade\nunder the Act\n26. Police (Special Constabulary) Regulations (Rg 3)\n10(a) Medical examination of an individual for the purposes of\nregulation 6A(1) or (2)\n27. Singapore Armed Forces (Volunteers) Regulations (Rg 7)\n(a) Medical examination of an individual for the purposes of\nregulation 6(1)\n15Individuals providing healthcare services\n28. Allied Health Professions Act 2011\n(a) Medicalexaminationofanindividualforthepurposesofsection21(2)\n29. Allied Health Professions (Professional Conduct and Discipline)\nRegulations 2013\n20(a) ",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 148,
@@ -100773,8 +101189,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p148_c330",
-      "text": "\n28. Allied Health Professions Act 2011\n(a) Medical examination of an individual for the purposes of section 21(2)\n29. Allied Health Professions (Professional Conduct and Discipline)\nRegulations 2013\n20(a) Medical examination of a registered allied health professional\nmentioned in regulation 26(1)(a)\n30. Dental Registration Act 1999\n(a) Medical examination of an individual for the purposes of section 15(2)\nor 22(2)\n2531. Dental Registration Regulations (Rg 1)\n(a) Medical examination of a registered person mentioned in\nregulation 29(1)(a) or 37(4)\n32. Medical Registration Act 1997\n(a) Medical examination of an individual mentioned in section 29(4)(b)\n3033. Medical Registration Regulations 2010\n(a) Medical examination of a practitioner pursuant to a direction of the\nHealth Committee under regulation 50(1) or 57(4)\n147",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p148_c362",
+      "text": "dicalexaminationofanindividualforthepurposesofsection21(2)\n29. Allied Health Professions (Professional Conduct and Discipline)\nRegulations 2013\n20(a) Medical examination of a registered allied health professional\nmentioned in regulation 26(1)(a)\n30. Dental Registration Act 1999\n(a) Medicalexaminationofanindividualforthepurposesofsection15(2)\nor 22(2)\n2531. Dental Registration Regulations (Rg 1)\n(a) Medical examination of a registered person mentioned in\nregulation 29(1)(a) or 37(4)\n32. Medical Registration Act 1997\n(a) Medical examination of an individual mentioned in section 29(4)(b)\n3033. Medical Registration Regulations 2010\n(a) Medical examination of a practitioner pursuant to a direction of the\nHealth Committee under regulation 50(1) or 57(4)\n147",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 148,
@@ -100786,8 +101202,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p149_c331",
-      "text": "150 NO. 1 OF 2026\nTHIRD SCHEDULE — continued\n34. Nurses and Midwives Act 1999\n(a) Medical examination of an individual for the purposes of section 15(1)\n35. Nurses and Midwives Regulations 2012\n5 (a) Medical examination of a registered nurse, an enrolled nurse, a\nregistered midwife or an Advanced Practice Nurse mentioned in\nregulation 34(1)(a) or 41(2)\n36. Pharmacists Registration Act 2007\n(a) Medical examination of an individual for the purposes of section 21(2)\n10 37. Pharmacists Registration (Registration of Pharmacists) Regulations 2013\n(a) Medical examination of an individual for the purposes of a medical\nreport mentioned in regulation 7(3)(a)(ii)\n(b) Medical examination of an individual required by the Singapore\nPharmacy Council under regulation 8(3)\n15 Court proceedings\n38. Criminal Procedure Code 2010\n(a) Medical examination of an individual for the purposes of\nsection 247(3) or ",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p149_c363",
+      "text": "150 NO. 1 OF 2026\nTHIRD SCHEDULE —continued\n34. Nurses and Midwives Act 1999\n(a) Medicalexaminationofanindividualforthepurposesofsection15(1)\n35. Nurses and Midwives Regulations 2012\n5 (a) Medical examination of a registered nurse, an enrolled nurse, a\nregistered midwife or an Advanced Practice Nurse mentioned in\nregulation 34(1)(a) or 41(2)\n36. Pharmacists Registration Act 2007\n(a) Medicalexaminationofanindividualforthepurposesofsection21(2)\n10 37. Pharmacists Registration (Registration of Pharmacists) Regulations 2013\n(a) Medical examination of an individual for the purposes of a medical\nreport mentioned in regulation 7(3)(a)(ii)\n(b) Medical examination of an individual required by the Singapore\nPharmacy Council under regulation 8(3)\n15 Court proceedings\n38. Criminal Procedure Code 2010\n(a) Medical examination of an individual for the purposes of\nsection 247(3) or (6), 252(3), 253(2), ",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 149,
@@ -100799,8 +101215,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p149_c332",
-      "text": " regulation 8(3)\n15 Court proceedings\n38. Criminal Procedure Code 2010\n(a) Medical examination of an individual for the purposes of\nsection 247(3) or (6), 252(3), 253(2), 254(1) or 256(1) or (2)\n39. State Courts Act 1970\n20 (a) Medical examination of an individual pursuant to section 31(2)(c),\n50(1)(b), 51(1)(b) or 52(1B)(b)(iii)\n40. Supreme Court of Judicature Act 1969\n(a) Medical examination of an individual pursuant to paragraph 19 or 20\nof the First Schedule to the Act\n25 Sentencing in criminal matters and implementation of sentences imposed\n41. Criminal Procedure Code 2010\n(a) Medical examination of an individual for the purposes of a report\nmentioned in section 304(3), 305(3) or 339(2)\n(b) Medical examination of an offender for the purposes of a medical\n30 officer’s certificate mentioned in section 331(1)\n148",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p149_c364",
+      "text": "ourt proceedings\n38. Criminal Procedure Code 2010\n(a) Medical examination of an individual for the purposes of\nsection 247(3) or (6), 252(3), 253(2), 254(1) or 256(1) or (2)\n39. State Courts Act 1970\n20 (a) Medical examination of an individual pursuant to section 31(2)(c),\n50(1)(b), 51(1)(b) or 52(1B)(b)(iii)\n40. Supreme Court of Judicature Act 1969\n(a) Medical examination of an individual pursuant to paragraph 19 or 20\nof the First Schedule to the Act\n25 Sentencing in criminal matters and implementation of sentences imposed\n41. Criminal Procedure Code 2010\n(a) Medical examination of an individual for the purposes of a report\nmentioned in section 304(3), 305(3) or 339(2)\n(b) Medical examination of an offender for the purposes of a medical\n30 officer’s certificate mentioned in section 331(1)\n148",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 149,
@@ -100812,8 +101228,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p150_c333",
-      "text": "HEALTH INFORMATION 151\nTHIRD SCHEDULE — continued\nArrest and detention of individuals\n42. Civil Defence (Detention) Regulations (Rg 3)\n(a) Medical examination of an individual for the purposes of\n5regulation 8(1) or 34(1)\n(b) Medical examination of an arrested person or a person serving\ndetention in relation to an approval by a medical officer under\nregulation 17(5)\n(c) Medical examination of an arrested person or a person serving\n10detention for the purposes of regulation 27(4) or 28A(1)\n(d) Periodic medical observation of an arrested person or a person serving\ndetention for the purposes of regulation 28\n43. Criminal Procedure Code (Corrective Training and Preventive Detention)\nRegulations 2010\n15(a) Medical examination of a prisoner in relation to a certification by a\nmedical officer under regulation 13(3)\n44. Internal Security (Detained Persons) Rules (R 1)\n(a) Medical examination of ",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p150_c365",
+      "text": "HEALTH INFORMATION 151\nTHIRD SCHEDULE —continued\nArrest and detention of individuals\n42. Civil Defence (Detention) Regulations (Rg 3)\n(a) Medical examination of an individual for the purposes of\n5regulation 8(1) or 34(1)\n(b) Medical examination of an arrested person or a person serving\ndetention in relation to an approval by a medical officer under\nregulation 17(5)\n(c) Medical examination of an arrested person or a person serving\n10detention for the purposes of regulation 27(4) or 28A(1)\n(d) Periodicmedicalobservationofanarrestedpersonorapersonserving\ndetention for the purposes of regulation 28\n43. Criminal Procedure Code (Corrective Training and Preventive Detention)\nRegulations 2010\n15(a) Medical examination of a prisoner in relation to a certification by a\nmedical officer under regulation 13(3)\n44. Internal Security (Detained Persons) Rules (R 1)\n(a) Medical examination of a detained ",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 150,
@@ -100825,8 +101241,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p150_c334",
-      "text": "lation to a certification by a\nmedical officer under regulation 13(3)\n44. Internal Security (Detained Persons) Rules (R 1)\n(a) Medical examination of a detained person for the purposes of\nrule 17A(2)(a), 53(b) or 61(1)\n20(b) Medical examination of a detained person in relation to a certification\nby a medical officer under rule 53(a) or 75\n45. Intoxicating Substances (Discipline in Approved Centres) Regulations\n(Rg 2)\n(a) Medical examination of an inmate for the purposes of regulation 5(2)\n2546. Intoxicating Substances (Treatment and Rehabilitation) Regulations (Rg 3)\n(a) Medical examination of an inmate for the purposes of regulation 4\nor 5(1)\n47. Mental Health (Care and Treatment) Act 2008\n(a) Examination of an individual by a medical practitioner under\n30section 7(1)(a)\n(b) Examination of an individual by a designated medical practitioner at a\npsychiatric institution under section 10(1",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p150_c366",
+      "text": " certification by a\nmedical officer under regulation 13(3)\n44. Internal Security (Detained Persons) Rules (R 1)\n(a) Medical examination of a detained person for the purposes of\nrule 17A(2)(a), 53(b) or 61(1)\n20(b) Medical examination of a detained person in relation to a certification\nby a medical officer under rule 53(a) or 75\n45. Intoxicating Substances (Discipline in Approved Centres) Regulations\n(Rg 2)\n(a) Medical examination of an inmate for the purposes of regulation 5(2)\n2546. Intoxicating Substances (Treatment and Rehabilitation) Regulations (Rg 3)\n(a) Medical examination of an inmate for the purposes of regulation 4\nor 5(1)\n47. Mental Health (Care and Treatment) Act 2008\n(a) Examination of an individual by a medical practitioner under\n30section 7(1)(a)\n(b) Examination ofanindividualbyadesignated medicalpractitionerata\npsychiatric institution under section 10(1)\n48. Misuse of Dru",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 150,
@@ -100838,8 +101254,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p150_c335",
-      "text": "titioner under\n30section 7(1)(a)\n(b) Examination of an individual by a designated medical practitioner at a\npsychiatric institution under section 10(1)\n48. Misuse of Drugs (Approved Institutions) (Discipline) Regulations (Rg 5)\n(a) Medical examination of an inmate for the purposes of regulation 5(2)\n149",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p150_c367",
+      "text": "der\n30section 7(1)(a)\n(b) Examination ofanindividualbyadesignated medicalpractitionerata\npsychiatric institution under section 10(1)\n48. Misuse of Drugs (Approved Institutions) (Discipline) Regulations (Rg 5)\n(a) Medical examination of an inmate for the purposes of regulation 5(2)\n149",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 150,
@@ -100851,8 +101267,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p151_c336",
-      "text": "152 NO. 1 OF 2026\nTHIRD SCHEDULE — continued\n(b) Medical examination of an inmate in relation to a certification by a\nmedical officer under regulation 12(c)\n49. Misuse of Drugs (Approved Institutions, Medical Observation and\n5 Treatment and Rehabilitation) Regulations (Rg 3)\n(a) Medical examination of a suspected drug addict or an inmate for the\npurposes of regulation 4 or 8(1)\n50. Police Force (Special Constabulary — Detention) Regulations 2016\n(a) Medical examination of an individual for the purposes of\n10 regulation 8(1)\n(b) Medical examination of a detainee in relation to an approval by a\nmedical officer under regulation 17(5)\n(c) Medical examination of a detainee for the purposes of\nregulation 26(4)(a), 28(1) or 35(1)\n15 (d) Periodic medical observation of a detainee for the purposes of\nregulation 27\n51. Prisons Act 1933\n(a) Medical examination of a prisoner in relation to a certifi",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p151_c368",
+      "text": "152 NO. 1 OF 2026\nTHIRD SCHEDULE —continued\n(b) Medical examination of an inmate in relation to a certification by a\nmedical officer under regulation 12(c)\n49. Misuse of Drugs (Approved Institutions, Medical Observation and\n5 Treatment and Rehabilitation) Regulations (Rg 3)\n(a) Medical examination of a suspected drug addict or an inmate for the\npurposes of regulation 4 or 8(1)\n50. Police Force (Special Constabulary — Detention) Regulations 2016\n(a) Medical examination of an individual for the purposes of\n10 regulation 8(1)\n(b) Medical examination of a detainee in relation to an approval by a\nmedical officer under regulation 17(5)\n(c) Medical examination of a detainee for the purposes of\nregulation 26(4)(a), 28(1) or 35(1)\n15 (d) Periodic medical observation of a detainee for the purposes of\nregulation 27\n51. Prisons Act 1933\n(a) Medical examination of a prisoner in relation to a certific",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 151,
@@ -100864,8 +101280,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p151_c337",
-      "text": "edical observation of a detainee for the purposes of\nregulation 27\n51. Prisons Act 1933\n(a) Medical examination of a prisoner in relation to a certification by a\nmedical officer under section 67 or 77(4)\n20 52. Prisons (Lock‑ups in Specified Court Houses) Regulations 2011\n(a) Medical examination of a lock‑up prisoner for the purposes of\nregulation 16(3)(a)\n53. Prisons (Police Lock‑ups) Regulations 2013\n(a) Examination of a lock‑up prisoner for the purposes of\n25 regulation 17(3)(a)\n54. Prisons Regulations (Rg 2)\n(a) Medical examination of a prisoner for the purposes of\nregulation 38(2)(a), 74A, 75(1), 94(1) or 142\n(b) Medical examination of a vagrant for the purposes of regulation 94(2)\n30 55. Singapore Armed Forces (Detention and Imprisonment) Regulations (Rg 3)\n(a) Medical examination of a detainee or military prisoner for the purposes\nof regulation 6(3)(b), 13(d), 21(1), 39(4), 47(3) ",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p151_c369",
+      "text": "dical observation of a detainee for the purposes of\nregulation 27\n51. Prisons Act 1933\n(a) Medical examination of a prisoner in relation to a certification by a\nmedical officer under section 67 or 77(4)\n20 52. Prisons (Lock‑ups in Specified Court Houses) Regulations 2011\n(a) Medical examination of a lock‑up prisoner for the purposes of\nregulation 16(3)(a)\n53. Prisons (Police Lock‑ups) Regulations 2013\n(a) Examination of a lock‑up prisoner for the purposes of\n25 regulation 17(3)(a)\n54. Prisons Regulations (Rg 2)\n(a) Medical examination of a prisoner for the purposes of\nregulation 38(2)(a), 74A, 75(1), 94(1) or 142\n(b) Medical examination of a vagrant for the purposes of regulation 94(2)\n30 55. Singapore Armed Forces (Detention and Imprisonment) Regulations (Rg 3)\n(a) Medicalexaminationofadetaineeormilitaryprisonerforthepurposes\nof regulation 6(3)(b), 13(d), 21(1), 39(4), 47(3) or 50(1)\n15",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 151,
@@ -100877,21 +101293,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p151_c338",
-      "text": "ent) Regulations (Rg 3)\n(a) Medical examination of a detainee or military prisoner for the purposes\nof regulation 6(3)(b), 13(d), 21(1), 39(4), 47(3) or 50(1)\n150",
-      "metadata": {
-        "source": "health-information-act-2026.pdf",
-        "page": 151,
-        "category": "sg-hia",
-        "jurisdiction": "SG",
-        "document_id": "sg-hia",
-        "framework": "HIA",
-        "content_type": "primary"
-      }
-    },
-    {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p152_c339",
-      "text": "HEALTH INFORMATION 153\nTHIRD SCHEDULE — continued\n56. Singapore Armed Forces (Disciplinary Barracks) Regulations (Rg 8)\n(a) Medical examination of an individual for the purposes of\nregulation 8(c) or 28\n5Medical examinations relating to making of mandatory treatment orders\nunder written law\n57. Protection from Harassment Act 2014\n(a) Medical examination of an individual in relation to a formal\nassessment report mentioned in section 13B(3)(b)\n10(b) Medical examination of an individual in relation to a preliminary\nassessment report mentioned in section 13B(4)(a)\n58. Women’s Charter 1961\n(a) Medical examination of an individual in relation to a preliminary\nassessment report mentioned in section 60F(6)(a)\n15(b) Medical examination of an individual in relation to a formal\nassessment report mentioned in section 60F(9)(a)\nVulnerable individuals\n59. Adoption of Children Act 2022\n(a) Medical, psy",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p152_c370",
+      "text": "HEALTH INFORMATION 153\nTHIRD SCHEDULE —continued\n56. Singapore Armed Forces (Disciplinary Barracks) Regulations (Rg 8)\n(a) Medical examination of an individual for the purposes of\nregulation 8(c) or 28\n5Medical examinations relating to making of mandatory treatment orders\nunder written law\n57. Protection from Harassment Act 2014\n(a) Medical examination of an individual in relation to a formal\nassessment report mentioned in section 13B(3)(b)\n10(b) Medical examination of an individual in relation to a preliminary\nassessment report mentioned in section 13B(4)(a)\n58. Women’s Charter 1961\n(a) Medical examination of an individual in relation to a preliminary\nassessment report mentioned in section 60F(6)(a)\n15(b) Medical examination of an individual in relation to a formal\nassessment report mentioned in section 60F(9)(a)\nVulnerable individuals\n59. Adoption of Children Act 2022\n(a) Medical, psyc",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 152,
@@ -100903,8 +101306,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p152_c340",
-      "text": "ual in relation to a formal\nassessment report mentioned in section 60F(9)(a)\nVulnerable individuals\n59. Adoption of Children Act 2022\n(a) Medical, psychiatric or psychological assessment of any joint\n20applicant or sole applicant for or issued with an Adoption Suitability\nAssessment pursuant to a direction of an authorised adoption agency or\nthe Guardian‑in‑Adoption under section 19(2)(a)(i)\n(b) Medical, psychiatric or psychological assessment of any joint\napplicant or sole applicant, or any relevant person of a child before\n25the court, pursuant to a direction of the Guardian‑in‑Adoption under\nsection 29(1)(a)(i)\n(c) Medical, psychiatric or psychological assessment of a child pursuant to\na direction of the Guardian‑in‑Adoption under section 29(1)(c)\n(d) Medical, psychiatric or psychological assessment of any joint\n30applicant or sole applicant of an adoption application, or any\nrelevant",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p152_c371",
+      "text": "al in relation to a formal\nassessment report mentioned in section 60F(9)(a)\nVulnerable individuals\n59. Adoption of Children Act 2022\n(a) Medical, psychiatric or psychological assessment of any joint\n20applicant or sole applicant for or issued with an Adoption Suitability\nAssessmentpursuanttoadirectionofanauthorisedadoptionagencyor\nthe Guardian‑in‑Adoption under section 19(2)(a)(i)\n(b) Medical, psychiatric or psychological assessment of any joint\napplicant or sole applicant, or any relevant person of a child before\n25the court, pursuant to a direction of the Guardian‑in‑Adoption under\nsection 29(1)(a)(i)\n(c) Medical,psychiatricorpsychologicalassessmentofachildpursuantto\na direction of the Guardian‑in‑Adoption under section 29(1)(c)\n(d) Medical, psychiatric or psychological assessment of any joint\n30applicant or sole applicant of an adoption application, or any\nrelevant person of the child",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 152,
@@ -100916,8 +101319,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p152_c341",
-      "text": "n 29(1)(c)\n(d) Medical, psychiatric or psychological assessment of any joint\n30applicant or sole applicant of an adoption application, or any\nrelevant person of the child before the court, pursuant to an order of\nthe court under section 34(1)(b)(i)\n(e) Medical, psychiatric or psychological assessment of a child before the\ncourt pursuant to an order of the court under section 34(1)(b)(ii)\n151",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p152_c372",
+      "text": "al, psychiatric or psychological assessment of any joint\n30applicant or sole applicant of an adoption application, or any\nrelevant person of the child before the court, pursuant to an order of\nthe court under section 34(1)(b)(i)\n(e) Medical, psychiatric or psychological assessment of a child before the\ncourt pursuant to an order of the court under section 34(1)(b)(ii)\n151",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 152,
@@ -100929,8 +101332,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p153_c342",
-      "text": "154 NO. 1 OF 2026\nTHIRD SCHEDULE — continued\n60. Children and Young Persons Act 1993\n(a) Assessment of a child or young person by a registered medical\npractitioner or psychologist under section 10(1)(b)\n5 (b) Assessment of a child or young person by a registered medical\npractitioner mentioned in section 13(2) that is authorised by a warrant\nissued by a Magistrate’s Court under section 13\n(c) Medical or psychological assessment of a child or young person, or the\nparent or guardian of a child or young person, required by the Youth\n10 Court under section 47(11)(b)\n(d) Assessment of a child or young person by a registered medical\npractitioner ordered by the Youth Court under section 54(14)(c)\n(e) Medical, psychiatric or psychological assessment of the parent or\nguardian of a child or young person ordered by the Youth Court under\n15 section 54(14)(d)\n61. Children and Young Persons (Government",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p153_c373",
+      "text": "154 NO. 1 OF 2026\nTHIRD SCHEDULE —continued\n60. Children and Young Persons Act 1993\n(a) Assessment of a child or young person by a registered medical\npractitioner or psychologist under section 10(1)(b)\n5 (b) Assessment of a child or young person by a registered medical\npractitioner mentioned in section 13(2) that is authorised by a warrant\nissued by a Magistrate’s Court under section 13\n(c) Medicalorpsychologicalassessmentofachildoryoungperson,orthe\nparent or guardian of a child or young person, required by the Youth\n10 Court under section 47(11)(b)\n(d) Assessment of a child or young person by a registered medical\npractitioner ordered by the Youth Court under section 54(14)(c)\n(e) Medical, psychiatric or psychological assessment of the parent or\nguardian of a child or young person ordered by the Youth Court under\n15 section 54(14)(d)\n61. Children and Young Persons (Government Homes) Regu",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 153,
@@ -100942,8 +101345,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p153_c343",
-      "text": " of the parent or\nguardian of a child or young person ordered by the Youth Court under\n15 section 54(14)(d)\n61. Children and Young Persons (Government Homes) Regulations 2011\n(a) Medical examination of a resident under regulation 11\n62. Children and Young Persons (Licensing of Homes) Regulations 2011\n(a) Medical examination of a resident under regulation 14\n20 63. Destitute Persons (Welfare Homes) Rules (R 1)\n(a) Medical examination of a destitute person admitted into a welfare\nhome under rule 24(1)\n64. Vulnerable Adults Act 2018\n(a) Assessment (within the meaning given by section 2(1)) of an\n25 individual or a vulnerable adult under section 6(1)(a) or (b)\n(b) Assessment (within the meaning given by section 2(1)) of an\nindividual pursuant to a court order under section 14(4)(c)\n65. Women’s Charter 1961\n(a) Assessment (within the meaning given by section 59(6)) of an\n30 individual by a pr",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p153_c374",
+      "text": "nt or\nguardian of a child or young person ordered by the Youth Court under\n15 section 54(14)(d)\n61. Children and Young Persons (Government Homes) Regulations 2011\n(a) Medical examination of a resident under regulation 11\n62. Children and Young Persons (Licensing of Homes) Regulations 2011\n(a) Medical examination of a resident under regulation 14\n20 63. Destitute Persons (Welfare Homes) Rules (R 1)\n(a) Medical examination of a destitute person admitted into a welfare\nhome under rule 24(1)\n64. Vulnerable Adults Act 2018\n(a) Assessment (within the meaning given by section 2(1)) of an\n25 individual or a vulnerable adult under section 6(1)(a) or (b)\n(b) Assessment (within the meaning given by section 2(1)) of an\nindividual pursuant to a court order under section 14(4)(c)\n65. Women’s Charter 1961\n(a) Assessment (within the meaning given by section 59(6)) of an\n30 individual by a protector or a",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 153,
@@ -100955,8 +101358,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p153_c344",
-      "text": "o a court order under section 14(4)(c)\n65. Women’s Charter 1961\n(a) Assessment (within the meaning given by section 59(6)) of an\n30 individual by a protector or a qualified assessor under section 59(1)\n66. Women’s Charter (Protection of Women and Girls) Rules (R 2)\n(a) Medical examination of a girl under rule 55(a), (b) or (e)\n(b) Examination of the teeth of a girl under rule 57(1)\n152",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p153_c375",
+      "text": "der under section 14(4)(c)\n65. Women’s Charter 1961\n(a) Assessment (within the meaning given by section 59(6)) of an\n30 individual by a protector or a qualified assessor under section 59(1)\n66. Women’s Charter (Protection of Women and Girls) Rules (R 2)\n(a) Medical examination of a girl under rule 55(a), (b) or (e)\n(b) Examination of the teeth of a girl under rule 57(1)\n152",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 153,
@@ -100968,8 +101371,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p154_c345",
-      "text": "HEALTH INFORMATION 155\nFOURTH SCHEDULE\nSections 47 and 51(1)(a) and (2)(c)\nDISCLOSURE, COLLECTION AND\nUSE OF RELEV ANT INFORMA TION\n5PART 1\nFirst column Second column Third column\nDiscloser or\nclass of discloser\nRecipient or\nclass of recipient\nUse case\nContinuity of care for national health initiatives\n101. Any of the\nfollowing\npersons:\n(a) a public\nhealthcare\n15institution;\n(b) a cluster\nHQ\nAIC (a) Identifying individuals who\nmay require a community\nhealth service; and\n(b) contacting and engaging the\nindividuals mentioned in\nparagraph (a), as part of the\nHealthier SG programme or\nthe Age Well SG\nprogramme established by\nthe Government —\n20(i) to encourage those\nindividuals to make\nbehavioural changes\nto reduce or eliminate\nthe risk of developing\n25or aggravating their\nhealth conditions; or\n(ii) to refer those\nindividuals to\nproviders of any\n30healthcare service or\ncommunity health\nservi",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p154_c376",
+      "text": "HEALTH INFORMATION 155\nFOURTH SCHEDULE\nSections 47 and 51(1)(a) and (2)(c)\nDISCLOSURE, COLLECTION AND\nUSE OF RELEVANT INFORMATION\n5PART 1\nFirst column Second column Third column\nDiscloser or\nclass of discloser\nRecipient or\nclass of recipient\nUse case\nContinuity of care for national health initiatives\n101. Any of the\nfollowing\npersons:\n(a) a public\nhealthcare\n15institution;\n(b) a cluster\nHQ\nAIC (a) Identifying individuals who\nmay require a community\nhealth service; and\n(b) contactingandengagingthe\nindividuals mentioned in\nparagraph (a), as part of the\nHealthier SG programme or\nthe Age Well SG\nprogramme established by\nthe Government —\n20(i) to encourage those\nindividuals to make\nbehavioural changes\nto reduce or eliminate\nthe risk of developing\n25or aggravating their\nhealth conditions; or\n(ii) to refer those\nindividuals to\nproviders of any\n30healthcare service or\ncommunity health\nservice to",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 154,
@@ -100981,8 +101384,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p154_c346",
-      "text": "loping\n25or aggravating their\nhealth conditions; or\n(ii) to refer those\nindividuals to\nproviders of any\n30healthcare service or\ncommunity health\nservice to enable them\nto better manage or\naddress their health\n35conditions.\n153",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p154_c377",
+      "text": "g\n25or aggravating their\nhealth conditions; or\n(ii) to refer those\nindividuals to\nproviders of any\n30healthcare service or\ncommunity health\nservice to enable them\nto better manage or\naddress their health\n35conditions.\n153",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 154,
@@ -100994,8 +101397,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p155_c347",
-      "text": "156 NO. 1 OF 2026\nFOURTH SCHEDULE — continued\nFirst column Second column Third column\nDiscloser or\nclass of discloser\nRecipient or\nclass of recipient\nUse case\n5 2. AIC Any of the following\npersons:\n(a) a public\nhealthcare\ninstitution;\n10 (b) a cluster HQ\n(a) Identifying individuals who\nmay require a community\nhealth service; and\n(b) contacting and engaging the\nindividuals mentioned in\nparagraph (a), as part of the\nHealthier SG programme or\nthe Age Well SG\nprogramme established by\nthe Government —\n15 (i) to encourage those\nindividuals to make\nbehavioural changes\nto reduce or eliminate\nthe risk of developing\n20 or aggravating their\nhealth conditions; or\n(ii) to refer those\nindividuals to\nproviders of any\n25 healthcare service or\ncommunity health\nservice to enable them\nto better manage or\naddress their health\n30 conditions.\n154",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p155_c378",
+      "text": "156 NO. 1 OF 2026\nFOURTH SCHEDULE —continued\nFirst column Second column Third column\nDiscloser or\nclass of discloser\nRecipient or\nclass of recipient\nUse case\n5 2. AIC Any of the following\npersons:\n(a) a public\nhealthcare\ninstitution;\n10 (b) a cluster HQ\n(a) Identifying individuals who\nmay require a community\nhealth service; and\n(b) contactingandengagingthe\nindividuals mentioned in\nparagraph (a), as part of the\nHealthier SG programme or\nthe Age Well SG\nprogramme established by\nthe Government —\n15 (i) to encourage those\nindividuals to make\nbehavioural changes\nto reduce or eliminate\nthe risk of developing\n20 or aggravating their\nhealth conditions; or\n(ii) to refer those\nindividuals to\nproviders of any\n25 healthcare service or\ncommunity health\nservice to enable them\nto better manage or\naddress their health\n30 conditions.\n154",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 155,
@@ -101007,8 +101410,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p156_c348",
-      "text": "HEALTH INFORMATION 157\nFOURTH SCHEDULE — continued\nFirst column Second column Third column\nDiscloser or\nclass of discloser\nRecipient or\nclass of recipient\nUse case\n5Outreach for national health initiatives\n3. Any public\nagency\nAIC (a) Identifying individuals\nabove 60 years of age who\nreside at a place other than\nthe place of residence\n10registered under the\nNational Registration\nAct 1965; and\n(b) contacting and engaging the\nindividuals mentioned in\n15paragraph (a) —\n(i) to check on the\nphysical or mental\nwellbeing of those\nindividuals; and\n20(ii) if necessary, to refer\nthose individuals to\nproviders of any\nhealthcare service or\ncommunity health\n25service that are\nparticipating in the\nAge Well SG\nprogramme\nestablished by the\n30Government.\n155",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p156_c379",
+      "text": "HEALTH INFORMATION 157\nFOURTH SCHEDULE —continued\nFirst column Second column Third column\nDiscloser or\nclass of discloser\nRecipient or\nclass of recipient\nUse case\n5Outreach for national health initiatives\n3. Any public\nagency\nAIC (a) Identifying individuals\nabove 60 years of age who\nreside at a place other than\nthe place of residence\n10registered under the\nNational Registration\nAct 1965; and\n(b) contactingandengagingthe\nindividuals mentioned in\n15paragraph (a) —\n(i) to check on the\nphysical or mental\nwellbeing of those\nindividuals; and\n20(ii) if necessary, to refer\nthose individuals to\nproviders of any\nhealthcare service or\ncommunity health\n25service that are\nparticipating in the\nAge Well SG\nprogramme\nestablished by the\n30Government.\n155",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 156,
@@ -101020,8 +101423,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p157_c349",
-      "text": "158 NO. 1 OF 2026\nFOURTH SCHEDULE — continued\nFirst column Second column Third column\nDiscloser or\nclass of discloser\nRecipient or\nclass of recipient\nUse case\n5 4. Any public\nagency\nAny of the following\npersons:\n(a) a public\nhealthcare\ninstitution;\n10 (b) a cluster HQ;\n(c) AIC\nAs part of the Healthier SG\nprogramme established by the\nGovernment —\n(a) identifying and engaging\nindividuals who may\nbenefit from taking up,\ncontinuing or completing\nany action or measure to\nmonitor, maintain or\nimprove their health; and\n(b) to engage and encourage15\nthose individuals to take up,\ncontinue or complete any\naction or measure\nmentioned in paragraph (a).\nPART 2\n20\nDEFINITIONS\n1. In this Schedule —\n“AIC” means the Agency for Integrated Care Pte Ltd;\n“cluster HQ” means any of the following:\n(a) National Healthcare Group Pte Ltd;25\n(b) National University Health System Pte Ltd;\n(c) Singapore Health Servi",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p157_c380",
+      "text": "158 NO. 1 OF 2026\nFOURTH SCHEDULE —continued\nFirst column Second column Third column\nDiscloser or\nclass of discloser\nRecipient or\nclass of recipient\nUse case\n5 4. Any public\nagency\nAny of the following\npersons:\n(a) a public\nhealthcare\ninstitution;\n10 (b) a cluster HQ;\n(c) AIC\nAs part of the Healthier SG\nprogramme established by the\nGovernment —\n(a) identifying and engaging\nindividuals who may\nbenefit from taking up,\ncontinuing or completing\nany action or measure to\nmonitor, maintain or\nimprove their health; and\n(b) to engage and encourage15\nthoseindividualstotakeup,\ncontinue or complete any\naction or measure\nmentioned in paragraph (a).\nPART 2\n20\nDEFINITIONS\n1. In this Schedule —\n“AIC” means the Agency for Integrated Care Pte Ltd;\n“cluster HQ” means any of the following:\n(a) National Healthcare Group Pte Ltd;25\n(b) National University Health System Pte Ltd;\n(c) Singapore Health Services P",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 157,
@@ -101033,8 +101436,8 @@
       }
     },
     {
-      "id": "health-information-act-2026.pdf_4ae36901f9fb_p157_c350",
-      "text": "ter HQ” means any of the following:\n(a) National Healthcare Group Pte Ltd;25\n(b) National University Health System Pte Ltd;\n(c) Singapore Health Services Pte Ltd;\n“public healthcare institution” means a person that —\n(a) is or is controlled by a cluster HQ or its subsidiary; and\n(b) is licensed under the Healthcare Services Act 2020 to provide30\nany licensable healthcare service.\n156",
+      "id": "health-information-act-2026.pdf_4ae36901f9fb_p157_c381",
+      "text": "Q” means any of the following:\n(a) National Healthcare Group Pte Ltd;25\n(b) National University Health System Pte Ltd;\n(c) Singapore Health Services Pte Ltd;\n“public healthcare institution” means a person that —\n(a) is or is controlled by a cluster HQ or its subsidiary; and\n(b) is licensed under the Healthcare Services Act 2020 to provide30\nany licensable healthcare service.\n156",
       "metadata": {
         "source": "health-information-act-2026.pdf",
         "page": 157,

--- a/frontend/src/components/regbot/login-form.tsx
+++ b/frontend/src/components/regbot/login-form.tsx
@@ -40,7 +40,6 @@ export function LoginForm() {
     try {
       await login(username, password);
       router.replace("/");
-      router.refresh();
     } catch (reason) {
       setError(reason instanceof Error ? reason.message : "Sign in failed.");
     } finally {
@@ -54,7 +53,6 @@ export function LoginForm() {
     try {
       await continueAsViewer();
       router.replace("/");
-      router.refresh();
     } catch (reason) {
       setError(reason instanceof Error ? reason.message : "Viewer access failed.");
     } finally {

--- a/src/regbot/compliance.py
+++ b/src/regbot/compliance.py
@@ -46,6 +46,14 @@ _LEGACY_STATUS_TO_COVERAGE = {
     "non compliant": "incomplete",
     "unknown": "unknown",
 }
+_CHAT_CITATION_RE = re.compile(r"\[chunk_id=([^\]\s]+)\]")
+
+
+def _invalid_chat_citation_ids(reply: str, chunks: List[Dict[str, Any]]) -> List[str]:
+    """Return explicit chat citations that are absent from the retrieved evidence set."""
+    allow = allowed_chunk_ids(chunks)
+    cited = _CHAT_CITATION_RE.findall(reply)
+    return sorted({chunk_id for chunk_id in cited if chunk_id not in allow})
 
 
 def normalize_coverage(raw: Optional[str]) -> str:
@@ -537,6 +545,41 @@ def chat_followup_policy_qa(
             messages=history,
             temperature=0.3,
         )
+        reply = (resp.choices[0].message.content or "").strip() or "(empty reply)"
+        invalid_ids = _invalid_chat_citation_ids(reply, chunks)
+        if invalid_ids:
+            allow = sorted(allowed_chunk_ids(chunks))
+            logger.warning("Chat reply cited unknown chunk ids: %s", invalid_ids)
+            correction: List[ChatCompletionMessageParam] = [
+                *history,
+                {"role": "assistant", "content": reply},
+                {
+                    "role": "user",
+                    "content": (
+                        "Rewrite the complete answer because the previous response cited chunk ids "
+                        f"outside the retrieved evidence set: {invalid_ids}. Use only these exact "
+                        f"chunk ids when citing policy text: {allow}. Do not mention or reuse any "
+                        "other chunk id."
+                    ),
+                },
+            ]
+            resp = client.chat.completions.create(
+                model=model_name,
+                messages=correction,
+                temperature=0.1,
+            )
+            reply = (resp.choices[0].message.content or "").strip() or "(empty reply)"
+            invalid_ids = _invalid_chat_citation_ids(reply, chunks)
+            if invalid_ids:
+                logger.warning(
+                    "Corrected chat reply still cited unknown chunk ids: %s", invalid_ids
+                )
+                return (
+                    "RegBot could not produce an answer with fully verifiable chunk citations.\n\n"
+                    "What to do: review the retrieved policy excerpts shown below and retry the "
+                    "question.\n\n"
+                    "Error code: CHAT_CITATION_GROUNDING_FAILED"
+                )
     except (RateLimitError, AuthenticationError, APIConnectionError, BadRequestError) as e:
         logger.warning("Chat LLM request failed: %s", type(e).__name__, exc_info=True)
         if use_ollama:
@@ -565,4 +608,4 @@ def chat_followup_policy_qa(
             "Error code: OPENAI_UNAVAILABLE"
         )
 
-    return (resp.choices[0].message.content or "").strip() or "(empty reply)"
+    return reply

--- a/src/regbot/jurisdiction.py
+++ b/src/regbot/jurisdiction.py
@@ -19,7 +19,7 @@ JURISDICTION_CODES: Tuple[str, ...] = (
 
 # Short labels for UI (corpus scope hints — not legal advice).
 JURISDICTION_LABELS: Dict[str, str] = {
-    "SG": "Singapore — PDPA, HBRA, Health Information Bill",
+    "SG": "Singapore — PDPA, HBRA, Health Information Act 2026",
     "CN": "China — HGR, PIPL, Data Security Law",
     "TW": "Taiwan — Human Biobank Act, PDPA",
     "KR": "Korea — Bioethics Act, PIPA",

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -63,6 +63,60 @@ class TestChatFailureGuidance(unittest.TestCase):
         self.assertIn("What to do:", reply)
         self.assertIn("LLM_NOT_CONFIGURED", reply)
 
+    def test_unknown_chat_citation_is_retried_with_allow_list(self) -> None:
+        import os
+        from unittest import mock
+
+        invalid = mock.Mock()
+        invalid.choices = [mock.Mock(message=mock.Mock(content="See [chunk_id=invented_chunk]."))]
+        corrected = mock.Mock()
+        corrected.choices = [mock.Mock(message=mock.Mock(content="See [chunk_id=sg_p0_c1]."))]
+        completion = mock.Mock(side_effect=[invalid, corrected])
+        client = mock.Mock()
+        client.chat.completions.create = completion
+
+        with (
+            mock.patch.dict(os.environ, {"REGBOT_LLM_PROVIDER": "openai"}),
+            mock.patch("src.regbot.compliance.OpenAI", return_value=client),
+        ):
+            reply = chat_followup_policy_qa(
+                CHUNKS,
+                "Some consent text.",
+                [{"role": "user", "content": "What applies?"}],
+                api_key="test-key",
+            )
+
+        self.assertEqual(reply, "See [chunk_id=sg_p0_c1].")
+        self.assertEqual(completion.call_count, 2)
+        correction_messages = completion.call_args_list[1].kwargs["messages"]
+        self.assertIn("invented_chunk", correction_messages[-1]["content"])
+        self.assertIn("sg_p0_c1", correction_messages[-1]["content"])
+
+    def test_repeated_unknown_chat_citation_fails_closed(self) -> None:
+        import os
+        from unittest import mock
+
+        invalid = mock.Mock()
+        invalid.choices = [mock.Mock(message=mock.Mock(content="See [chunk_id=invented_chunk]."))]
+        completion = mock.Mock(return_value=invalid)
+        client = mock.Mock()
+        client.chat.completions.create = completion
+
+        with (
+            mock.patch.dict(os.environ, {"REGBOT_LLM_PROVIDER": "openai"}),
+            mock.patch("src.regbot.compliance.OpenAI", return_value=client),
+        ):
+            reply = chat_followup_policy_qa(
+                CHUNKS,
+                "Some consent text.",
+                [{"role": "user", "content": "What applies?"}],
+                api_key="test-key",
+            )
+
+        self.assertIn("CHAT_CITATION_GROUNDING_FAILED", reply)
+        self.assertNotIn("invented_chunk", reply)
+        self.assertEqual(completion.call_count, 2)
+
 
 class TestQuoteSelection(unittest.TestCase):
     def test_quote_is_verbatim_from_chunk(self) -> None:

--- a/tests/test_jurisdiction.py
+++ b/tests/test_jurisdiction.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 from src.regbot.ingestion import ingest_policy_file, read_manifest
 from src.regbot.jurisdiction import (
     jurisdiction_matches,
+    jurisdiction_option_label,
     jurisdictions_in_manifest,
     parse_jurisdiction_filter,
 )
@@ -33,6 +34,11 @@ class _FakeSentenceTransformer:
 
 
 class TestJurisdiction(unittest.TestCase):
+    def test_singapore_label_names_enacted_health_information_law(self) -> None:
+        label = jurisdiction_option_label("SG")
+        self.assertIn("Health Information Act 2026", label)
+        self.assertNotIn("Bill", label)
+
     def test_parse_filter_empty(self) -> None:
         self.assertIsNone(parse_jurisdiction_filter(None))
         self.assertIsNone(parse_jurisdiction_filter([]))


### PR DESCRIPTION
## Summary
- validate chat chunk citations against retrieved evidence, retry once, and fail closed if correction remains invalid
- fix public/account login navigation so the URL leaves `/login`
- rename Singapore Health Information Bill to Health Information Act 2026
- rebuild the tracked corpus manifest with pypdf 6.15.0 (8,112 chunks)

## Verification
- Python citation and jurisdiction tests (32 tests)
- FastAPI chat endpoint tests (7 tests)
- ruff check and format check
- mypy `src.regbot`
- frontend ESLint, TypeScript, and production build
- local production UI public-login smoke test
- manifest invariants: 8,112 unique chunks, 85 documents, SG HIA 382 chunks