### PR TITLE
Link GA4GH logos to the organization website

### DIFF
--- a/frontend/src/components/regbot/login-form.tsx
+++ b/frontend/src/components/regbot/login-form.tsx
@@ -74,14 +74,22 @@ export function LoginForm() {
       <div className="relative mx-auto grid min-h-screen w-full max-w-7xl items-center gap-8 px-5 py-7 sm:gap-10 sm:px-8 sm:py-10 lg:grid-cols-[1.08fr_0.92fr] lg:gap-16 lg:px-12">
         <section className="mx-auto w-full max-w-2xl lg:mx-0">
           <div className="mb-7 inline-flex rounded-2xl border border-white/90 bg-white/85 p-5 shadow-[0_18px_50px_-30px_rgba(15,74,122,0.55)] backdrop-blur-sm sm:mb-10 sm:p-6">
-            <Image
-              src="/global-alliance-logo.svg"
-              alt="Global Alliance for Genomics and Health"
-              width={384}
-              height={100}
-              priority
-              className="h-auto w-[17rem] sm:w-[22rem]"
-            />
+            <a
+              href="https://www.ga4gh.org/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Visit the GA4GH website (opens in a new tab)"
+              className="rounded-sm focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#1b75bb]"
+            >
+              <Image
+                src="/global-alliance-logo.svg"
+                alt="Global Alliance for Genomics and Health"
+                width={384}
+                height={100}
+                priority
+                className="h-auto w-[17rem] sm:w-[22rem]"
+              />
+            </a>
           </div>
 
           <div className="mb-5 inline-flex items-center gap-2 rounded-full border border-[#1b75bb]/15 bg-[#1b75bb]/8 px-3 py-1.5 text-xs font-semibold tracking-wide text-[#1769a6] uppercase">

--- a/frontend/src/components/regbot/regbot-app.tsx
+++ b/frontend/src/components/regbot/regbot-app.tsx
@@ -154,14 +154,22 @@ export function RegBotApp({ user }: { user: AuthUser }) {
       <header className="border-border/70 bg-card/85 sticky top-0 z-20 border-b backdrop-blur-xl">
         <div className="mx-auto flex max-w-7xl flex-col gap-4 px-4 py-3 sm:flex-row sm:items-center sm:justify-between lg:px-6">
           <div className="flex min-w-0 items-center gap-3 sm:gap-4">
-            <Image
-              src="/global-alliance-logo.svg"
-              alt="Global Alliance for Genomics and Health"
-              width={192}
-              height={50}
-              priority
-              className="h-auto w-36 shrink-0 sm:w-40"
-            />
+            <a
+              href="https://www.ga4gh.org/"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Visit the GA4GH website (opens in a new tab)"
+              className="shrink-0 rounded-sm focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#1b75bb]"
+            >
+              <Image
+                src="/global-alliance-logo.svg"
+                alt="Global Alliance for Genomics and Health"
+                width={192}
+                height={50}
+                priority
+                className="h-auto w-36 sm:w-40"
+              />
+            </a>
             <div className="bg-border h-10 w-px shrink-0" aria-hidden="true" />
             <div className="min-w-0">
               <h1 className="text-lg font-semibold tracking-tight sm:text-xl">RegBot</h1>


### PR DESCRIPTION
## Summary
- make the GA4GH logo clickable in the login page and workspace header
- open https://www.ga4gh.org/ in a new tab
- add noopener/noreferrer and visible keyboard focus styling

## Verification
- npm run lint
- npx tsc -p tsconfig.json --noEmit
- npm run build
- browser smoke: link attributes verified; click opened a new GA4GH tab while preserving the RegBot page